### PR TITLE
fix srun error when running ctests

### DIFF
--- a/modulefiles/RDAS/hera.intel.lua
+++ b/modulefiles/RDAS/hera.intel.lua
@@ -78,7 +78,7 @@ setenv("CC","mpiicc")
 setenv("FC","mpiifort")
 setenv("CXX","mpiicpc")
 
-local mpiexec = '/apps/slurm/default/bin/srun'
+local mpiexec = '/apps/slurm_hera/default/bin/srun'
 local mpinproc = '-n'
 setenv('MPIEXEC_EXEC', mpiexec)
 setenv('MPIEXEC_NPROC', mpinproc)


### PR DESCRIPTION
This PR addresses https://github.com/NOAA-EMC/RDASApp/issues/14. We were just pointing to the wrong version of srun.

Tested on Hera and using this before running the ctest: 
`source /scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-jedi-bundle/tlei-jedi-rocky.csh`