### PR TITLE
Add cron to update stable branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,48 +1,64 @@
 [submodule "sorc/crtm"]
 	path = sorc/crtm
 	url = https://github.com/jcsda/crtm
+	branch = release/crtm_jedi_v2.4.1
 [submodule "sorc/femps"]
 	path = sorc/femps
 	url = https://github.com/jcsda/femps
+	branch = develop
 [submodule "sorc/fms"]
 	path = sorc/fms
 	url = https://github.com/jcsda/fms
+	branch = release-stable
 [submodule "sorc/fv3"]
 	path = sorc/fv3
 	url = https://github.com/jcsda/GFDL_atmos_cubed_sphere
+	branch = release-stable
 [submodule "sorc/fv3-jedi"]
 	path = sorc/fv3-jedi
 	url = https://github.com/jcsda/fv3-jedi
+	branch = develop
 [submodule "sorc/fv3-jedi-km"]
 	path = sorc/fv3-jedi-lm
 	url = https://github.com/JCSDA/fv3-jedi-linearmodel
+	branch = develop
 [submodule "sorc/gsibec"]
 	path = sorc/gsibec
 	url = https://github.com/GEOS-ESM/GSIbec
+	branch = develop
 [submodule "sorc/ioda"]
 	path = sorc/ioda
 	url = https://github.com/jcsda/ioda
+	branch = develop
 [submodule "sorc/iodaconv"]
 	path = sorc/iodaconv
 	url = https://github.com/jcsda-internal/ioda-converters
+	branch = develop
 [submodule "sorc/jedicmake"]
 	path = sorc/jedicmake
 	url = https://github.com/jcsda/jedi-cmake
+	branch = develop
 [submodule "sorc/oops"]
 	path = sorc/oops
 	url = https://github.com/jcsda/oops
+	branch = develop
 [submodule "sorc/saber"]
 	path = sorc/saber
 	url = https://github.com/jcsda/saber
+	branch = develop
 [submodule "sorc/ufo"]
 	path = sorc/ufo
 	url = https://github.com/jcsda/ufo
+	branch = develop
 [submodule "sorc/vader"]
 	path = sorc/vader
 	url = https://github.com/jcsda/vader
+	branch = develop
 [submodule "sorc/mpas"]
 	path = sorc/mpas
 	url = https://github.com/jcsda-internal/MPAS-Model
+	branch = develop
 [submodule "sorc/mpas-jedi"]
 	path = sorc/mpas-jedi
 	url = https://github.com/JCSDA/mpas-jedi
+	branch = develop

--- a/ci/stable_driver.sh
+++ b/ci/stable_driver.sh
@@ -1,0 +1,140 @@
+#!/bin/bash --login
+
+my_dir="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
+
+# ==============================================================================
+usage() {
+  set +x
+  echo
+  echo "Usage: $0 -t <target> -h"
+  echo
+  echo "  -t  target/machine script is running on    DEFAULT: $(hostname)"
+  echo "  -h  display this message and quit"
+  echo
+  exit 1
+}
+
+# ==============================================================================
+# First, set up runtime environment
+
+export TARGET="$(hostname)"
+
+while getopts "t:h" opt; do
+  case $opt in
+    t)
+      TARGET=$OPTARG
+      ;;
+    h|\?|:)
+      usage
+      ;;
+  esac
+done
+
+case ${TARGET} in
+  hera | orion)
+    echo "Running stability check on $TARGET"
+    source $MODULESHOME/init/sh
+    source $my_dir/${TARGET}.sh
+    module purge
+    module use $RDAS_MODULE_USE
+    module load RDAS/$TARGET
+    module list
+    ;;
+  *)
+    echo "Unsupported platform. Exiting with error."
+    exit 1
+    ;;
+esac
+
+set -x
+# ==============================================================================
+datestr="$(date +%Y%m%d)"
+repo_url="https://github.com/NOAA-EMC/RDASApp.git"
+stableroot=$RDAS_CI_ROOT/stable
+
+mkdir -p $stableroot/$datestr
+cd $stableroot/$datestr
+
+# clone RDASApp develop branch
+rdasdir=$stableroot/$datestr/rdas
+git clone --recursive $repo_url $rdasdir
+
+# checkout develop
+cd $rdasdir
+git checkout develop
+git pull
+
+# ==============================================================================
+# update the hashes to the most recent
+$my_dir/../ush/submodules/update_develop.sh $rdasdir
+
+# ==============================================================================
+# run the automated testing
+$my_dir/run_ci.sh -d $rdasdir -o $stableroot/$datestr/output
+ci_status=$?
+total=0
+if [ $ci_status -eq 0 ]; then
+  cd $rdasdir
+  # checkout feature/stable-nightly
+  git stash
+  total=$(($total+$?))
+  if [ $total -ne 0 ]; then
+    echo "Unable to git stash" >> $stableroot/$datestr/output
+  fi
+  git checkout feature/stable-nightly
+  total=$(($total+$?))
+  if [ $total -ne 0 ]; then
+    echo "Unable to checkout feature/stable-nightly" >> $stableroot/$datestr/output
+  fi
+  # merge in develop
+  git merge develop
+  total=$(($total+$?))
+  if [ $total -ne 0 ]; then
+    echo "Unable to merge develop" >> $stableroot/$datestr/output
+  fi
+  # add in submodules
+  git stash pop
+  total=$(($total+$?))
+  if [ $total -ne 0 ]; then
+    echo "Unable to git stash pop" >> $stableroot/$datestr/output
+  fi
+  $my_dir/../ush/submodules/add_submodules.sh $rdasdir
+  total=$(($total+$?))
+  if [ $total -ne 0 ]; then
+    echo "Unable to add updated submodules to commit" >> $stableroot/$datestr/output
+  fi
+  git diff-index --quiet HEAD || git commit -m "Update to new stable build on $datestr"
+  total=$(($total+$?))
+  caution=""
+  if [ $total -ne 0 ]; then
+    echo "Unable to commit" >> $stableroot/$datestr/output
+  fi
+  git push --set-upstream origin feature/stable-nightly
+  total=$(($total+$?))
+  if [ $total -ne 0 ]; then
+    echo "Unable to push" >> $stableroot/$datestr/output
+  fi
+  if [ $total -ne 0 ]; then
+    echo "Issue merging with develop. please manually fix"
+    PEOPLE="Cory.R.Martin@noaa.gov Shun.Liu@noaa.gov Ting.Lei@noaa.gov Donald.E.Lippi@noaa.gov Hui.Liu@noaa.gov"
+    SUBJECT="Problem updating feature/stable-nightly branch of RDASApp"
+    BODY=$stableroot/$datestr/output_stable_nightly
+    cat > $BODY << EOF
+Problem updating feature/stable-nightly branch of RDASApp. Please check $stableroot/$datestr/RDASApp
+
+EOF
+    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY
+  else
+    echo "Stable branch updated"
+  fi
+else
+  # do nothing
+  echo "Testing failed, stable branch will not be updated"
+fi
+# ==============================================================================
+# publish some information to RZDM for quick viewing
+# THIS IS A TODO FOR NOW
+
+# ==============================================================================
+# scrub working directory for older files
+find $stableroot/* -maxdepth 1 -mtime +3 -exec rm -rf {} \;


### PR DESCRIPTION
Using submodules means that `develop` has to be manually updated. But we can create a cron that will ensure that `feature/stable-nightly` has the most recent versions of JEDI repositories that build and tests pass.

To do this, the default branches had to be updated/added for the repositories. This is because the public JCSDA repos have `master` branches as default but we usually need `develop`. Running `git submodule update` on the public repos would have resulted in grabbing very old commits rather than recent ones.

Note: this script will not run properly until develop is updated with those submodule changes in `.gitmodules`. To test, one can add `git checkout feature/update-stable` in the `stable_driver.sh` script right after `git checkout develop` but this was tested manually yesterday on Orion. See: https://github.com/NOAA-EMC/RDASApp/tree/feature/stable-nightly