### PR TITLE
meet the data ownership requirement by the mpas-jedi tests with change on mpas-jedi-data to be copied into RDASapp/bundle dir

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 [submodule "sorc/mpas"]
 	path = sorc/mpas
 	url = https://github.com/jcsda-internal/MPAS-Model
-	branch = develop
+	branch = release-stable 
 [submodule "sorc/mpas-jedi"]
 	path = sorc/mpas-jedi
 	url = https://github.com/JCSDA/mpas-jedi

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -109,6 +109,7 @@ endif()
 
 # ioda, ufo, fv3-jedi, and saber test data
 #---------------------------------
+  set(myown_JCSDA_DATA_ROOT "/scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-jedi-new/jedi-bundle") #clt
   if(CLONE_JCSDADATA)
 
    set(JCSDA_DATA_ROOT "$ENV{RDASAPP_TESTDATA}/jcsda")
@@ -118,7 +119,8 @@ endif()
      ecbuild_bundle( PROJECT fv3-jedi-data SOURCE "${JCSDA_DATA_ROOT}/fv3-jedi-data" )
    endif()
    if(MPAS_DYCORE)
-     ecbuild_bundle( PROJECT mpas-jedi-data SOURCE "${JCSDA_DATA_ROOT}/mpas-jedi-data" )
+#     ecbuild_bundle( PROJECT mpas-jedi-data SOURCE "${myown_JCSDA_DATA_ROOT}/mpas-jedi-data" )
+     file( COPY "${myown_JCSDA_DATA_ROOT}/mpas-jedi-data" DESTINATION mpas-jedi-data )
    endif()
 
   endif(CLONE_JCSDADATA)

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -109,7 +109,6 @@ endif()
 
 # ioda, ufo, fv3-jedi, and saber test data
 #---------------------------------
-  set(myown_JCSDA_DATA_ROOT "/scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-jedi-new/jedi-bundle") #clt
   if(CLONE_JCSDADATA)
 
    set(JCSDA_DATA_ROOT "$ENV{RDASAPP_TESTDATA}/jcsda")
@@ -119,8 +118,8 @@ endif()
      ecbuild_bundle( PROJECT fv3-jedi-data SOURCE "${JCSDA_DATA_ROOT}/fv3-jedi-data" )
    endif()
    if(MPAS_DYCORE)
-#     ecbuild_bundle( PROJECT mpas-jedi-data SOURCE "${myown_JCSDA_DATA_ROOT}/mpas-jedi-data" )
-     file( COPY "${myown_JCSDA_DATA_ROOT}/mpas-jedi-data" DESTINATION mpas-jedi-data )
+     set(DESTINATION_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+     file( COPY "${JCSDA_DATA_ROOT}/mpas-jedi-data" DESTINATION ${DESTINATION_DIR} )
    endif()
 
   endif(CLONE_JCSDADATA)


### PR DESCRIPTION
MPAS-jedi apps require write permission to some template files, which are from mpas-jedi-data.  This PR changes the symlink of mpas-jedi-data from a specified machine-dependent location (which might not be owned by the user and cause all mpas-jedi tests fail) to "copy" of that dir to the current RDASapp/bundle dir to resolve this issue. 
With this PR, all mpas-jedi tests passed except for :
```
The following tests FAILED:
    1375 - test_mpasjedi_3denvar_amsua_allsky (Failed)
    1376 - test_mpasjedi_3denvar_amsua_bc (Failed)
    1381 - test_mpasjedi_4denvar_VarBC (Failed)
    1382 - test_mpasjedi_4denvar_VarBC_nonpar (Failed)
```
which were attributed to the use of different crtm data . 
