### PR TITLE
initial version with a rrfs test add

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project(RDASApp VERSION 1.0.0 LANGUAGES C CXX Fortran )
 
 include(GNUInstallDirs)
 enable_testing()
+#clt for rrfs test
+set(MPIEXEC_MAX_NUMPROCS 120 CACHE STRING "Maximum number of processors")
 
 # Build type.
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")

--- a/build.sh
+++ b/build.sh
@@ -132,6 +132,7 @@ if [[ $BUILD_TARGET == 'hera' ]]; then
   ln -sf $RDASAPP_TESTDATA/crtm $dir_root/bundle/test-data-release/crtm
 fi
 
+  CMAKE_OPTS+=" -DMPIEXEC_MAX_NUMPROCS:STRING=120"
 # Configure
 echo "Configuring ..."
 set -x

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -123,7 +123,12 @@ endif()
    endif()
 
   endif(CLONE_JCSDADATA)
+     set(RDAS_RRFS_DATA_ROOT "$ENV{RDASAPP_RRFS_TESTDATA}/jcsda")
+     set(RDAS_RRFS_DATA_ROOT "/scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-emc-rdas/rrfs-test-data") #clttodo
+     set(DESTINATION_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+     file( COPY "${RDAS_RRFS_DATA_ROOT}" DESTINATION ${DESTINATION_DIR} )
 
+  ecbuild_bundle( PROJECT rrfs-test SOURCE "../rrfs-test" )
 endif(BUILD_RDASBUNDLE)
 
 # Finalize bundle

--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -1,9 +1,8 @@
-# (C) Copyright 2017-2023 UCAR
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#!-------------------------------------------------------------------------
+#!    NOAA/NCEP, National Centers for Environmental Prediction  RDASapp        !
+#!-------------------------------------------------------------------------
 
-# FV3-JEDI test data - from fv3-jedi-data repo if found, from local directory, or from tarball
+# rrfs data - from rrfs-test-data repo if found, from local directory, or from tarball
 set(rrfs-test-data_FOUND 1)  #clttodo
 if (rrfs-test-data_FOUND)
   message(STATUS "Use test data from rrfs-test-data repository")
@@ -34,17 +33,13 @@ foreach(case IN LISTS rrfs_fv3jedi_test_cases)
    endif()
 endforeach()
 
-# FV3 config files
+# JEDI config files
 # ----------------
 list( APPEND rrfs_fv3_test_yamf_files 
 rrfs_fv3jedi_hyb_2022052619.yaml
 )
 
-# gsibec config files
-# -------------------
-# ------------
 
-# Interface tests
 # ---------------
 set(target_test rrfs_fv3jedi_hyb_2022052619)
 ecbuild_add_test( TARGET   ${target_test} 

--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -1,0 +1,56 @@
+# (C) Copyright 2017-2023 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# FV3-JEDI test data - from fv3-jedi-data repo if found, from local directory, or from tarball
+set(rrfs-test-data_FOUND 1)  #clttodo
+if (rrfs-test-data_FOUND)
+  message(STATUS "Use test data from rrfs-test-data repository")
+  set (rrfs-test_data_local "${CMAKE_SOURCE_DIR}/rrfs-test-data/")
+# It's unclear if anyone is using the local data functionality, therefore comment it out
+# for now and add in if someone complains / remove if completely if not.
+#elseif (DEFINED ENV{FV3_JEDI_TESTFILES})
+#  message(STATUS "Use test data from local directory $ENV{FV3_JEDI_TESTFILES}")
+#  # A bit of guesswork here, I don't know if folks using this option stored it in the same directory structure
+#  set (fv3-jedi_data_testinput_tier_1_local "$ENV{FV3_JEDI_TESTFILES}/fv3-jedi-data/testinput_tier_1")
+else()
+  message(FATAL_ERROR  "rrfs data would only be avaiable from local sourcerfs-fv3-jedi-data repository")
+endif()
+list( APPEND rrfs_fv3jedi_test_cases
+       rrfs_fv3jedi_hyb_2022052619
+    )
+foreach(case IN LISTS rrfs_fv3jedi_test_cases)
+   set(casedir "${CMAKE_CURRENT_BINARY_DIR}/rundir-${case}")
+   set(src_casedir "${rrfs-test_data_local}/rundir-${case}")
+   if (NOT EXISTS "${casedir}")
+     file(MAKE_DIRECTORY ${casedir})
+     file(CREATE_LINK ${src_casedir}/DataFix ${casedir}/DataFix SYMBOLIC)
+     file(CREATE_LINK ${src_casedir}/Data_static ${casedir}/Data_static SYMBOLIC)
+#clt     file(CREATE_LINK ${src_casedir}/testinput ${casedir} SYMBOLIC)
+     file(COPY ${src_casedir}/INPUT DESTINATION ${casedir} )
+     file(COPY ${src_casedir}/${case}.yaml  DESTINATION ${casedir} )
+     file(COPY ${src_casedir}/Data DESTINATION ${casedir} )
+   endif()
+endforeach()
+
+# FV3 config files
+# ----------------
+list( APPEND rrfs_fv3_test_yamf_files 
+rrfs_fv3jedi_hyb_2022052619.yaml
+)
+
+# gsibec config files
+# -------------------
+# ------------
+
+# Interface tests
+# ---------------
+set(target_test rrfs_fv3jedi_hyb_2022052619)
+ecbuild_add_test( TARGET   ${target_test} 
+                  MPI      80 
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rundir-${target_test}
+                  ARGS     ${target_test}.yaml 
+                  COMMAND  fv3jedi_var.x )
+
+


### PR DESCRIPTION
Begin creating a rdasapp component to store/help organize rrfs jedi tests.
The structure in rdasapp and strategies for managing rrfs jedi test  could be continually adjusted according to RDASapp developers/users's feedbacks. 
Co-authors:  @ShunLiu-NOAA and @delippi 
