### PR TITLE
A rrfs Ens3Dvar test for mpasjedi is added

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -123,8 +123,8 @@ endif()
    endif()
 
   endif(CLONE_JCSDADATA)
-     set(RDAS_RRFS_DATA_ROOT "$ENV{RDASAPP_RRFS_TESTDATA}/jcsda")
-     set(RDAS_RRFS_DATA_ROOT "/scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-emc-rdas/rrfs-test-data") #clttodo
+     set(RDAS_RRFS_DATA_ROOT "$ENV{RDAS_RRFS_DATA_ROOT}/rrfs-test-data")
+#cltorg     set(RDAS_RRFS_DATA_ROOT "/scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-emc-rdas/rrfs-test-data") #clttodo
      set(DESTINATION_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
      file( COPY "${RDAS_RRFS_DATA_ROOT}" DESTINATION ${DESTINATION_DIR} )
 

--- a/modulefiles/RDAS/hera.intel.lua
+++ b/modulefiles/RDAS/hera.intel.lua
@@ -85,6 +85,7 @@ setenv('MPIEXEC_NPROC', mpinproc)
 
 setenv("CRTM_FIX","/scratch1/NCEPDEV/da/Cory.R.Martin/RDASApp/fix/crtm/2.4.0")
 setenv("RDASAPP_TESTDATA","/scratch1/NCEPDEV/da/Cory.R.Martin/CI/RDASApp/data")
+setenv("RDAS_RRFS_DATA_ROOT","/scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-emc-rdas/")
 --prepend_path("PATH","/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/intel-18.0.5.274/prod_util/1.2.2/bin")
 
 whatis("Name: ".. pkgName)

--- a/modulefiles/RDAS/orion.intel.lua
+++ b/modulefiles/RDAS/orion.intel.lua
@@ -80,6 +80,7 @@ setenv('MPIEXEC_NPROC', mpinproc)
 
 setenv("CRTM_FIX","/work2/noaa/da/cmartin/RDASApp/fix/crtm/2.4.0")
 setenv("RDASAPP_TESTDATA","/work2/noaa/da/cmartin/CI/RDASApp/data")
+setenv("RDAS_RRFS_DATA_ROOT","/work/noaa/fv3-cam/tlei/dr-emc-rdas/")
 prepend_path("PATH","/apps/contrib/NCEP/libs/hpc-stack/intel-2018.4/prod_util/1.2.2/bin")
 
 execute{cmd="ulimit -s unlimited",modeA={"load"}}

--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -16,36 +16,76 @@ if (rrfs-test-data_FOUND)
 else()
   message(FATAL_ERROR  "rrfs data would only be avaiable from local sourcerfs-fv3-jedi-data repository")
 endif()
-list( APPEND rrfs_fv3jedi_test_cases
-       rrfs_fv3jedi_hyb_2022052619
+if(FV3_DYCORE)
+   list( APPEND rrfs_fv3jedi_test_cases
+          rrfs_fv3jedi_hyb_2022052619
+       )
+   # JEDI config files
+   # ----------------
+   list( APPEND rrfs_fv3jedi_test_yamf_files 
+   rrfs_fv3jedi_hyb_2022052619.yaml
+   )
+   foreach(case IN LISTS rrfs_fv3jedi_test_cases)
+      set(casedir "${CMAKE_CURRENT_BINARY_DIR}/rundir-${case}")
+      set(src_casedir "${rrfs-test_data_local}/rundir-${case}")
+      if (NOT EXISTS "${casedir}")
+        file(MAKE_DIRECTORY ${casedir})
+      endif()
+      file(CREATE_LINK ${src_casedir}/DataFix ${casedir}/DataFix SYMBOLIC)
+      file(CREATE_LINK ${src_casedir}/Data_static ${casedir}/Data_static SYMBOLIC)
+   #clt     file(CREATE_LINK ${src_casedir}/testinput ${casedir} SYMBOLIC)
+      file(COPY ${src_casedir}/INPUT DESTINATION ${casedir} )
+      file(COPY ${src_casedir}/${case}.yaml  DESTINATION ${casedir} )
+      file(COPY ${src_casedir}/Data DESTINATION ${casedir} )
+   endforeach() 
+   # ---------------
+   set(target_test rrfs_fv3jedi_hyb_2022052619)
+   ecbuild_add_test( TARGET   ${target_test} 
+                     MPI      80 
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rundir-${target_test}
+                     ARGS     ${target_test}.yaml 
+                     COMMAND  fv3jedi_var.x )
+endif()
+if(MPAS_DYCORE)
+   list( APPEND rrfs_mpasjedi_test_cases
+       rrfs_mpasjedi_2022052619_Ens3Dvar
     )
-foreach(case IN LISTS rrfs_fv3jedi_test_cases)
-   set(casedir "${CMAKE_CURRENT_BINARY_DIR}/rundir-${case}")
-   set(src_casedir "${rrfs-test_data_local}/rundir-${case}")
-   if (NOT EXISTS "${casedir}")
-     file(MAKE_DIRECTORY ${casedir})
-     file(CREATE_LINK ${src_casedir}/DataFix ${casedir}/DataFix SYMBOLIC)
-     file(CREATE_LINK ${src_casedir}/Data_static ${casedir}/Data_static SYMBOLIC)
-#clt     file(CREATE_LINK ${src_casedir}/testinput ${casedir} SYMBOLIC)
-     file(COPY ${src_casedir}/INPUT DESTINATION ${casedir} )
-     file(COPY ${src_casedir}/${case}.yaml  DESTINATION ${casedir} )
-     file(COPY ${src_casedir}/Data DESTINATION ${casedir} )
-   endif()
-endforeach()
+   # JEDI config files
+   # ----------------
+   list( APPEND rrfs_mpasjedi_test_yamf_files 
+   rrfs_mpasjedi_2022052619_Ens3Dvar.yaml
+   )
+   foreach(case IN LISTS rrfs_mpasjedi_test_cases)
+      set(casedir "${CMAKE_CURRENT_BINARY_DIR}/rundir-${case}")
+      set(src_casedir "${rrfs-test_data_local}/rundir-${case}")
+      if (NOT EXISTS "${casedir}")
+        file(MAKE_DIRECTORY ${casedir})
+      endif()
+      file(CREATE_LINK ${src_casedir}/ensemble ${casedir}/ensemble SYMBOLIC)
+      file(CREATE_LINK ${src_casedir}/BUMP_files ${casedir}/BUMP_files SYMBOLIC)
+      file(GLOB YAML_FILES "${src_casedir}/*.yaml")
+      file(COPY ${YAML_FILES} DESTINATION ${casedir})
+      file(GLOB nc_FILES "${src_casedir}/*.nc")
+      file(COPY ${nc_FILES} DESTINATION ${casedir})
+      file(GLOB bl_FILES "${src_casedir}/*.*BL")
+      file(COPY ${bl_FILES} DESTINATION ${casedir})
 
-# JEDI config files
-# ----------------
-list( APPEND rrfs_fv3_test_yamf_files 
-rrfs_fv3jedi_hyb_2022052619.yaml
-)
+      file(GLOB stream_FILES "${src_casedir}/stream*.atmo*")
+      file(COPY ${stream_FILES} DESTINATION ${casedir})
+      file(GLOB DATA_FILES "${src_casedir}/*.DATA")
+      file(COPY ${DATA_FILES} DESTINATION ${casedir})
 
+      file(COPY ${src_casedir}/Data DESTINATION ${casedir})
+      file(COPY ${src_casedir}/CONUS.graph.info.part.36  DESTINATION ${casedir})
+      file(COPY ${src_casedir}/namelist.atmosphere_15km  DESTINATION ${casedir})
 
-# ---------------
-set(target_test rrfs_fv3jedi_hyb_2022052619)
-ecbuild_add_test( TARGET   ${target_test} 
-                  MPI      80 
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rundir-${target_test}
-                  ARGS     ${target_test}.yaml 
-                  COMMAND  fv3jedi_var.x )
+   endforeach()
 
+   set(target_test rrfs_mpasjedi_2022052619_Ens3Dvar)
+   ecbuild_add_test( TARGET   ${target_test} 
+                     MPI      36 
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rundir-${target_test}
+                     ARGS     ${target_test}.yaml 
+                     COMMAND  mpasjedi_variational.x )
 
+endif()


### PR DESCRIPTION
Following the similar procedure by which a rrfs test for fv3jedi was added,  a rrfs Ens3Dvar test is added for mpasjedi. 
The ctest name is  rrfs_mpasjedi_2022052619_Ens3Dvar. 
Also, now the env variable pointing to the location of the local dir containing the rrfs data is set in the machine specific module file.
