### PR TITLE
changes for rrfs-mpas jedi rrfs test on orion 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,7 @@ case ${BUILD_TARGET} in
     source $dir_root/ush/module-setup.sh
     module use $dir_root/modulefiles
     module load RDAS/$BUILD_TARGET.$COMPILER
-    CMAKE_OPTS+=" -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON"
+    CMAKE_OPTS+=" -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON -DMACHINE_ID=$MACHINE_ID"
     module list
     ;;
   $(hostname))

--- a/modulefiles/RDAS/orion.intel.lua
+++ b/modulefiles/RDAS/orion.intel.lua
@@ -83,7 +83,7 @@ setenv("RDASAPP_TESTDATA","/work2/noaa/da/cmartin/CI/RDASApp/data")
 setenv("RDAS_RRFS_DATA_ROOT","/work/noaa/fv3-cam/tlei/dr-emc-rdas/")
 prepend_path("PATH","/apps/contrib/NCEP/libs/hpc-stack/intel-2018.4/prod_util/1.2.2/bin")
 
-execute{cmd="ulimit -s unlimited",modeA={"load"}}
+--cltorg execute{cmd="ulimit -s unlimited",modeA={"load"}}
 
 whatis("Name: ".. pkgName)
 whatis("Version: ".. pkgVersion)

--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -81,7 +81,7 @@ if(MPAS_DYCORE)
 
    endforeach()
   message(STATUS "MACHINCE_ID is " ${MACHINE_ID})
-   if("${MACHINE_ID}" STREQUAL "orion")
+   if("$ENV{MACHINE_ID}" STREQUAL "orion")
      message(STATUS "MACHINCE_ID ok " )
      if (MPI_ARGS)
        set(RESTORE_MPI_ARGS ${MPI_ARGS})

--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -80,12 +80,23 @@ if(MPAS_DYCORE)
       file(COPY ${src_casedir}/namelist.atmosphere_15km  DESTINATION ${casedir})
 
    endforeach()
-
-   set(target_test rrfs_mpasjedi_2022052619_Ens3Dvar)
-   ecbuild_add_test( TARGET   ${target_test} 
+  message(STATUS "MACHINCE_ID is " ${MACHINE_ID})
+   if("${MACHINE_ID}" STREQUAL "orion")
+     message(STATUS "MACHINCE_ID ok " )
+     if (MPI_ARGS)
+       set(RESTORE_MPI_ARGS ${MPI_ARGS})
+     endif()
+     set( MPI_ARGS "${MPI_ARGS} -N 2 --ntasks-per-node=18")
+   endif()
+     set(target_test rrfs_mpasjedi_2022052619_Ens3Dvar)
+     ecbuild_add_test( TARGET   ${target_test} 
                      MPI      36 
                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rundir-${target_test}
                      ARGS     ${target_test}.yaml 
-                     COMMAND  mpasjedi_variational.x )
+                     COMMAND   mpasjedi_variational.x )
+     if( RESTORE_MPI_ARGS )
+    
+       set(MPI_ARGS ${RESTORE_MPI_ARGS})
+     endif()
 
 endif()


### PR DESCRIPTION
It is found a few changes needed for rdasapp building and running on orion.
One is as discussed in https://github.com/ecmwf/ecbuild/issues/61 when mpasjedi rrfs test case requires two nodes to get enough memory avoid the job fail.