### PR TITLE
Add exclusive MPI option for ctest on Orion to prevent memory error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,7 @@ case ${BUILD_TARGET} in
     source $dir_root/ush/module-setup.sh
     module use $dir_root/modulefiles
     module load RDAS/$BUILD_TARGET.$COMPILER
-    CMAKE_OPTS+=" -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON"
+    CMAKE_OPTS+=" -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON -DMACHINE_ID=$MACHINE_ID"
     module list
     ;;
   $(hostname))

--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -35,12 +35,21 @@ if (CLONE_RRFSDATA)
          file(COPY ${src_casedir}/Data DESTINATION ${casedir} )
       endforeach()
       # ---------------
-      set(target_test rrfs_fv3jedi_hyb_2022052619)
-      ecbuild_add_test( TARGET   ${target_test}
+      message(STATUS "MACHINE_ID is " ${MACHINE_ID})
+         if("${MACHINE_ID}" STREQUAL "orion")
+            message(STATUS "Because MACHINE_ID is orion, adding exclusive MPI option" )
+            set(RESTORE_MPI_ARGS ${MPI_ARGS})
+            set(MPI_ARGS "${MPI_ARGS} --exclusive")
+         endif()   
+         set(target_test rrfs_fv3jedi_hyb_2022052619)
+         ecbuild_add_test( TARGET   ${target_test}
                         MPI      80
                         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rundir-${target_test}
                         ARGS     ${target_test}.yaml
                         COMMAND  fv3jedi_var.x )
+         if("${MACHINE_ID}" STREQUAL "orion")
+            set(MPI_ARGS ${RESTORE_MPI_ARGS})
+         endif()
    endif()
    if(MPAS_DYCORE)
       list( APPEND rrfs_mpasjedi_test_cases
@@ -77,12 +86,20 @@ if (CLONE_RRFSDATA)
 
       endforeach()
 
-      set(target_test rrfs_mpasjedi_2022052619_Ens3Dvar)
-      ecbuild_add_test( TARGET   ${target_test}
+      message(STATUS "MACHINE_ID is " ${MACHINE_ID})
+         if("${MACHINE_ID}" STREQUAL "orion")
+            message(STATUS "Because MACHINE_ID is orion, adding exclusive MPI option" )
+            set(RESTORE_MPI_ARGS ${MPI_ARGS})
+            set(MPI_ARGS "${MPI_ARGS} --exclusive")
+         endif()   
+         set(target_test rrfs_mpasjedi_2022052619_Ens3Dvar)
+         ecbuild_add_test( TARGET   ${target_test}
                         MPI      36
                         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rundir-${target_test}
                         ARGS     ${target_test}.yaml
                         COMMAND  mpasjedi_variational.x )
-
+         if("${MACHINE_ID}" STREQUAL "orion")
+            set(MPI_ARGS ${RESTORE_MPI_ARGS})
+	 endif()
    endif()
 endif()

--- a/rrfs-test/ush/fv3jedi-increment.py
+++ b/rrfs-test/ush/fv3jedi-increment.py
@@ -19,8 +19,6 @@ import warnings
 from scipy.spatial.distance import cdist
 
 warnings.filterwarnings('ignore')
-cartopy.config['data_dir']='/home/Donald.E.Lippi/cartopy' ### For Hera
-#cartopy.config['data_dir']='/work/noaa/fv3-cam/sdegelia/cartopy' ### For Orion
 
 ############ USER INPUT ##########################################################
 plot_var = "Increment"
@@ -47,6 +45,13 @@ jgrid = f"{datapath}/Data/bkg/fv3_grid_spec.nc"
 jdiag = f"{datapath}/Data/hofx/{singleob_type}_hofxs_2022052619.nc4"
 
 ###################################################################################
+# Set cartopy shapefile path
+platform = os.getenv('HOSTNAME').upper()
+if 'ORION' in platform:
+        cartopy.config['data_dir']='/work/noaa/fv3-cam/sdegelia/cartopy'
+elif 'H' in platform: # Will need to improve this once Hercules is supported
+        cartopy.config['data_dir']='/home/Donald.E.Lippi/cartopy'
+
 print(f"{jdiag}")
 # Do a quick omf and hofx value check from GSI diag file
 

--- a/rrfs-test/ush/mpasjedi-increment.py
+++ b/rrfs-test/ush/mpasjedi-increment.py
@@ -19,8 +19,6 @@ import warnings
 from scipy.spatial.distance import cdist
 
 warnings.filterwarnings('ignore')
-cartopy.config['data_dir']='/home/Donald.E.Lippi/cartopy' ### For Hera
-#cartopy.config['data_dir']='/work/noaa/fv3-cam/sdegelia/cartopy' ### For Orion
 
 ############ USER INPUT ##########################################################
 plot_var = "Increment"
@@ -49,6 +47,12 @@ jdiag = f"{datapath}/Data/hofx/{singleob_type}_hofxs_2022052619.nc4"
 
 
 ###################################################################################
+# Set cartopy shapefile path
+platform = os.getenv('HOSTNAME').upper()
+if 'ORION' in platform:
+        cartopy.config['data_dir']='/work/noaa/fv3-cam/sdegelia/cartopy'
+elif 'H' in platform: # Will need to improve this once Hercules is supported
+        cartopy.config['data_dir']='/home/Donald.E.Lippi/cartopy'
 print(f"{jdiag}")
 # Do a quick omf and hofx value check from GSI diag file
 


### PR DESCRIPTION
This PR is similar to Ting's closed PR from last week to fix an issue with running the ctest on Orion. I found that the ctest can rarely crash on Orion with a memory error. This occurs when the job allocation shares nodes with other jobs, and thus not all of the memory on that node/nodes are available. The fix here features simple addition of the `--exclusive` tag to the ctest in rrfs_test so that the ctest job requests exclusive access to that node and memory is not shared. 

* `$MACHINE_ID` is passed into `CMAKE_OPTS` during `build.sh` to be read later
* `rrfs_test/CMakeLists.txt` is modified to now pass in the `--exclusive` tag only when building the ctests on Orion

I tested this change by running the ctest about 10 times and it succeeded every time. 

Also, this PR features a quick commit to the python scripts to now feature a line where the path to the cartopy shapefiles is set automatically based on `hostname` instead of having the user manually comment in/out the correct lines. If this PR is approved then I will update the wiki respectively. 