### PR TITLE
simplify the setup experiment helper scripti to set up a basic experi…

### DIFF
--- a/rrfs-test/scripts/setup_experiment.sh
+++ b/rrfs-test/scripts/setup_experiment.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+START=$(date +%s)
+
 # This script is used after compiling RDASApp with -r option which downloads
 # RRFS test data. This script helps a user set up an experiment directory.
 
@@ -8,8 +10,6 @@ YOUR_PATH_TO_RDASAPP="/path/to/your/installation/of/RDASApp"
 YOUR_EXPERIMENT_DIR="/path/to/your/desired/experiment/directory/jedi-assim_test"
 SLURM_ACCOUNT="fv3-cam"
 DYCORE="FV3" #FV3 or MPAS
-YAML="${YOUR_PATH_TO_RDASAPP}/rrfs-test/testinput/rrfs_fv3jedi_hyb_2022052619.yaml" # test yaml you want to run
-EXE="fv3jedi_var.x" # executable corresponding to this test
 platform="hera" #hera or orion
 #######################
 
@@ -19,29 +19,21 @@ echo -e "\tYOUR_PATH_TO_RDASAPP=$YOUR_PATH_TO_RDASAPP"
 echo -e "\tYOUR_EXPERIMENT_DIR=$YOUR_EXPERIMENT_DIR"
 echo -e "\tSLURM_ACCOUNT=$SLURM_ACCOUNT"
 echo -e "\tDYCORE=$DYCORE"
-echo -e "\tDA_METHOD=$DA_METHOD"
 echo -e "\tplatform=$platform\n"
 
 # Check to see if user changed the paths to something valid.
-if [[ ! -d $YOUR_PATH_TO_RDASAPP && ! -d `dirname $YOUR_EXPERIMENT_DIR` ]]; then
+if [[ ! -d $YOUR_PATH_TO_RDASAPP || ! -d `dirname $YOUR_EXPERIMENT_DIR` ]]; then
   echo "Please make sure to edit the USER INPUT BLOCK before running $0."
   echo "exiting!!!"
   exit 1
 fi
 
-# Error check if choosing LETKF for MPAS 
-if [[ $DYCORE == "MPAS" && $DA_METHOD == "LETKF" ]]; then
-   echo "ERROR: LETKF is not yet implemented for MPAS"
-   exit 1
-fi 
-
 # At the moment these are the only test data that exists. Maybe become user input later?
 # It also seems the best to just do either FV3 or MPAS data each time script is run.
-# NOTE: Currently using same hybrid input data for LETKF test case
 if [[ $DYCORE == "FV3" ]]; then
-  INPUT_DATA="rrfs-data_fv3jedi_2022052619"
+  TEST_DATA="rrfs-data_fv3jedi_2022052619"
 elif [[ $DYCORE == "MPAS" ]]; then
-  INPUT_DATA="rrfs-data_mpasjedi_2022052619"
+  TEST_DATA="rrfs-data_mpasjedi_2022052619"
 else
   echo "Not a valid DYCORE: ${DYCORE}. Please use FV3 or MPAS."
   echo "exiting!!!"
@@ -57,50 +49,29 @@ fi
 declare -l dycore="$DYCORE"
 
 # Ensure experiment directory exists, the move into that space.
-YAML_NOFILETYPE=${YAML::-5}
-YOUR_EXPERIMENT_DIR="${YOUR_EXPERIMENT_DIR}/rundir-$(basename ${YAML_NOFILETYPE})"
 mkdir -p $YOUR_EXPERIMENT_DIR
 cd $YOUR_EXPERIMENT_DIR
 
 # Copy the test data into the experiment directory.
-# Need some special handling of LETKF since using the same input data as hybrid cases
 echo "Copying data. This may take awhile."
-if [[ $DYCORE == "FV3" ]]; then 
-   ln -sf ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/DataFix ./
-   ln -sf ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/Data_static ./
-   ln -sf ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/Data ./
-   ln -sf ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/INPUT ./
-elif [[ $DYCORE == "MPAS" ]]; then 
-   ln -sf ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/DataFix ./
-   ln -sf ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/Data_static ./
-   ln -sf ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/Data ./
-   cp ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/streams.atmosphere_15km ./
-   cp ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/namelist.atmosphere_15km ./
-   cp ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/geovars.yaml ./
-   cp ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/keptvars.yaml ./
-   cp ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/obsop_name_map.yaml ./
-   cp ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/*.*BL ./
-   cp ${YOUR_PATH_TO_RDASAPP}/bundle/rrfs-test-data/${INPUT_DATA}/*DATA* ./
-fi
-cp ${YAML} ./
+echo "  --> ${dycore}-jedi data on $platform"
+rsync -a $YOUR_PATH_TO_RDASAPP/bundle/rrfs-test-data/${TEST_DATA} .
 
 # Copy the template run script which will be updated according to the user input
-cp -p $YOUR_PATH_TO_RDASAPP/rrfs-test/scripts/templates/run_${dycore}jedi_${platform}_template.sh ./${runpath}/run_${dycore}jedi_${platform}.sh
+cp -p $YOUR_PATH_TO_RDASAPP/rrfs-test/scripts/templates/run_${dycore}jedi_${platform}_template.sh ./${TEST_DATA}/run_${dycore}jedi_${platform}.sh
 
 # Stream editor to edit files. Use "#" instead of "/" since we have "/" in paths.
-cd ${YOUR_EXPERIMENT_DIR}/${runpath}
+cd ${YOUR_EXPERIMENT_DIR}/${TEST_DATA}
 sed -i "s#@YOUR_PATH_TO_RDASAPP@#${YOUR_PATH_TO_RDASAPP}#g" ./run_${dycore}jedi_${platform}.sh
 sed -i "s#@YOUR_EXPERIMENT_DIR@#${YOUR_EXPERIMENT_DIR}#g"   ./run_${dycore}jedi_${platform}.sh
 sed -i "s#@SLURM_ACCOUNT@#${SLURM_ACCOUNT}#g"               ./run_${dycore}jedi_${platform}.sh
-sed -i "s#@YAML@#$(basename ${YAML})#g"                                 ./run_${dycore}jedi_${platform}.sh
-sed -i "s#@EXECUTABLE@#${EXE}#g"                            ./run_${dycore}jedi_${platform}.sh
 
 # Copy visualization package.
 cp -p $YOUR_PATH_TO_RDASAPP/rrfs-test/ush/colormap.py .
 if [[ $DYCORE == "FV3" ]]; then
   cp -p $YOUR_PATH_TO_RDASAPP/rrfs-test/ush/fv3jedi_increment_singleob.py .
   cp -p $YOUR_PATH_TO_RDASAPP/rrfs-test/ush/fv3jedi_increment_fulldom.py .
-elif [[ $DYCORE == "MPAS" ]]; then 
+elif [[ $DYCORE == "MPAS" ]]; then
   cp -p $YOUR_PATH_TO_RDASAPP/rrfs-test/ush/mpasjedi_increment_singleob.py .
 fi
 
@@ -110,3 +81,6 @@ cp -p $YOUR_PATH_TO_RDASAPP/rrfs-test/testinput/* testinput/.
 cp -p $YOUR_PATH_TO_RDASAPP/rrfs-test/obs/* Data/obs/.
 
 echo "done."
+END=$(date +%s)
+DIFF=$((END - START))
+echo "Time taken to run the code: $DIFF seconds"

--- a/rrfs-test/scripts/templates/run_fv3jedi_hera_template.sh
+++ b/rrfs-test/scripts/templates/run_fv3jedi_hera_template.sh
@@ -27,10 +27,10 @@ ulimit -a
 
 inputfile=$1
 if [[ $inputfile == "" ]]; then
-  inputfile=./testinput/@YAML@
+  inputfile=./testinput/rrfs_fv3jedi_hyb_2022052619.yaml
 fi
 
 jedibin="@YOUR_PATH_TO_RDASAPP@/build/bin"
 # Run JEDI - currently cannot change processor count
-srun -l -n 80 $jedibin/@EXECUTABLE@ ./$inputfile out.log
+srun -l -n 80 $jedibin/fv3jedi_var.x ./$inputfile out.log
 

--- a/rrfs-test/scripts/templates/run_fv3jedi_orion_template.sh
+++ b/rrfs-test/scripts/templates/run_fv3jedi_orion_template.sh
@@ -27,10 +27,10 @@ ulimit -a
 
 inputfile=$1
 if [[ $inputfile == "" ]]; then
-  inputfile=./testinput/@YAML@
+  inputfile=./testinput/rrfs_fv3jedi_hyb_2022052619.yaml
 fi
 
 jedibin="@YOUR_PATH_TO_RDASAPP@/build/bin"
 # Run JEDI - currently cannot change processor count
-srun -l -n 80 $jedibin/@EXECUTABLE@ ./$inputfile out.log
+srun -l -n 80 $jedibin/fv3jedi_var.x ./$inputfile out.log
 

--- a/rrfs-test/scripts/templates/run_mpasjedi_hera_template.sh
+++ b/rrfs-test/scripts/templates/run_mpasjedi_hera_template.sh
@@ -27,10 +27,10 @@ ulimit -a
 
 inputfile=$1
 if [[ $inputfile == "" ]]; then
-  inputfile=./testinput/@YAML@
+  inputfile=./testinput/rrfs_mpasjedi_2022052619_Ens3Dvar.yaml
 fi
 
 jedibin="@YOUR_PATH_TO_RDASAPP@/build/bin"
 # Run JEDI - currently cannot change processor count
-srun -l -n 36 $jedibin/@EXECUTABLE@ ./$inputfile out.log
+srun -l -n 36 $jedibin/mpasjedi_variational.x ./$inputfile out.log
 

--- a/rrfs-test/scripts/templates/run_mpasjedi_orion_template.sh
+++ b/rrfs-test/scripts/templates/run_mpasjedi_orion_template.sh
@@ -27,10 +27,10 @@ ulimit -a
 
 inputfile=$1
 if [[ $inputfile == "" ]]; then
-  inputfile=./testinput/@YAML@
+  inputfile=./testinput/rrfs_mpasjedi_2022052619_Ens3Dvar.yaml
 fi
 
 jedibin="@YOUR_PATH_TO_RDASAPP@/build/bin"
 # Run JEDI - currently cannot change processor count
-srun -l -n 36 $jedibin/@EXECUTABLE@ ./$inputfile out.log
+srun -l -n 36 $jedibin/mpasjedi_variational.x ./$inputfile out.log
 


### PR DESCRIPTION
…ment and changed to use rsync to copy data instead of links.

This helper script is just meant to be pretty basic in getting a user set up to run an experiment without giving them too many options. Once they verify they can run this, they could then change which exe or yaml to use.

Copy and paste my rational for rsync vs links:
> I like having a copy of the data knowing that I have a safe copy to go back to and it allows the directory to be a little cleaner. The copy is really only done once and for me only takes about 80s (for fv3jedi data) so it isn’t really saving much time. You also don’t have to worry about if the directory housing those files gets deleted like if you are cleaning up old versions of RDASApp or something happens to it while recompiling. If that happens you might end up using more time to recompile and copy the staged data. You can also use the same data directory with a new version of the code and just modify where the executables are and such in the script. I guess my thinking was to keep it completely untethered from a specific RDASApp install since the data is reusable and you can just point the run script to a new install manually. I’m probably just being overly picky here, but I just prefer having a copy instead of a link hahaha. I also think a user might only have at the very most a handful of these data directories for their experiments and at 18GB per that is really not an issue. Fv3-cam scratch2 has like 45TB of free space currently