### PR TITLE
Adding ctest for LETKF in MPAS-JEDI

### DIFF
--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -79,11 +79,13 @@ if (CLONE_RRFSDATA)
       #       Also need to add the associated executable to the rrfs_fv3jedi_exes list below 
       list( APPEND rrfs_mpasjedi_tests
              rrfs_mpasjedi_2022052619_Ens3Dvar
+             rrfs_mpasjedi_2022052619_letkf
           )
 
       # JEDI executables for each test case above
       list ( APPEND rrfs_mpasjedi_exes
              mpasjedi_variational.x
+             mpasjedi_enkf.x
       )
 
       foreach(case IN LISTS rrfs_mpasjedi_tests)

--- a/rrfs-test/testinput/rrfs_fv3jedi_letkf_2022052619.yaml
+++ b/rrfs-test/testinput/rrfs_fv3jedi_letkf_2022052619.yaml
@@ -161,4 +161,9 @@ output: # for outputting mean posterior
   datapath: ./
   prefix: letkf-meanposterior-fv3_lam-C775
 
+test:
+  reference filename: Data/testinput/rrfs-fv3jedi-letkf.ref
+  test output filename: ./rrfs-fv3jedi-letkf.out
+  float relative tolerance: 1.0e-3
+  float absolute tolerance: 1.0e-6
 

--- a/rrfs-test/testinput/rrfs_mpasjedi_2022052619_Ens3Dvar.yaml
+++ b/rrfs-test/testinput/rrfs_mpasjedi_2022052619_Ens3Dvar.yaml
@@ -175,7 +175,7 @@ cost function:
        monitoring only: true
 test:
   reference filename: Data/testinput/rrfs-mpasjedi-ens3dvar.ref
-  test output filename: ./rrfs-fv3jedi-ens3dvar.out
+  test output filename: ./rrfs-mpasjedi-ens3dvar.out
   float relative tolerance: 1.0e-3
   float absolute tolerance: 1.0e-6
 

--- a/rrfs-test/testinput/rrfs_mpasjedi_2022052619_letkf.yaml
+++ b/rrfs-test/testinput/rrfs_mpasjedi_2022052619_letkf.yaml
@@ -1,0 +1,163 @@
+_hor obs localization: &HorizObsLoc
+   localization method: Horizontal Gaspari-Cohn
+   lengthscale: 1000e3
+
+_conventional vertical localization: &HeightVertObsLoc
+   localization method: Vertical localization
+   vertical lengthscale: 6000
+   ioda vertical coordinate: height
+   ioda vertical coordinate group: MetaData
+   localization function: Gaspari Cohn
+
+
+geometry:
+  nml_file: ./namelist.atmosphere_15km
+  streams_file: ./streams.atmosphere_15km
+  deallocate non-da fields: true
+  interpolation type: unstructured
+  iterator dimension: 3 
+
+increment variables: [temperature, spechum, uReconstructZonal, uReconstructMeridional, surface_pressure]
+
+background: 
+   members from template: 
+      template:
+         date: '2022-05-26T19:00:00Z'
+         state variables: [spechum,surface_pressure,temperature,uReconstructMeridional,uReconstructZonal,theta,rho,u,qv,pressure,landmask,xice,snowc,skintemp,ivgtyp,isltyp,snowh,vegfra,u10,v10,lai,smois,tslb,pressure_p,qc,qi,qg,qr,qs,cldfrac]
+         stream_name: background
+         filename: ./Data/inputs/%iMember%/restart.nc
+      pattern: '%iMember%'
+      start: 1 
+      zero padding: 1
+      nmembers: 5 
+
+observations:
+     observers:
+     - obs space:
+         name: Aircraft
+         distribution:
+           name: Halo
+           halo size: 5.0e6
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: Data/obs/rass_tsen_obs_2022052619.nc4
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: ./rass_tsen_obs_2022052619_hofx.nc4
+         simulated variables: [airTemperature]
+         observed variables: [airTemperature]
+       obs operator:
+         name: VertInterp
+       obs error:
+         covariance model: diagonal
+       obs localizations: 
+         - <<: *HorizObsLoc
+         - <<: *HeightVertObsLoc
+       obs filters:
+       - filter: Bounds Check
+         filter variables:
+         - name: airTemperature@GsiUseFlag 
+         minvalue: 0.5 
+         maxvalue: 1.5 
+         action:
+            name: accept 
+
+     - obs space:
+         name: sonde  
+         distribution:
+           name: Halo
+           halo size: 5.0e6
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: Data/obs/sondes_tsen_obs_2022052619.nc4
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: ./rass_tsen_obs_2022052619_hofx.nc4
+         simulated variables: [airTemperature]
+         observed variables: [airTemperature]
+       obs operator:
+         name: VertInterp
+       obs error:
+         covariance model: diagonal
+       obs localizations: 
+         - <<: *HorizObsLoc
+         - <<: *HeightVertObsLoc
+       obs filters:
+       - filter: Bounds Check
+         filter variables:
+         - name: airTemperature@GsiUseFlag 
+         minvalue: 0.5 
+         maxvalue: 1.5 
+         action:
+            name: accept 
+
+
+     - obs space:
+         name: sonde
+         distribution:
+           name: Halo
+           halo size: 5.0e6
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: Data/obs/sondes_uv_obs_2022052619.nc4
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: ./sonde_uv_obs_2022052619_hofx.nc4
+         simulated variables: [windEastward, windNorthward]
+       obs operator:
+         name: VertInterp
+         vertical coordinate: air_pressure
+         observation vertical coordinate: pressure
+         interpolation method: log-linear
+       obs error:
+         covariance model: diagonal ufo
+       obs localizations: 
+         - <<: *HorizObsLoc
+         - <<: *HeightVertObsLoc
+       obs filters:
+       - filter: PreQC
+         maxvalue: 3
+       - filter: Background Check
+         filter variables:
+         - name: windEastward
+         - name: windNorthward
+         threshold: 6.0
+       monitoring only: true
+
+
+driver:
+  save posterior ensemble: false
+  save prior mean: true
+  save posterior mean: true
+
+time window:
+       begin: 2022-05-26T18:00:00Z
+       length: PT2H
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.95
+    rtpp: 0.6
+    mult: 1.1
+
+output mean prior:
+  filename: ./bg.$Y-$M-$D_$h.$m.$s.nc
+  stream name: background
+
+output: # for outputting mean posterior
+  filename: ./an.$Y-$M-$D_$h.$m.$s.nc
+  stream name: analysis 
+
+test:
+  reference filename: Data/testinput/rrfs-mpasjedi-letkf.ref
+  test output filename: ./rrfs-mpasjedi-letkf.out
+  float relative tolerance: 1.0e-3
+  float absolute tolerance: 1.0e-6
+

--- a/rrfs-test/ush/mpasjedi_increment_fulldom.py
+++ b/rrfs-test/ush/mpasjedi_increment_fulldom.py
@@ -1,0 +1,159 @@
+from netCDF4 import Dataset
+import pdb
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import cartopy.geodesic
+import cartopy
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+import matplotlib.ticker as mticker
+import numpy as np
+import colormap
+import time
+import sys, os
+import shapely.geometry
+import warnings
+from scipy.spatial.distance import cdist
+
+warnings.filterwarnings('ignore')
+
+############ USER INPUT ##########################################################
+plot_var = "Increment"
+lev = 9                # 1=sfc, 60=toa
+clevmax_incr = 2.0     # max contour level for colorbar increment plots
+decimals = 4            # number of decimals to round for text boxes
+plot_box_width = 75.     # define size of plot domain (units: lat/lon degrees)
+plot_box_height = 30
+
+variable = "airTemperature"
+if variable == "airTemperature":
+    obtype = 't'
+    offset = -273.15
+
+# JEDI data
+datapath = "./"
+jstatic      = "./Data_static/static.93175.nc"                         # to load the MPAS lat/lon
+
+# FOR LETKF 
+janalysis   = "./an.2022-05-26_19.00.00.nc"            # analysis file
+jbackgrnd   = "./bg.2022-05-26_19.00.00.nc"            # background file
+
+# FOR HYBRID (or ENVAR)
+#janalysis   = "./an.2022-05-26_19.00.00.nc"            # analysis file
+#jbackgrnd   = "./Data/bkg/bg.2022-05-26_19.00.00.nc"            # background file
+
+
+###################################################################################
+# Set cartopy shapefile path
+platform = os.getenv('HOSTNAME').upper()
+if 'ORION' in platform:
+        cartopy.config['data_dir']='/work/noaa/fv3-cam/sdegelia/cartopy'
+elif 'H' in platform: # Will need to improve this once Hercules is supported
+        cartopy.config['data_dir']='/home/Donald.E.Lippi/cartopy'
+
+f_latlon = Dataset(jstatic, "r")
+lats = np.array( f_latlon.variables['latCell'][:] ) * 180.0 / np.pi
+lons0 = np.array( f_latlon.variables['lonCell'][:] ) * 180.0 / np.pi
+lons = np.where(lons0>180.0,lons0-360.0,lons0)
+
+# Open NETCDF4 dataset for reading
+nc_a = Dataset(janalysis, mode='r')
+nc_b = Dataset(jbackgrnd, mode='r')
+
+# Read data and get dimensions
+jedi_a = nc_a.variables["theta"][0,:,lev].astype(np.float64)
+jedi_b = nc_b.variables["theta"][0,:,lev].astype(np.float64)
+
+# Convert to temperature
+if variable == "airTemperature":
+	pres_a = (nc_a.variables['pressure_p'][0,:,lev] + nc_b['pressure_base'][0,:,lev])/100.0
+	pres_b = (nc_b.variables['pressure_p'][0,:,lev] + nc_b['pressure_base'][0,:,lev])/100.0
+	dividend_a = (1000.0/pres_a)**(0.286)
+	dividend_b = (1000.0/pres_b)**(0.286)
+	jedi_a = jedi_a / dividend_a
+	jedi_b = jedi_b / dividend_b
+
+# compute increment
+jedi_inc = jedi_a - jedi_b
+
+if plot_var == "Increment":
+    title1 = "JEDI"
+    jedi = jedi_inc
+    clevmax = clevmax_incr
+
+# CREATE PLOT ##############################
+fig = plt.figure(figsize=(7,4))
+m1 = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree(central_longitude=0))
+
+# Determine extent for plot domain
+cen_lat = 35.5
+cen_lon = -99.0
+half = plot_box_width / 2.
+left = cen_lon - half
+right = cen_lon + half
+half = plot_box_height / 2.
+bot = cen_lat - half
+top = cen_lat + half
+
+# Set extent for both plots
+m1.set_extent([left, right, top, bot])
+
+# Add features to the subplots
+#m1.add_feature(cfeature.GSHHSFeature(scale='low'))
+m1.add_feature(cfeature.COASTLINE)
+m1.add_feature(cfeature.BORDERS)
+m1.add_feature(cfeature.STATES)
+#m.add_feature(cfeature.OCEAN)
+#m.add_feature(cfeature.LAND)
+#m.add_feature(cfeature.LAKES)
+
+# Gridlines for the subplots
+gl1 = m1.gridlines(crs = ccrs.PlateCarree(), draw_labels = True, linewidth = 0.5, color = 'k', alpha = 0.25, linestyle = '-')
+gl1.xlocator = mticker.FixedLocator([])
+gl1.xlocator = mticker.FixedLocator(np.arange(-180., 181., 5.))
+gl1.ylocator = mticker.FixedLocator(np.arange(-80., 91., 5.))
+gl1.xformatter = LONGITUDE_FORMATTER
+gl1.yformatter = LATITUDE_FORMATTER
+gl1.xlabel_style = {'size': 5, 'color': 'gray'}
+gl1.ylabel_style = {'size': 5, 'color': 'gray'}
+
+
+def plot_T_inc(var_n, clevmax):
+    """Temperature increment/diff [K]"""
+    longname = "airTemperature"
+    units="K"
+    inc = 0.05*clevmax
+    clevs = np.arange(-1.0*clevmax, 1.0*clevmax+inc, inc)
+    cm = colormap.diff_colormap(clevs)
+    return(clevs, cm, units, longname)
+
+# Plot the data
+if variable == "airTemperature":
+    clevs, cm, units, longname = plot_T_inc(jedi_inc, clevmax)
+
+units="K"
+#c1 = m1.contourf(lons, lats, jedi, clevs, cmap = cm)
+c1 = plt.tricontourf(lons, lats, jedi, clevs, cmap = cm, extend='both')
+
+# Add colorbar
+cbar1 = fig.colorbar(c1, orientation="horizontal", fraction=0.046, pad=0.07)
+cbar1.set_label(units, size=8)
+cbar1.ax.tick_params(labelsize=5, rotation=30)
+
+# Add titles, text, and save the figure
+#plt.suptitle(f"Temperature {plot_var} at Level: {lev+1}\nobtype: {longname}", fontsize = 9, y = 1.05)
+#m1.set_title(f"{title1}", fontsize = 9, y = 0.98)
+#subtitle1_minmax = f"min: {np.around(np.min(jedi), decimals)}\nmax: {np.around(np.max(jedi), decimals)}"
+#m1.text(left, top, f"{subtitle1_minmax}", fontsize = 6, ha='left', va='bottom')
+#m1.text(left, bot, f"{subtitle1_hofx}", fontsize = 6, ha='left', va='bottom')
+if plot_var == "Increment":
+    plt.tight_layout()
+    plt.savefig(f"./increment_{variable}.png", dpi=250, bbox_inches='tight')
+
+# Print some final stats
+print(f"Stats:")
+print(f" {title1} max: {np.around(np.max(jedi), decimals)}")
+print(f" {title1} min: {np.around(np.min(jedi), decimals)}")


### PR DESCRIPTION
Discussion in issue #39 demonstrates that the LETKF for MPAS-JEDI is working as expected, so this PR is meant to go ahead and add that yaml file. I also updated `RDASApp/rrfs-test/CMakeLists.txt` to add the ctest and added the python script `RDASApp/rrfs-test/ush/mpasjedi_increment_fulldom.py` for plotting the output from this case. I note that the changes to `CMakeLists.txt` serve as an example of how to add a new ctest. 

There are also a couple minor modifications to: 
1. Add test references for the FV3-JEDI LETKF case (`rrfs_fv3jedi_letkf_2022052619.yaml`)
2. Clean up the name for the reference output in the MPAS-JEDI EnVar case (`rrfs_mpasjedi_2022052619_Ens3Dvar.yaml`)

All four of the current ctests for RDASApp should now have references included, and these reference files are included in the staged data on both Hera and Orion. 