### PR TITLE
Fixes the minimization algorithm for the hybrid fv3-jedi case

### DIFF
--- a/rrfs-test/testinput/rrfs_fv3jedi_hyb_2022052619.yaml
+++ b/rrfs-test/testinput/rrfs_fv3jedi_hyb_2022052619.yaml
@@ -177,7 +177,7 @@ cost function:
 
 variational:
   minimizer:
-    algorithm: DRIPCG
+    algorithm: DRPCG
   iterations:
   - ninner: 5
     gradient norm reduction: 1e-60


### PR DESCRIPTION
This PR is a quick bug fix to change the minimization algorithm for the hybrid fv3-jedi case in `RDASApp/rrfs-test/testinput/rrfs_fv3jedi_hyb_2022052619.yaml` to DRPCG. We want to ensure that none of our example yamls are using DRIPCG. All of the other yamls in rrfs-test use DRPCG. 