### PR TITLE
Feature/atms

### DIFF
--- a/modulefiles/RDAS/hera.intel.lua
+++ b/modulefiles/RDAS/hera.intel.lua
@@ -86,7 +86,8 @@ setenv('MPIEXEC_NPROC', mpinproc)
 setenv("CRTM_FIX","/scratch1/NCEPDEV/da/Cory.R.Martin/RDASApp/fix/crtm/2.4.0")
 setenv("RDASAPP_TESTDATA","/scratch1/NCEPDEV/da/Cory.R.Martin/CI/RDASApp/data")
 --setenv("RDAS_RRFS_DATA_ROOT","/scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-emc-rdas/")
-setenv("RDAS_RRFS_DATA_ROOT", "/scratch1/NCEPDEV/da/Samuel.Degelia/RRFS")
+--setenv("RDAS_RRFS_DATA_ROOT", "/scratch1/NCEPDEV/da/Samuel.Degelia/RRFS")
+setenv("RDAS_RRFS_DATA_ROOT", "/scratch1/NCEPDEV/da/Xiaoyan.Zhang/RRFS")
 
 --prepend_path("PATH","/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/intel-18.0.5.274/prod_util/1.2.2/bin")
 

--- a/modulefiles/RDAS/hera.intel.lua
+++ b/modulefiles/RDAS/hera.intel.lua
@@ -86,8 +86,8 @@ setenv('MPIEXEC_NPROC', mpinproc)
 setenv("CRTM_FIX","/scratch1/NCEPDEV/da/Cory.R.Martin/RDASApp/fix/crtm/2.4.0")
 setenv("RDASAPP_TESTDATA","/scratch1/NCEPDEV/da/Cory.R.Martin/CI/RDASApp/data")
 --setenv("RDAS_RRFS_DATA_ROOT","/scratch2/NCEPDEV/fv3-cam/Ting.Lei/dr-emc-rdas/")
---setenv("RDAS_RRFS_DATA_ROOT", "/scratch1/NCEPDEV/da/Samuel.Degelia/RRFS")
-setenv("RDAS_RRFS_DATA_ROOT", "/scratch1/NCEPDEV/da/Xiaoyan.Zhang/RRFS")
+--setenv("RDAS_RRFS_DATA_ROOT", "/scratch1/NCEPDEV/da/Xiaoyan.Zhang/RRFS")
+setenv("RDAS_RRFS_DATA_ROOT", "/scratch1/NCEPDEV/da/Samuel.Degelia/RRFS")
 
 --prepend_path("PATH","/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/intel-18.0.5.274/prod_util/1.2.2/bin")
 

--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -80,12 +80,14 @@ if (CLONE_RRFSDATA)
       list( APPEND rrfs_mpasjedi_tests
              rrfs_mpasjedi_2022052619_Ens3Dvar
              rrfs_mpasjedi_2022052619_letkf
+             rrfs_mpasjedi_2022052619_atms_npp_qc
           )
 
       # JEDI executables for each test case above
       list ( APPEND rrfs_mpasjedi_exes
              mpasjedi_variational.x
              mpasjedi_enkf.x
+             mpasjedi_variational.x
       )
 
       foreach(case IN LISTS rrfs_mpasjedi_tests)

--- a/rrfs-test/testinput/rrfs_mpasjedi_2022052619_atms_npp_qc.yaml
+++ b/rrfs-test/testinput/rrfs_mpasjedi_2022052619_atms_npp_qc.yaml
@@ -723,4 +723,8 @@ cost function:
            - name: reject
 
 
-
+test:
+  reference filename: Data/testinput/rrfs-mpasjedi-atms_npp.ref
+  test output filename: ./rrfs-mpasjedi-atms_npp.out
+  float relative tolerance: 1.0e-3
+  float absolute tolerance: 1.0e-6

--- a/rrfs-test/testinput/rrfs_mpasjedi_2022052619_atms_npp_qc.yaml
+++ b/rrfs-test/testinput/rrfs_mpasjedi_2022052619_atms_npp_qc.yaml
@@ -1,0 +1,726 @@
+
+# application-agnostic anchors that specify observation errors
+# applicable to Variational, HofX3D
+
+# reusable latitude bands for all observation types
+_conventional obs localizations: &heightAndHorizObsLoc
+  _blank: null
+
+_nonconventional obs localizations: &horizObsLoc
+  _blank: null
+
+_obs space: &ObsSpace
+  obs perturbations seed: 1
+  io pool:
+    max pool size: 10
+  distribution:
+    name: RoundRobin
+
+_obs error diagonal: &ObsErrorDiagonal
+  covariance model: diagonal
+  # Note: the same 'obs perturbations seed' must be used for all members for the 'zero-mean perturbations' option to work
+  zero-mean perturbations: true
+  member: 1
+  number of members: 1
+
+_get values: &GetValues
+  nnearest: 3
+
+_multi iteration filter: &multiIterationFilter
+  apply at iterations: 0,1,2,3,4,5
+# ObsAnchors and ObsErrorAnchors are automatically prepended above this line
+_iteration: &iterationConfig
+  geometry:
+    nml_file: ./namelist.atmosphere_15km
+    streams_file: ./streams.atmosphere_15km
+    deallocate non-da fields: true
+    interpolation type: unstructured
+  gradient norm reduction: 1e-3
+_member: &memberConfig
+  date: &analysisDate '2022-05-26T19:00:00Z'
+  state variables: &incvars [spechum,surface_pressure,temperature,uReconstructMeridional,uReconstructZonal]
+  stream name: ensemble
+
+output:
+  filename: ./an.$Y-$M-$D_$h.$m.$s.nc
+  stream name: analysis
+variational:
+  minimizer:
+    algorithm: DRPCG
+  iterations:
+  - <<: *iterationConfig
+    diagnostics:
+      departures: ombg
+    ninner: 50
+  - <<: *iterationConfig
+    ninner: 50
+final:
+  diagnostics:
+    departures: oman
+cost function:
+  cost type: 3D-Var
+  time window:
+     begin: '2022-05-26T18:00:00Z'
+     length: PT2H
+  jb evaluation: false
+  geometry:
+    nml_file: ./namelist.atmosphere_15km
+    streams_file: ./streams.atmosphere_15km
+    deallocate non-da fields: true
+    interpolation type: unstructured
+  analysis variables: *incvars 
+  background:
+    state variables: [spechum,surface_pressure,temperature,uReconstructMeridional,uReconstructZonal,theta,rho,u,qv,pressure,landmask,xice,snowc,skintemp,ivgtyp,isltyp,snowh,vegfra,u10,v10,lai,smois,tslb,pressure_p,qc,qi,qg,qr,qs,cldfrac]
+    filename: Data/bkg/bg.2022-05-26_19.00.00.nc
+    date: *analysisDate 
+  background error:
+    covariance model: ensemble
+    localization:
+      localization method: SABER
+      saber central block:
+        saber block name: BUMP_NICAS
+        active variables: *incvars
+        read:
+          io:
+            data directory: DataFix/bump_new
+            files prefix: bumploc_1000km6km 
+          drivers:
+            multivariate strategy: duplicated
+            read local nicas: true
+          model:
+            level for 2d variables: last
+    members from template:
+      template:
+        <<: *memberConfig
+        filename: ./Data/inputs/%iMember%/restart.nc
+      pattern: %iMember%
+      start: 1
+      zero padding: 1 
+      nmembers: 5 
+  observations:
+     observers:
+     - obs space:
+         name: Aircraft
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: Data/obs/rass_tsen_obs_2022052619.nc4
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: Data/hofx/rass_tsen_obs_2022052619.nc4
+         simulated variables: [airTemperature]
+         observed variables: [airTemperature]
+       obs operator:
+         name: VertInterp
+       obs error:
+         covariance model: diagonal
+       obs filters:
+       - filter: Bounds Check
+         filter variables:
+         - name: airTemperature@GsiUseFlag 
+         minvalue: 0.5 
+         maxvalue: 1.5 
+         action:
+            name: accept 
+
+     - obs space:
+         name: sonde  
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: Data/obs/sondes_tsen_obs_2022052619.nc4
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: Data/hofx/rass_tsen_obs_2022052619.nc4
+         simulated variables: [airTemperature]
+         observed variables: [airTemperature]
+       obs operator:
+         name: VertInterp
+       obs error:
+         covariance model: diagonal
+       obs filters:
+       - filter: Bounds Check
+         filter variables:
+         - name: airTemperature@GsiUseFlag 
+         minvalue: 0.5 
+         maxvalue: 1.5 
+         action:
+            name: accept 
+
+
+     - obs space:
+         name: sonde
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: Data/obs/sondes_uv_obs_2022052619.nc4
+         simulated variables: [windEastward, windNorthward]
+       obs operator:
+         name: VertInterp
+         vertical coordinate: air_pressure
+         observation vertical coordinate: pressure
+         interpolation method: log-linear
+       obs error:
+         covariance model: diagonal ufo
+       obs filters:
+       - filter: PreQC
+         maxvalue: 3
+       - filter: Background Check
+         filter variables:
+         - name: windEastward
+         - name: windNorthward
+         threshold: 6.0
+       monitoring only: true
+
+     - obs space:
+         name: atms_npp
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: Data/obs/atms_npp_obs_2022052619.nc
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: Data/hofx/rass_atms_obs_2022052619.nc4
+         simulated variables: [brightnessTemperature]
+         observed variables: [brightnessTemperature]
+         channels: &atms_npp_channels 1-22
+       obs operator:
+           name: CRTM
+           Absorbers: [H2O,O3]
+           SurfaceWindGeoVars: uv
+           obs options:
+             Sensor_ID: atms_npp
+             EndianType: little_endian
+             CoefficientPath: Data/crtm_2.4.0/
+             IRVISlandCoeff: IGBP
+           linear obs operator:
+             Absorbers: [H2O, O3]
+
+       obs pre filters:
+       # Step 0-A: Create Diagnostic Flags
+       - filter: Create Diagnostic Flags
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         flags:
+         - name: ScanEdgeRemoval
+           initial value: false
+           force reinitialization: false
+         - name: Thinning
+           initial value: false
+           force reinitialization: false
+         - name: CLWRetrievalCheck
+           initial value: false
+           force reinitialization: false
+         - name: WindowChannelExtremeResidual
+           initial value: false
+           force reinitialization: false
+         - name: HydrometeorCheck
+           initial value: false
+           force reinitialization: false
+         - name: GrossCheck
+           initial value: false
+           force reinitialization: false
+         - name: InterChannelConsistency
+           initial value: false
+           force reinitialization: false
+         - name: UseflagCheck
+           initial value: false
+           force reinitialization: false
+
+       obs post filters:
+       # Step 0-B: Calculate derived variables
+       # Calculate CLW retrieved from observation
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWRetFromObs@DerivedMetaData
+           type: float
+           function:
+             name: CLWRetMW@ObsFunction
+             options:
+               clwret_ch238: 1
+               clwret_ch314: 2
+               clwret_types: [ObsValue]
+
+       # Calculate CLW retrieved from observation
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWRetFromBkg@DerivedMetaData
+           type: float
+           function:
+             name: CLWRetMW@ObsFunction
+             options:
+               clwret_ch238: 1
+               clwret_ch314: 2
+               clwret_types: [HofX]
+
+       # Calculate symmetric retrieved CLW
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWRetSymmetric@DerivedMetaData
+           type: float
+           value: 1000.0
+
+       - filter: Variable Assignment
+         where:
+         - variable:
+             name: CLWRetFromObs@DerivedMetaData
+           minvalue:   0.
+           maxvalue: 999.
+         - variable:
+             name: CLWRetFromBkg@DerivedMetaData
+           minvalue:   0.
+           maxvalue: 999.
+         where operator: and
+         assignments:
+         - name: CLWRetSymmetric@DerivedMetaData
+           type: float
+           function:
+             name: Arithmetic@ObsFunction
+             options:
+               variables:
+               - name: CLWRetFromObs@DerivedMetaData
+               - name: CLWRetFromBkg@DerivedMetaData
+               total coefficient: 0.5
+
+       # Calculate scattering index from observation
+       - filter: Variable Assignment
+         assignments:
+         - name: SIRetFromObs@DerivedMetaData
+           type: float
+           function:
+             name: SCATRetMW@ObsFunction
+             options:
+               scatret_ch238: 1
+               scatret_ch314: 2
+               scatret_ch890: 16
+               scatret_types: [ObsValue]
+
+       # Calculate CLW obs/bkg match index
+       - filter: Variable Assignment
+         assignments:
+         - name: CLWMatchIndex@DerivedMetaData
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: CLWMatchIndexMW@ObsFunction
+             channels: *atms_npp_channels
+             options:
+               channels: *atms_npp_channels
+               clwobs_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               clwbkg_function:
+                 name: CLWRetFromBkg@DerivedMetaData
+               clwret_clearsky: [ 0.030,  0.030,  0.030,  0.020,  0.030,
+                                  0.080,  0.150,  0.000,  0.000,  0.000,
+                                  0.000,  0.000,  0.000,  0.000,  0.000,
+                                  0.020,  0.030,  0.030,  0.030,  0.030,
+                                  0.050,  0.100]
+       # Calculate symmetric observation error
+       - filter: Variable Assignment
+         assignments:
+         - name: InitialObsError@DerivedMetaData
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: ObsErrorModelRamp@ObsFunction
+             channels: *atms_npp_channels
+             options:
+               channels: *atms_npp_channels
+               xvar:
+                 name: CLWRetSymmetric@DerivedMetaData
+               x0:    [ 0.030,  0.030,  0.030,  0.020,  0.030,
+                        0.080,  0.150,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.000,
+                        0.020,  0.030,  0.030,  0.030,  0.030,
+                        0.050,  0.100]
+               x1:    [ 0.350,  0.380,  0.400,  0.450,  0.500,
+                        1.000,  1.000,  0.000,  0.000,  0.000,
+                        0.000,  0.000,  0.000,  0.000,  0.000,
+                        0.350,  0.500,  0.500,  0.500,  0.500,
+                        0.500,  0.500]
+               err0:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
+                        0.300,  0.300,  0.400,  0.400,  0.400,
+                        0.450,  0.450,  0.550,  0.800,  4.000,
+                        4.000,  4.000,  3.500,  3.000,  3.000,
+                        3.000,  3.000]
+               err1:  [20.000, 25.000, 12.000,  7.000,  3.500,
+                        3.000,  0.800,  0.400,  0.400,  0.400,
+                        0.450,  0.450,  0.550,  0.800,  4.000,
+                       19.000, 30.000, 25.000, 16.500, 12.000,
+                        9.000,  6.500]
+
+       # Calculate Innovation@DerivedMetaData
+       - filter: Variable Assignment
+         assignments:
+         - name: Innovation@DerivedMetaData
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: ObsFunction/Arithmetic
+             channels: *atms_npp_channels
+             options:
+               variables:
+               - name: brightnessTemperature@ObsValue
+                 channels: *atms_npp_channels
+               - name: brightnessTemperature@HofX
+                 channels: *atms_npp_channels
+               coefs: [1, -1]
+
+       - filter: Bounds Check
+         filter variables:
+         #- name: brightnessTemperature
+         - name: HofX/brightnessTemperature
+           channels: *atms_npp_channels
+         minvalue: 50.00001
+         maxvalue: 449.99999
+         action:
+           name: reject
+
+       # Regional Domain Check
+       - filter: Bounds Check
+         fileter variables:
+         - name: brightnessTemperature
+         test variables:
+         - name: LAMDomainCheck@ObsFunction
+           options: 
+             map_projection: circle
+             save: true
+             cenlat: 38.5 
+             cenlon: -97.5
+             #radius: 1700000
+             radius: 1700
+         minvalue: 1.0
+
+       # Step 0-C: Assign Initial All-Sky Observation Error
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         action:
+           name: assign error
+           error function:
+             name: InitialObsError@DerivedMetaData
+             channels: *atms_npp_channels
+
+
+       # Step 1: Remove Observations from the Edge of the Scan
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-22
+         where:
+         - variable:
+             name: MetaData/sensorScanPosition
+           is_in: 7-90
+         actions:
+           - name: set
+             flag: ScanEdgeRemoval
+           - name: reject
+
+       # Step 2: Data Thinning
+       - filter: Gaussian Thinning
+         horizontal_mesh: 145
+         use_reduced_horizontal_grid: true
+         distance_norm: geodesic
+       #  round_horizontal_bin_count_to_nearest: true
+       #  partition_longitude_bins_using_mesh: true
+         actions:
+           - name: set
+             flag: Thinning
+           - name: reject
+
+       # Step 3A: CLW Retrieval Check (observation_based)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16-22
+         test variables:
+         - name: CLWRetFromObs@DerivedMetaData
+         maxvalue: 999.0
+         actions:
+           - name: set
+             flag: CLWRetrievalCheck
+           - name: reject
+
+       # Step 3B: CLW Retrieval Check (background_based)
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16-22
+         test variables:
+         - name: CLWRetFromBkg@DerivedMetaData
+         maxvalue: 999.0
+         actions:
+           - name: set
+             flag: CLWRetrievalCheck
+           - name: reject
+
+       # Step 4: Window Channel Sanity Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: 1-7, 16, 17-22
+         test variables:
+         - name: Innovation@DerivedMetaData
+           channels: 1, 2, 5-7, 16
+         maxvalue: 200.0
+         minvalue: -200.0
+         flag all filter variables if any test variable is out of bounds: true
+         actions:
+           - name: set
+             flag: WindowChannelExtremeResidual
+           - name: reject
+
+       # Step 5: Hydrometeor Check (cloud/precipitation affected chanels)
+       - filter: Variable Assignment
+         assignments:
+         - name: DerivedMetaData/HydrometeorCheckATMS
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: HydrometeorCheckATMS@ObsFunction
+             channels: *atms_npp_channels
+             options:
+               channels: *atms_npp_channels
+               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
+                                   0.300,  0.300,  0.400,  0.400,  0.400,
+                                   0.450,  0.450,  0.550,  0.800,  4.000,
+                                   4.000,  4.000,  3.500,  3.000,  3.000,
+                                   3.000,  3.000]
+               clwret_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_npp_channels
+
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         test variables:
+         - name: DerivedMetaData/HydrometeorCheckATMS
+           channels: *atms_npp_channels
+         maxvalue: 0.0
+         actions:
+           - name: set
+             flag: HydrometeorCheck
+             ignore: rejected observations
+           - name: reject
+
+       # Step 6: Observation Error Inflation based on Topography Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorTopo@DerivedMetaData
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: ObsErrorFactorTopoRad@ObsFunction
+             channels: *atms_npp_channels
+             options:
+               sensor: atms_npp
+               channels: *atms_npp_channels
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorTopo@DerivedMetaData
+             channels: *atms_npp_channels
+
+       # Step 7: Obs Error Inflation based on TOA Transmittancec Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorTransmitTop@DerivedMetaData
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: ObsErrorFactorTransmitTopRad@ObsFunction
+             channels: *atms_npp_channels
+             options:
+               channels: *atms_npp_channels
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorTransmitTop@DerivedMetaData
+             channels: *atms_npp_channels
+
+       # Step 8: Observation Error Inflation based on Surface Jacobian Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorSurfJacobian@DerivedMetaData
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: ObsErrorFactorSurfJacobianRad@ObsFunction
+             channels: *atms_npp_channels
+             options:
+               sensor: atms_npp
+               channels: *atms_npp_channels
+               obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+               obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorSurfJacobian@DerivedMetaData
+             channels: *atms_npp_channels
+
+       # Step 9: Situation Dependent Check
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorSituDepend@DerivedMetaData
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: ObsErrorFactorSituDependMW@ObsFunction
+             channels: *atms_npp_channels
+             options:
+               sensor: atms_npp
+               channels: *atms_npp_channels
+               clwbkg_function:
+                 name: CLWRetFromBkg@DerivedMetaData
+               clwobs_function:
+                 name: CLWRetFromObs@DerivedMetaData
+               scatobs_function:
+                 name: SIRetFromObs@DerivedMetaData
+               clwmatchidx_function:
+                 name: CLWMatchIndex@DerivedMetaData
+                 channels: *atms_npp_channels
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_npp_channels
+               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
+                                   0.300,  0.300,  0.400,  0.400,  0.400,
+                                   0.450,  0.450,  0.550,  0.800,  4.000,
+                                   4.000,  4.000,  3.500,  3.000,  3.000,
+                                   3.000,  3.000]
+
+       - filter: Perform Action
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorSituDepend@DerivedMetaData
+             channels: *atms_npp_channels
+ 
+       # Step 10: Gross check
+       # Remove data if abs(Obs-HofX) > absolute threhold
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorLat@DerivedMetaData
+           type: float
+           function:
+             name: ObsErrorFactorLatRad@ObsFunction
+             options:
+               latitude_parameters: [25.0, 0.25, 0.04, 3.0]
+
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorBound@DerivedMetaData
+           channels: *atms_npp_channels
+           type: float
+           function:
+             name: ObsErrorBoundMW@ObsFunction
+             channels: *atms_npp_channels
+             options:
+               sensor: atms_npp
+               channels: *atms_npp_channels
+               obserr_bound_latitude:
+                 name: ObsErrorFactorLat@DerivedMetaData
+               obserr_bound_transmittop:
+                 name: ObsErrorFactorTransmitTop@DerivedMetaData
+                 channels: *atms_npp_channels
+                 options:
+                   channels: *atms_npp_channels
+               obserr_bound_topo:
+                 name: ObsErrorFactorTopo@DerivedMetaData
+                 channels: *atms_npp_channels
+               obserr_function:
+                 name: InitialObsError@DerivedMetaData
+                 channels: *atms_npp_channels
+                 threhold: 3
+               obserr_bound_max: [4.5, 4.5, 3.0, 3.0, 1.0,
+                                  1.0, 1.0, 1.0, 1.0, 1.0,
+                                  1.0, 1.0, 1.0, 2.0, 4.5,
+                                  4.5, 2.0, 2.0, 2.0, 2.0,
+                                  2.0, 2.0]
+
+       - filter: Background Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         function absolute threshold:
+         - name: ObsErrorBound@DerivedMetaData
+           channels: *atms_npp_channels
+         actions:
+           - name: set
+             flag: GrossCheck
+             ignore: rejected observations
+           - name: reject
+
+       # Step 11: Inter-Channel Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         test variables:
+         - name: InterChannelConsistencyCheck@ObsFunction
+           channels: *atms_npp_channels
+           options:
+             channels: *atms_npp_channels
+             use passive_bc: true
+             sensor: atms_npp
+             use_flag: [ 1,  1,  1,  1,  1,
+                         1,  1,  1,  1,  1,
+                         1,  1,  1,  1,  4,
+                         1,  1,  1,  1,  1,
+                         1,  1]
+         maxvalue: 1.0e-12
+         actions:
+           - name: set
+             flag: InterChannelConsistency
+             ignore: rejected observations
+           - name: reject
+
+       # Step 12: Useflag Check
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *atms_npp_channels
+           options:
+             channels: *atms_npp_channels
+             use_flag: [ 1,  1,  1,  1,  1,
+                         1,  1,  1,  1,  1,
+                         1,  1,  1,  1,  4,
+                         1,  1,  1,  1,  1,
+                         1,  1]
+         minvalue: 1.0e-12
+         actions:
+           - name: set
+             flag: UseflagCheck
+             ignore: rejected observations
+           - name: reject
+
+
+


### PR DESCRIPTION
This PR add the YAML file of satellite radiance ATMS_NPP into rrfs_test for MPAS_JEDI. This is based on the issue #32 temporally resolved the boundary check. The YAML file included the basic information of ATMS NPP instrument information, CRTM, and quality control information. The YAML file is: RDASApp//rrfs-test/testinput/rrfs_mpasjedi_2022052619_atms_npp_qc.yaml.

**The ctest result on Hera**:
[Xiaoyan.Zhang@hfe08 rrfs-test]$ ctest
Test project /scratch2/NCEPDEV/fv3-cam/Xiaoyan.Zhang/noscrub/JEDI/RDASApp_atms/build/rr
    Start 1: rrfs_mpasjedi_2022052619_Ens3Dvar
1/3 Test #1: rrfs_mpasjedi_2022052619_Ens3Dvar ......   Passed   71.91 sec
    Start 2: rrfs_mpasjedi_2022052619_letkf
2/3 Test #2: rrfs_mpasjedi_2022052619_letkf .........   Passed   37.02 sec
    Start 3: rrfs_mpasjedi_2022052619_atms_npp_qc
3/3 Test #3: rrfs_mpasjedi_2022052619_atms_npp_qc ...   Passed   89.96 sec

100% tests passed, 0 tests failed out of 3

Label Time Summary:
mpi            = 198.89 sec*proc (3 tests)
rdas-bundle    = 198.89 sec*proc (3 tests)
script         = 198.89 sec*proc (3 tests)

Total Test time (real) = 199.18 sec
