### PR TITLE
Ioda-converters YAML for the LGYCLD BUFR data

### DIFF
--- a/rrfs-test/IODA/yaml/bufr_ncep_lgycld.yaml
+++ b/rrfs-test/IODA/yaml/bufr_ncep_lgycld.yaml
@@ -1,0 +1,121 @@
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./rap.t00z.lgycld.tm00.bufr_d"
+
+      exports:
+        variables:
+          # MetaData
+          timestamp:
+            datetime:
+              year: "*/YEAR"
+              month: "*/MNTH"
+              day: "*/DAYS"
+              hour: "*/HOUR"
+              minute: "*/MINU"
+              second: "*/SECO"
+          longitude:
+            query: "*/CLONH"
+            transforms:
+              - offset: 360.0
+          latitude:
+            query: "*/CLATH"
+          satelliteIdentifier:
+            query: "*/SAID"
+
+          # ObsValue - cloud, cloud ceiling, visibility, gust wind, min/max temperature, weather
+          # note: cloud ceiling is a derivative of HOCB, the height of cloud base
+          cloudPhase:
+            query: "*/CLDP"
+          heightOfBaseOfCloud:
+            query: "*/HOCB"
+          heightOfTopOfCloud:
+            query: "*/HOCT"
+          pressureAtBaseOfCloud:
+            query: "*/CDBP"
+          pressureAtTopOfCloud:
+            query: "*/CDTP"
+          equivalentBlackBodyTemperature:
+            query: "*/EBBTH"
+          liquidWaterPath:
+            query: "*/VILWC"
+
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./rap.t00z.lgycld.tm00.bufr_d.nc"
+
+      variables:
+        # MetaData
+        - name: "MetaData/dateTime"
+          coordinates: "longitude latitude"
+          source: variables/timestamp
+          longName: "Datetime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/latitude"
+          coordinates: "longitude latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          coordinates: "longitude latitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degree_east"
+          range: [0, 360]
+
+        - name: "MetaData/satelliteIdentifier"
+          coordinates: "longitude latitude"
+          source: variables/satelliteIdentifier
+          longName: "Satelliate Identifier"
+
+        # Observation - cloud
+        - name: "ObsValue/cloudPhase"
+          coordinates: "longitude latitude"
+          source: variables/cloudPhase
+          longName: "Cloud Phase"
+
+        - name: "ObsValue/heightOfBaseOfCloud"
+          coordinates: "longitude latitude"
+          source: variables/heightOfBaseOfCloud
+          longName: "Height of Base of Cloud"
+          units: "m" 
+
+        - name: "ObsValue/heightOfTopOfCloud"
+          coordinates: "longitude latitude"
+          source: variables/heightOfTopOfCloud
+          longName: "Height of Top of Cloud"
+          units: "m"
+
+        - name: "ObsValue/pressureAtBaseOfCloud"
+          coordinates: "longitude latitude"
+          source: variables/pressureAtBaseOfCloud
+          longName: "Pressure at Base of Cloud"
+          units: "Pa"
+
+        - name: "ObsValue/pressureAtTopOfCloud"
+          coordinates: "longitude latitude"
+          source: variables/pressureAtTopOfCloud
+          longName: "Pressure at Top of Cloud"
+          units: "Pa"
+
+        - name: "ObsValue/equivalentBlackBodyTemperature"
+          coordinates: "longitude latitude"
+          source: variables/equivalentBlackBodyTemperature
+          longName: "Equivalent Black Boday Temperature"
+          units: "K"
+
+        - name: "ObsValue/liquidWaterPath"
+          coordinates: "longitude latitude"
+          source: variables/liquidWaterPath
+          longName: "Vertically Integrated Liquid Water Content"
+          units: "kg m-2"


### PR DESCRIPTION
This PR adds an ioda-converters YAML for the  LGYCLD BUFR data. The following test date data was used for the validation 2022052700.

The following file(s) is new:
rrfs-test/IODA/yaml/bufr_ncep_lgycld.yaml

The validation for the output obs is performed in https://github.com/NOAA-EMC/RDASApp/issues/12.