### PR TITLE
add yaml rrfs_fv3jedi_bumploc_2022052619.yaml for creatiing bumploc 

### DIFF
--- a/rrfs-test/testinput/rrfs_fv3jedi_bumploc_2022052619.yaml
+++ b/rrfs-test/testinput/rrfs_fv3jedi_bumploc_2022052619.yaml
@@ -1,0 +1,86 @@
+geometry:
+ fms initialization:
+   namelist filename: DataFix/fmsmpp.nml
+   field table filename: DataFix/field_table
+ namelist filename: DataFix/input_lam_C775.nml
+ akbk: DataFix/fix/akbk61.nc
+ field metadata override: Data/fieldmetadata/tlei-gfs-restart.yaml
+ # input.nml
+ npz: 60
+ layout: [8,10]
+ io_layout: [1,1]
+ ntiles: 1 
+background:
+  datetime: 2022-05-26T19:00:00Z
+  filetype: fms restart
+  datapath: Data/bkg
+  filename_core: fv3_dynvars.nc
+  filename_trcr: fv3_tracer.nc
+  filename_sfcd: fv3_sfcdata.nc
+  filename_cplr: coupler.res
+  state variables: [air_temperature,surface_pressure] 
+background error:
+  covariance model: SABER
+  saber central block:
+    saber block name: BUMP_NICAS
+    calibration:
+      general:
+        universe length-scale: 250.0e3
+      io:
+        files prefix: Data/bump_new/fv3jedi_bumpparameters_nicas_lam_atm
+        alias:
+        - in code: air_temperature
+          in file: fixed_250km_0.3
+        - in code: surface_pressure
+          in file: fixed_250km
+
+      drivers:
+        multivariate strategy: univariate 
+        compute nicas: true
+        write local nicas: true
+      nicas:
+        resolution: 6
+        explicit length-scales: true
+        horizontal length-scale:
+        - groups:
+          - air_temperature
+          value: 250000.0
+        - groups:
+          - surface_pressure
+          value: 250000.0
+
+        vertical length-scale:
+        - groups:
+          - air_temperature
+          value: 0.3
+        - groups:
+          - surface_pressure
+          value: 0.0
+
+      grids:
+      - model:
+          variables:
+          - air_temperature
+      - model:
+          variables:
+          - surface_pressure
+      output model files:
+      - parameter: cor_rh
+        file:
+          filetype: fms restart
+          datapath: Data/bump_new/
+          filename_core: bumpparameters_nicas_lam_atm.cor_rh.fv_core.res.nc
+          filename_trcr: bumpparameters_nicas_lam_atm.cor_rh.fv_tracer.res.nc
+          filename_sfcd: bumpparameters_nicas_lam_atm.cor_rh.sfc_data.nc
+          filename_sfcw: bumpparameters_nicas_lam_atm.cor_rh.fv_srf_wnd.res.nc
+          filename_cplr: bumpparameters_nicas_lam_atm.cor_rh.coupler.res
+      - parameter: cor_rv
+        file:
+          filetype: fms restart
+          datapath: Data/bump_new/
+          filename_core: bumpparameters_nicas_lam_atm.cor_rv.fv_core.res.nc
+          filename_trcr: bumpparameters_nicas_lam_atm.cor_rv.fv_tracer.res.nc
+          filename_sfcd: bumpparameters_nicas_lam_atm.cor_rv.sfc_data.nc
+          filename_sfcw: bumpparameters_nicas_lam_atm.cor_rv.fv_srf_wnd.res.nc
+          filename_cplr: bumpparameters_nicas_lam_atm.cor_rv.coupler.res
+

--- a/rrfs-test/testinput/rrfs_mpasjedi_bumploc_2022052619.yaml
+++ b/rrfs-test/testinput/rrfs_mpasjedi_bumploc_2022052619.yaml
@@ -1,0 +1,40 @@
+_output config: &outputConfig
+  date: &validDate '2022-05-26T19:00:00Z'
+  stream name: control
+geometry:
+  nml_file: "./namelist.atmosphere_15km"
+  streams_file: "./streams.atmosphere_15km"
+  deallocate non-da fields: true
+  bump vunit: "height" # modellevel, height
+background:
+  state variables: &vars [spechum,surface_pressure,temperature,uReconstructMeridional,uReconstructZonal]
+  filename: "bg.2022-05-26_19.00.00.nc"
+  date: *validDate
+
+background error:
+  covariance model: SABER
+
+  saber central block:
+    saber block name: BUMP_NICAS
+    calibration:
+      io:
+        files prefix: bumploc_1000km6km
+
+      drivers:
+        multivariate strategy: duplicated
+        compute nicas: true
+        write local nicas: true
+        #write nicas grids: true
+        internal dirac test: false 
+      model:
+        level for 2d variables: last
+      nicas:
+        resolution: 8.0
+        explicit length-scales: true
+        horizontal length-scale:
+          - groups: [common]
+            value: 1000.0e3
+        vertical length-scale:
+          - groups: [common]
+            value: 6.0e3
+


### PR DESCRIPTION
Added the yaml : rrfs_fv3jedi_bumploc_2022052619.yaml, which was used to create bumploc files used in the corresponding fv3-jedi hybrid analysis case. 
