### PR TITLE
Ioda-converters YAML for the LGHTNG and MSONET BUFR DUMPs

### DIFF
--- a/rrfs-test/IODA/yaml/bufr_ncep_lghtng.yaml
+++ b/rrfs-test/IODA/yaml/bufr_ncep_lghtng.yaml
@@ -1,0 +1,94 @@
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./rap.t00z.lghtng.tm00.bufr_d"
+
+      exports:
+        variables:
+          # MetaData
+          timestamp:
+            datetime:
+              year: "*/YEAR"
+              month: "*/MNTH"
+              day: "*/DAYS"
+              hour: "*/HOUR"
+              minute: "*/MINU"
+              second: "*/SECO"
+          longitude:
+            query: "*/CLONH"
+          latitude:
+            query: "*/CLATH"
+          dataProviderRestricted:
+            query: "*/RSRD"
+          dataRestrictedExpiration:
+            query: "*/EXPRSRD"
+
+          # ObsValue
+          lightningDischargePolarity:
+            query: "*/PLRTS"
+          amplitudeOfLightningStrike: 
+            query: "*/AMPLS"
+          #numberOfFlashes:
+          lightningMultiStrikes:
+            query: "*/NOFL"
+  
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./rap.t00z.lghtng.tm00.bufr_d.nc"
+
+      variables:
+        # MetaData
+        - name: "MetaData/dateTime"
+          coordinates: "longitude latitude"
+          source: variables/timestamp
+          longName: "Datetime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/latitude"
+          coordinates: "longitude latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          coordinates: "longitude latitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degree_east"
+          range: [-180, 180]
+
+        - name: "MetaData/dataProviderRestricted"
+          coordinates: "longitude latitude"
+          source: variables/dataProviderRestricted
+          longName: "Restrictions On Data Redistribution"
+
+        - name: "MetaData/dataRestrictedExpiration"
+          coordinates: "longitude latitude"
+          source: variables/dataRestrictedExpiration
+          longName: "Expiration Of Restrictions On Data Redistribution"
+
+        # Observation
+        - name: "ObsValue/lightningDischargePolarity"
+          coordinates: "longitude latitude"
+          source: variables/lightningDischargePolarity
+          longName: "Polarity Of Lightning Stroke"
+
+        - name: "ObsValue/amplitudeOfLightningStrike"
+          coordinates: "longitude latitude"
+          source: variables/amplitudeOfLightningStrike
+          longName: "Amplitude Of Lightning Stroke"
+          units: "amps"
+
+        - name: "ObsValue/lightningMultiStrikes"
+          coordinates: "longitude latitude"
+          source: variables/lightningMultiStrikes
+          longName: "Multiplicity of Lightning Strikes"
+          units: "1"

--- a/rrfs-test/IODA/yaml/bufr_ncep_msonet.yaml
+++ b/rrfs-test/IODA/yaml/bufr_ncep_msonet.yaml
@@ -1,0 +1,222 @@
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
+# 
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./rap.t00z.msonet.tm00.bufr_d"
+
+      exports:
+        subsets:
+          - NC255002
+        variables:
+          # MetaData
+          timestamp:
+            datetime:
+              year: "*/YEAR"
+              month: "*/MNTH"
+              day: "*/DAYS"
+              hour: "*/HOUR"
+              minute: "*/MINU"
+          stationIdentification:
+            query: "*/RPID"
+          latitude:
+            query: "*/CLATH"
+          longitude:
+            query: "*/CLONH"
+          stationElevation:
+            query: "*/SELV"
+          height:
+            query: "*/HSMSL"
+          dataProviderRestricted:
+            query: "*/RSRD"
+          dataRestrictedExpiration:
+            query: "*/EXPRSRD"
+          pressure:
+            query: "*/MNPRESSQ/PRES"
+
+          # ObsValue
+          altimeterSetting:
+            query: "*/MNALSESQ/ALSE"
+          snowWaterEquivalentRate:
+            query: "*/MNREQVSQ/REQV"
+          # ObsValue/Temperature
+          airTemperature:
+            query: "*/MNTMDBSQ/TMDB"
+          dewPointTemperature:
+            query: "*/MNTMDPSQ/TMDP"
+          # ObsValue/Wind
+          windDirection:
+            query: "*/MNWDIRSQ/WDIR"
+          windSpeed:
+            query: "*/MNWSPDSQ/WSPD"
+          maximumWindGustDirection:
+            query: "*/MNGUSTSQ/MXGD"
+          maximumWindGustSpeed:
+            query: "*/MNGUSTSQ/MXGS"
+          # ObsValue/Humidity
+          totalPrecipitation:
+            query: "*/TOPC"
+          # ObsValue/Visibility
+          horizontalVisibility:
+            query: "*/MNHOVISQ/HOVI"
+
+          # QualityMarker
+          pressureQM:
+            query: "*/QMPR"
+          airTemperatureQM:
+            query: "*/QMAT"
+          dewPointTemperatureQM:
+            query: "*/QMDD"
+          windSpeedQM:
+            query: "*/QMWN"
+
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./rap.t00z.msonet.tm00.bufr_d.nc"
+
+
+      variables:
+        # MetaData
+        - name: "MetaData/dateTime"
+          coordinates: "longitude latitude"
+          source: variables/timestamp
+          longName: "Datetime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/stationIdentification"
+          coordinates: "longitude latitude"
+          source: variables/stationIdentification
+          longName: "Station Identification"
+
+        - name: "MetaData/latitude"
+          coordinates: "longitude latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          coordinates: "longitude latitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degree_east"
+          range: [-180, 180]
+
+        - name: "MetaData/stationElevation"
+          coordinates: "longitude latitude"
+          source: variables/stationElevation
+          longName: "Elevation of Observing Location"
+          units: "m"
+
+        - name: "MetaData/height"
+          coordinates: "longitude latitude"
+          source: variables/height
+          longName: "Height Above Mean Sea Level"
+          units: "m"
+
+        - name: "MetaData/dataProviderRestricted"
+          coordinates: "longitude latitude"
+          source: variables/dataProviderRestricted
+          longName: "Restrictions On Data Redistribution"
+
+        - name: "MetaData/dataRestrictedExpiration"
+          coordinates: "longitude latitude"
+          source: variables/dataRestrictedExpiration
+          longName: "Expiration Of Restrictions On Data Redistribution"
+
+        - name: "MetaData/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressure
+          longName: "Pressure"
+          units: "Pa"
+
+          # ObsValue
+        - name: "ObsValue/altimeterSetting"
+          coordinates: "longitude latitude"
+          source: variables/altimeterSetting
+          longName: "Altimeter Setting"
+          units: "Pa"
+  
+        - name: "ObsValue/snowWaterEquivalentRate"
+          coordinates: "longitude latitude"
+          source: variables/snowWaterEquivalentRate
+          longName: "Snow Water Equivalent Rate"
+          units: "kg m-2 s-1"
+
+        # ObsValue/Temperature
+        - name: "ObsValue/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperature
+          longName: "Air Temperature"
+          units: "K"
+
+        - name: "ObsValue/dewPointTemperature"
+          coordinates: "longitude latitude"
+          source: variables/dewPointTemperature
+          longName: "Dewpoint Temperature"
+          units: "K"
+
+        # ObsValue/Wind
+        - name: "ObsValue/windDirection"
+          coordinates: "longitude latitude"
+          source: variables/windDirection
+          longName: "Wind Direction"
+          units: "degree"
+
+        - name: "ObsValue/windSpeed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeed
+          longName: "Wind Speed"
+          units: "m s-1"
+
+        - name: "ObsValue/maximumWindGustDirection"
+          coordinates: "longitude latitude"
+          source: variables/maximumWindGustDirection
+          longName: "Maximum Wind Gust Direction"
+          units: "degree"
+
+        - name: "ObsValue/maximumWindGustSpeed"
+          coordinates: "longitude latitude"
+          source: variables/maximumWindGustSpeed
+          longName: "Maximum Wind Gust Speed"
+          units: "m s-1"
+
+        # ObsValue/Humidity
+        - name: "ObsValue/totalPrecipitation"
+          coordinates: "longitude latitude"
+          source: variables/totalPrecipitation
+          longName: "Total Precipitation"
+          units: "kg m-2"
+
+        # ObsValue/Visibility
+        - name: "ObsValue/horizontalVisibility"
+          coordinates: "longitude latitude"
+          source: variables/horizontalVisibility
+          longName: "Horizontal Visibility"
+          units: "m"
+
+        # QualityMarker
+        - name: "QualityMarker/pressure"
+          coordinates: "longitude latitude"
+          source: variables/pressureQM
+          longName: "Quality Indicator for Pressure"
+
+        - name: "QualityMarker/airTemperature"
+          coordinates: "longitude latitude"
+          source: variables/airTemperatureQM
+          longName: "Quality Indicator for Temperature"
+
+        - name: "QualityMarker/dewPointTemperature"
+          coordinates: "longitude latitude"
+          source: variables/dewPointTemperature
+          longName: "Quality Indicator for Moisture"
+
+        - name: "QualityMarker/windSpeed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeedQM
+          longName: "Quality Indicator for Wind"


### PR DESCRIPTION
This PR adds two ioda-converters YAML for the LGHTNG and MSONET BUFR data. 

**The following files are new:**

- rrfs-test/IODA/yaml/bufr_ncep_lghtng.yaml
- rrfs-test/IODA/yaml/bufr_ncep_msonet.yaml

The validation for the LGHTNG output obs is performed in the following https://github.com/NOAA-EMC/RDASApp/issues/13.
The validation for the MSONET data was performed earlier using the RTMA data files and is taken from the ioda-converters repository (https://github.com/JCSDA-internal/ioda-converters). 

The test-data will be added separately to the RRFS test-data directory on Hera.

