### PR TITLE
Speed up git operations in RDASApp by ignoring dirty submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,63 +2,79 @@
 	path = sorc/crtm
 	url = https://github.com/jcsda/crtm
 	branch = release/crtm_jedi_v2.4.1
+	ignore = dirty
 [submodule "sorc/femps"]
 	path = sorc/femps
 	url = https://github.com/jcsda/femps
 	branch = develop
+	ignore = dirty
 [submodule "sorc/fms"]
 	path = sorc/fms
 	url = https://github.com/jcsda/fms
 	branch = release-stable
+	ignore = dirty
 [submodule "sorc/fv3"]
 	path = sorc/fv3
 	url = https://github.com/jcsda/GFDL_atmos_cubed_sphere
 	branch = release-stable
+	ignore = dirty
 [submodule "sorc/fv3-jedi"]
 	path = sorc/fv3-jedi
 	url = https://github.com/jcsda/fv3-jedi
 	branch = develop
+	ignore = dirty
 [submodule "sorc/fv3-jedi-km"]
 	path = sorc/fv3-jedi-lm
 	url = https://github.com/JCSDA/fv3-jedi-linearmodel
 	branch = develop
+	ignore = dirty
 [submodule "sorc/gsibec"]
 	path = sorc/gsibec
 	url = https://github.com/GEOS-ESM/GSIbec
 	branch = develop
+	ignore = dirty
 [submodule "sorc/ioda"]
 	path = sorc/ioda
 	url = https://github.com/jcsda/ioda
 	branch = develop
+	ignore = dirty
 [submodule "sorc/iodaconv"]
 	path = sorc/iodaconv
 	url = https://github.com/jcsda-internal/ioda-converters
 	branch = develop
+	ignore = dirty
 [submodule "sorc/jedicmake"]
 	path = sorc/jedicmake
 	url = https://github.com/jcsda/jedi-cmake
 	branch = develop
+	ignore = dirty
 [submodule "sorc/oops"]
 	path = sorc/oops
 	url = https://github.com/jcsda/oops
 	branch = develop
+	ignore = dirty
 [submodule "sorc/saber"]
 	path = sorc/saber
 	url = https://github.com/jcsda/saber
 	branch = develop
+	ignore = dirty
 [submodule "sorc/ufo"]
 	path = sorc/ufo
 	url = https://github.com/jcsda/ufo
 	branch = develop
+	ignore = dirty
 [submodule "sorc/vader"]
 	path = sorc/vader
 	url = https://github.com/jcsda/vader
 	branch = develop
+	ignore = dirty
 [submodule "sorc/mpas"]
 	path = sorc/mpas
 	url = https://github.com/jcsda-internal/MPAS-Model
 	branch = release-stable 
+	ignore = dirty
 [submodule "sorc/mpas-jedi"]
 	path = sorc/mpas-jedi
 	url = https://github.com/JCSDA/mpas-jedi
 	branch = develop
+	ignore = dirty


### PR DESCRIPTION
This PR makes changes to `.gitmodules` to stop tracking **dirty** submodules used for RDASApp (following discussion in #65). This change significantly speeds up commands like `git status` and `git diff`. It is a similar effect to using `--ignore-submodules` for the git commands. If you are using RDASApp to make **dirty** changes to the submodules, please note that those will not be tracked from the root repository directory. They should still be tracked from the submodule sorc directories, however. 