### PR TITLE
add a comment that MPASJEDI can use logp for vertical localization

### DIFF
--- a/rrfs-test/testinput/rrfs_mpasjedi_bumploc_2022052619.yaml
+++ b/rrfs-test/testinput/rrfs_mpasjedi_bumploc_2022052619.yaml
@@ -5,7 +5,7 @@ geometry:
   nml_file: "./namelist.atmosphere_15km"
   streams_file: "./streams.atmosphere_15km"
   deallocate non-da fields: true
-  bump vunit: "height" # modellevel, height
+  bump vunit: "height" # modellevel, height, logp
 background:
   state variables: &vars [spechum,surface_pressure,temperature,uReconstructMeridional,uReconstructZonal]
   filename: "bg.2022-05-26_19.00.00.nc"


### PR DESCRIPTION
We had lots of good discussions about vertical localization units in PR https://github.com/NOAA-EMC/RDASApp/pull/53.

This PR is to add a comment in `rrfs-test/testinput/rrfs_mpasjedi_bumploc_2022052619.yaml` to remind users that MPASJEDI can use logp for vertical localization.

The related MPASJEDI codes can be found here:
[https://github.com/JCSDA-internal/mpas-jedi/blob/48a12b5e853bb3c087aa0309d2ce4b689ba626d5/src/mpasjedi/Geometry/mpas_geom_mod.F90#L512](https://github.com/JCSDA-internal/mpas-jedi/blob/48a12b5e853bb3c087aa0309d2ce4b689ba626d5/src/mpasjedi/Geometry/mpas_geom_mod.F90#L512)