### PR TITLE
updates for jet to use /lfs5

### DIFF
--- a/modulefiles/RDAS/jet.intel.lua
+++ b/modulefiles/RDAS/jet.intel.lua
@@ -6,7 +6,7 @@ local pkgName    = myModuleName()
 local pkgVersion = myModuleVersion()
 local pkgNameVer = myModuleFullName()
 
-prepend_path("MODULEPATH", '/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core')
+prepend_path("MODULEPATH", '/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core')
 
 -- below two lines get us access to the spack-stack modules
 load("stack-intel/2021.5.0")
@@ -74,7 +74,7 @@ load("py-scipy/1.11.3")
 load("py-xarray/2023.7.0")
 
 -- hack for wxflow
-prepend_path("PYTHONPATH", "/lfs4/BMC/nrtrr/RDAS_DATA/python/20240307")
+prepend_path("PYTHONPATH", "/lfs5/BMC/nrtrr/RDAS_DATA/python/20240307")
 
 setenv("CC","mpiicc")
 setenv("FC","mpiifort")
@@ -85,9 +85,9 @@ local mpinproc = '-n'
 setenv('MPIEXEC_EXEC', mpiexec)
 setenv('MPIEXEC_NPROC', mpinproc)
 
-setenv("CRTM_FIX","/lfs4/BMC/nrtrr/RDAS_DATA/crtm/2.4.0")
-setenv("RDASAPP_TESTDATA","/lfs4/BMC/nrtrr/RDAS_DATA")
-setenv("RDAS_RRFS_DATA_ROOT", "/lfs4/BMC/nrtrr/RDAS_DATA")
+setenv("CRTM_FIX","/lfs5/BMC/nrtrr/RDAS_DATA/crtm/2.4.0")
+setenv("RDASAPP_TESTDATA","/lfs5/BMC/nrtrr/RDAS_DATA")
+setenv("RDAS_RRFS_DATA_ROOT", "/lfs5/BMC/nrtrr/RDAS_DATA")
 
 whatis("Name: ".. pkgName)
 whatis("Version: ".. pkgVersion)

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -69,7 +69,7 @@ if [[ -d /lfs/h3 ]]; then
 elif [[ -d /lfs/h1 && ! -d /lfs/h3 ]]; then
   # We are on NOAA TDS Acorn
   MACHINE_ID=acorn
-elif [[ -d /mnt/lfs1 ]]; then
+elif [[ -d /mnt/lfs5 ]]; then
   # We are on NOAA Jet
   MACHINE_ID=jet
 elif [[ -d /scratch1 ]]; then


### PR DESCRIPTION
/lfs1 no longer exists on Jet
/lfs4 is unstable and will be unmounted in a few weeks.
So switch the spack-stack to /contrib and the RDAS_DATA to /lfs5