### PR TITLE
building fms in the APP to provide compatible lib for fv3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 	url = https://github.com/JCSDA/mpas-jedi
 	branch = develop
 	ignore = all
+[submodule "sorc/fms"]
+	path = sorc/fms
+	url = https://github.com/jcsda/fms

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -83,6 +83,7 @@ if(BUILD_RDASBUNDLE)
 
   if(FV3_DYCORE)
     # FMS and FV3 dynamical core
+    include(../sorc/fv3-interface.cmake)
     ecbuild_bundle( PROJECT fms SOURCE "../sorc/fms" )
     ecbuild_bundle( PROJECT fv3 SOURCE "../sorc/fv3" )
 

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -83,9 +83,7 @@ if(BUILD_RDASBUNDLE)
 
   if(FV3_DYCORE)
     # FMS and FV3 dynamical core
-# FMS and FV3 dynamical core
     ecbuild_bundle( PROJECT fms SOURCE "../sorc/fms" )
-#clt follow GDASapp     include(../sorc/fv3-interface.cmake)
     ecbuild_bundle( PROJECT fv3 SOURCE "../sorc/fv3" )
 
     # fv3-jedi and associated repositories

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -83,7 +83,9 @@ if(BUILD_RDASBUNDLE)
 
   if(FV3_DYCORE)
     # FMS and FV3 dynamical core
-    include(../sorc/fv3-interface.cmake)
+# FMS and FV3 dynamical core
+    ecbuild_bundle( PROJECT fms SOURCE "../sorc/fms" )
+#clt follow GDASapp     include(../sorc/fv3-interface.cmake)
     ecbuild_bundle( PROJECT fv3 SOURCE "../sorc/fv3" )
 
     # fv3-jedi and associated repositories


### PR DESCRIPTION
For the current RDASapp while using module ("fms/2023.04") following GDASapp, the building would show errors from the incompatibilities between fv3 (fv3-lam) and fms lib as reported in https://github.com/NOAA-EMC/RDASApp/issues/136. 
We could switch to the right fms module. But a more straightforward option is just to build fms submodule already in RDASapp. That is this PR does . 
After such a change, the building finished successfully. 