### PR TITLE
Resolving bugs with build and clone processes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@
 # 2 - configure; build; install
 # 4 - optional, run unit tests
 
+module purge
 set -eu
 START=$(date +%s)
 dir_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/docs/build_and_test.md
+++ b/docs/build_and_test.md
@@ -2,6 +2,8 @@
 ```
 git clone --recurse-submodules https://github.com/NOAA-EMC/RDASApp.git
 ```
+If running on Orion, you will also need to run `module load git-lfs` before cloning. 
+
 ## 2.Build RDASApp
 ```
     cd RDASApp

--- a/docs/build_and_test.md
+++ b/docs/build_and_test.md
@@ -1,9 +1,8 @@
 ## 1.Clone RDASApp
-If running on Orion, you will also need to run `module load git-lfs` before cloning. 
+If running on Orion/Hercules, you will need to run `module load git-lfs` before cloning. 
 ```
 git clone --recurse-submodules https://github.com/NOAA-EMC/RDASApp.git
 ```
-
 ## 2.Build RDASApp
 ```
     cd RDASApp

--- a/docs/build_and_test.md
+++ b/docs/build_and_test.md
@@ -1,8 +1,8 @@
 ## 1.Clone RDASApp
+If running on Orion, you will also need to run `module load git-lfs` before cloning. 
 ```
 git clone --recurse-submodules https://github.com/NOAA-EMC/RDASApp.git
 ```
-If running on Orion, you will also need to run `module load git-lfs` before cloning. 
 
 ## 2.Build RDASApp
 ```

--- a/rrfs-test/scripts/link_mpasjedi_expr.sh
+++ b/rrfs-test/scripts/link_mpasjedi_expr.sh
@@ -45,7 +45,7 @@ cp ${RDASApp}/rrfs-test/ush/mpasjedi_spread.py .
 mkdir -p data
 cd data
 mkdir -p bumploc bkg obs ens ref
-ln -snf ${RDASApp}/fix/bumploc/${BUMPLOC} bumploc/
+ln -snf ${RDASApp}/fix/bumploc/${BUMPLOC} bumploc/${BUMPLOC}
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/bkg/restart.2024-05-27_00.00.00.nc .
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/bkg/restart.2024-05-27_00.00.00.nc static.nc
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/obs/* obs/


### PR DESCRIPTION
This PR makes a few minor changes to resolve bugs associated with building and cloning, including: 

1. Resolving #144 by updating the documentation to note the need to run `module load git-lfs` before cloning on Orion.
2. Resolving #135 by adding `module purge` to the beginning of `build.sh`. Previously, if you had the eva modules loaded, `build.sh` would fail. This quick change prevents that error by forcing you to unload all modules before building. 
3. Modifying `link_mpasjedi_expr.sh` by adding the `${BUMPLOC}` directory name to prevent a linking error during build on Orion. Previously, the linking failed on due to the link directory not being specified which lead to `cannot overwrite directory` error. This error did not occur on Hera.

Note that there is still an ongoing bug with building on Orion (#146). Restarting the build resolves that issue, but I am still actively investigating the root cause. 