### PR TITLE
Fix build error on Orion by reducing the number of build tasks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -137,6 +137,13 @@ if [[ $DYCORE == 'MPAS' || $DYCORE == 'FV3andMPAS' ]]; then
   $dir_root/rrfs-test/scripts/link_mpasjedi_expr.sh
 fi
 
+# Set lower number of build jobs on Orion due to memory limit on login nodes
+if [[ $BUILD_TARGET == 'orion' ]]; then
+  BUILD_JOBS=${BUILD_JOBS:-4}
+else # hera, hercules, jet
+  BUILD_JOBS=${BUILD_JOBS:-6}
+fi
+
 CMAKE_OPTS+=" -DMPIEXEC_MAX_NUMPROCS:STRING=120"
 # Configure
 echo "Configuring ..."
@@ -150,11 +157,11 @@ set +x
 echo "Building ..."
 set -x
 if [[ $BUILD_JCSDA == 'YES' ]]; then
-  make -j ${BUILD_JOBS:-6} VERBOSE=$BUILD_VERBOSE
+  make -j $BUILD_JOBS VERBOSE=$BUILD_VERBOSE
 else
   for b in $builddirs; do
     cd $b
-    make -j ${BUILD_JOBS:-6} VERBOSE=$BUILD_VERBOSE
+    make -j $BUILD_JOBS VERBOSE=$BUILD_VERBOSE
     cd ../
   done
 fi


### PR DESCRIPTION
This PR resolves #146 by updating `build.sh` to use a lower number of parallel build tasks on Orion. Previously, the build would fail towards the end due to going over the memory limit for the login nodes. This update does increase the total build time (~70 min previously to ~100 min now), but at least it works now without having to restart the build multiple times. Note that this memory limit is not a problem on any other machine, including Hercules. 

Thanks @CoryMartin-NOAA for the tip here. 