### PR TITLE
Clean up build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ BUILD_SUPER_EXE="NO"
 DYCORE="FV3andMPAS"
 COMPILER="${COMPILER:-intel}"
 
-while getopts "p:c:m:j:hvfsx-:" opt; do
+while getopts "p:c:m:j:hvfsx" opt; do
   case $opt in
     p)
       INSTALL_PREFIX=$OPTARG

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,6 @@ BUILD_JCSDA="YES"
 BUILD_SUPER_EXE="NO"
 DYCORE="FV3andMPAS"
 COMPILER="${COMPILER:-intel}"
-#BUILD_JOBS="6"
 
 while getopts "p:c:m:j:hvfsx-:" opt; do
   case $opt in

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ usage() {
   echo "  -p  installation prefix <prefix>    DEFAULT: <none>"
   echo "  -c  additional CMake options        DEFAULT: <none>"
   echo "  -v  build with verbose output       DEFAULT: NO"
-  echo "  -j  number of build jobs            DEFAULT: 6"
+  echo "  -j  number of build jobs            DEFAULT: 4 on Orion, 6 on other machines"
   echo "  -f  force a clean build             DEFAULT: NO"
   echo "  -s  only build a subset of the bundle  DEFAULT: NO"
   echo "  -m  select dycore                      DEFAULT: FV3andMPAS"

--- a/build.sh
+++ b/build.sh
@@ -19,12 +19,12 @@ usage() {
   echo "Usage: $0 -p <prefix> | -t <target> -h"
   echo
   echo "  -p  installation prefix <prefix>    DEFAULT: <none>"
-  echo "  -t  target to build for <target>    DEFAULT: $MACHINE_ID"
   echo "  -c  additional CMake options        DEFAULT: <none>"
   echo "  -v  build with verbose output       DEFAULT: NO"
   echo "  -f  force a clean build             DEFAULT: NO"
   echo "  -s  only build a subset of the bundle  DEFAULT: NO"
   echo "  -m  select dycore                      DEFAULT: FV3andMPAS"
+  echo "  -x  build super executables         DEFAULT: NO"
   echo "  -h  display this message and quit"
   echo
   exit 1
@@ -37,19 +37,16 @@ INSTALL_PREFIX=""
 CMAKE_OPTS=""
 BUILD_TARGET="${MACHINE_ID:-'localhost'}"
 BUILD_VERBOSE="NO"
-ADD_RRFS_TESTS="YES"
 CLEAN_BUILD="NO"
 BUILD_JCSDA="YES"
+BUILD_SUPER_EXE="NO"
 DYCORE="FV3andMPAS"
 COMPILER="${COMPILER:-intel}"
 
-while getopts "p:t:c:m:hvfs-:" opt; do
+while getopts "p:c:m:hvfsx-:" opt; do
   case $opt in
     p)
       INSTALL_PREFIX=$OPTARG
-      ;;
-    t)
-      BUILD_TARGET=$OPTARG
       ;;
     c)
       CMAKE_OPTS=$OPTARG
@@ -66,6 +63,9 @@ while getopts "p:t:c:m:hvfs-:" opt; do
     s)
       BUILD_JCSDA=NO
       ;;
+    x)
+      BUILD_SUPER_EXE=YES
+      ;; 
     h|\?|:)
       usage
       ;;
@@ -87,8 +87,6 @@ case ${BUILD_TARGET} in
     exit
     ;;
 esac
-
-CMAKE_OPTS+=" -DADD_RRFS_TESTS=$ADD_RRFS_TESTS"
 
 BUILD_DIR=${BUILD_DIR:-$dir_root/build}
 if [[ $CLEAN_BUILD == 'YES' ]]; then
@@ -144,7 +142,7 @@ else # hera, hercules, jet
   BUILD_JOBS=${BUILD_JOBS:-6}
 fi
 
-CMAKE_OPTS+=" -DMPIEXEC_MAX_NUMPROCS:STRING=120"
+CMAKE_OPTS+=" -DMPIEXEC_MAX_NUMPROCS:STRING=120 -DBUILD_SUPER_EXE=$BUILD_SUPER_EXE"
 # Configure
 echo "Configuring ..."
 set -x

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -105,12 +105,11 @@ endif()
     ecbuild_bundle( PROJECT iodaconv SOURCE "../sorc/iodaconv" )
   endif()
 
-# rdas mega executable
-  ecbuild_bundle( PROJECT rdas SOURCE "../mains" )
-
-  if(ADD_RRFS_TESTS)
-    ecbuild_bundle( PROJECT rrfs-test SOURCE "../rrfs-test" )
-  endif(ADD_RRFS_TESTS)
+# rdas tests and super executables
+  ecbuild_bundle( PROJECT rrfs-test SOURCE "../rrfs-test" )
+  if(BUILD_SUPER_EXE)
+    ecbuild_bundle( PROJECT rdas SOURCE "../mains" )
+  endif()
 
 endif(BUILD_RDASBUNDLE)
 

--- a/rrfs-test/CMakeLists.txt
+++ b/rrfs-test/CMakeLists.txt
@@ -18,17 +18,16 @@ add_to_dictionary(rrfs_mpasjedi_tests "rrfs_mpasjedi_2024052700_letkf"    "mpasj
 add_to_dictionary(rrfs_mpasjedi_tests "rrfs_mpasjedi_2024052700_getkf"    "mpasjedi_enkf.x")
 add_to_dictionary(rrfs_mpasjedi_tests "rrfs_mpasjedi_2024052700_bumploc"  "mpasjedi_error_covariance_toolbox.x")
 
-if (ADD_RRFS_TESTS)
-   message(STATUS "Use test data from rrfs-test-data repository")
-   set (rrfs-test_data_local "${CMAKE_SOURCE_DIR}/rrfs-test-data/")
-   set (src_yaml "${CMAKE_SOURCE_DIR}/rrfs-test/testinput")
+message(STATUS "Use test data from rrfs-test-data repository")
+set (rrfs-test_data_local "${CMAKE_SOURCE_DIR}/rrfs-test-data/")
+set (src_yaml "${CMAKE_SOURCE_DIR}/rrfs-test/testinput")
 # It's unclear if anyone is using the local data functionality, therefore comment it out
 # for now and add in if someone complains / remove if completely if not.
 #elseif (DEFINED ENV{FV3_JEDI_TESTFILES})
 #  message(STATUS "Use test data from local directory $ENV{FV3_JEDI_TESTFILES}")
 #  # A bit of guesswork here, I don't know if folks using this option stored it in the same directory structure
 #  set (fv3-jedi_data_testinput_tier_1_local "$ENV{FV3_JEDI_TESTFILES}/fv3-jedi-data/testinput_tier_1")
-   if(FV3_DYCORE)
+if(FV3_DYCORE)
 
       message(STATUS "MACHINE_ID is " ${MACHINE_ID})
       if("${MACHINE_ID}" STREQUAL "orion")
@@ -106,5 +105,4 @@ if (ADD_RRFS_TESTS)
           set(MPI_ARGS ${RESTORE_MPI_ARGS})
       endif()
 
-   endif()
 endif()


### PR DESCRIPTION
This is a follow-up to #162 that was intended as a quick bugfix to allow RDASApp to build on Orion. This PR resolves #164 by further cleaning up `build.sh`. Changes include:

1. Removal of `-t` option to build for specified machine (we now use `ush/detech_machine.sh` to automatically do this)
2. Removal of `ADD_RRFS_TESTS` cmake option since we always want to build these tests in RDASApp
3. Addition of `-x` option to toggle building the super executables (use `-x` to build them; default is to not build them) 
4. Addition of `-j` option to specify number of build tasks (default is 4 on Orion, 6 on other supported machines) 

I tested the new `-x` and `-j` options and everything is working as expected. 