### PR TITLE
change the HERA's RDAS_DATA location to be under the role.rrfsfix account

### DIFF
--- a/ush/init.sh
+++ b/ush/init.sh
@@ -6,7 +6,7 @@ basedir="$(dirname "$ushdir")"
 
 case ${MACHINE_ID} in
   hera)
-    RDAS_DATA=/scratch1/NCEPDEV/fv3-cam/RDAS_DATA
+    RDAS_DATA=/scratch2/BMC/rtrr/RDAS_DATA
     ;;
   jet)
     RDAS_DATA=/lfs5/BMC/nrtrr/RDAS_DATA


### PR DESCRIPTION
This is to make things consistent with Jet, Gaea and rrfs-workflow.

The role.rrfsfix account has special environments to facilitate the use of the '[git-mega](https://github.com/git-mega/git-mega)' tool for the level 2 management of fix files (_note: only the fix file management team needs to deal with git-mega_)

The role.rrfsfix account is used only for the fix file management and will NOT run any jobs so as to ensure full data integrity.