### PR TITLE
Changing bumploc.yaml to rrfs_mpasjedi_2024052700_bumploc.yaml in setup_experiment.sh

### DIFF
--- a/rrfs-test/scripts/setup_experiment.sh
+++ b/rrfs-test/scripts/setup_experiment.sh
@@ -86,7 +86,7 @@ elif [[ $DYCORE == "MPAS" ]]; then
   mkdir -p graphinfo stream_list
   ln -sf ${RDAS_DATA}/fix/graphinfo/* graphinfo/
   cp -rp ${RDAS_DATA}/fix/stream_list/* stream_list/
-  cp ${YOUR_PATH_TO_RDASAPP}/rrfs-test/testinput_expr/bumploc.yaml .
+  cp ${YOUR_PATH_TO_RDASAPP}/rrfs-test/testinput_expr/rrfs_mpasjedi_2024052700_bumploc.yaml .
   cp ${YOUR_PATH_TO_RDASAPP}/rrfs-test/testinput_expr/namelist.atmosphere .
   cp ${YOUR_PATH_TO_RDASAPP}/rrfs-test/testinput_expr/rrfs_mpasjedi_2024052700_Ens3Dvar.yaml .
   cp ${YOUR_PATH_TO_RDASAPP}/rrfs-test/testinput_expr/rrfs_mpasjedi_2024052700_letkf.yaml .


### PR DESCRIPTION
This PR makes a small change to setup_experiment.sh when setting up test experiments within RDASApp. Previously, copying bumploc.yaml (line 89) returned an issue (No such file or directory) when executing setup_experiment.sh. This is changed to rrfs_mpasjedi_2024052700_bumploc.yaml now.

The new file is located at:
~/rrfs-test/scripts/setup_experiment.sh