### PR TITLE
Hotfix for offline domain check longitude range

### DIFF
--- a/rrfs-test/IODA/offline_domain_check.py
+++ b/rrfs-test/IODA/offline_domain_check.py
@@ -223,6 +223,7 @@ domain_path = Path(edge_points)
 # Extract observation latitudes and longitudes
 obs_lat = obs_ds.groups['MetaData'].variables['latitude'][:]
 obs_lon = obs_ds.groups['MetaData'].variables['longitude'][:]
+obs_lon = np.where(obs_lon < 0, obs_lon + 360, obs_lon)
 
 # Pair the observation lat/lon as coordinates
 obs_coords = np.vstack((obs_lon, obs_lat)).T


### PR DESCRIPTION
A quick fix for the problem described [here](https://github.com/NOAA-EMC/RDASApp/pull/215#issuecomment-2456248208) by @HuiLiu-NOAA. The conventional version of the offline domain check was not configured to work with obs whose longitudes range from (-180, 180). This line exists in `offline_domain_check_satrad.py` but needs to be added to `offline_domain_check.py`. 