### PR TITLE
Bugfix to remove duplicate `ombg` diagnostic in var-based yamls

### DIFF
--- a/rrfs-test/testinput/rrfs_fv3jedi_hyb_2022052619.yaml
+++ b/rrfs-test/testinput/rrfs_fv3jedi_hyb_2022052619.yaml
@@ -214,8 +214,6 @@ variational:
       ntiles: 1 
       fieldsets:
       - fieldset: DataFix/fix/dynamics_lam_cmaq.yaml
-    diagnostics:
-      departures: ombg
 final:
   diagnostics:
     departures: oman

--- a/rrfs-test/testinput/rrfs_mpasjedi_2024052700_Ens3Dvar.yaml
+++ b/rrfs-test/testinput/rrfs_mpasjedi_2024052700_Ens3Dvar.yaml
@@ -25,8 +25,6 @@ variational:
       deallocate non-da fields: true
       interpolation type: unstructured
     gradient norm reduction: 1e-3
-    diagnostics:
-      departures: ombg
     ninner: 50
 final:
   diagnostics:

--- a/rrfs-test/testinput_expr/rrfs_mpasjedi_2024052700_Ens3Dvar.yaml
+++ b/rrfs-test/testinput_expr/rrfs_mpasjedi_2024052700_Ens3Dvar.yaml
@@ -25,8 +25,6 @@ variational:
       deallocate non-da fields: true
       interpolation type: unstructured
     gradient norm reduction: 1e-3
-    diagnostics:
-      departures: ombg
     ninner: 50
 final:
   diagnostics:

--- a/rrfs-test/validated_yamls/templates/basic_config/mpasjedi_3dvar.yaml
+++ b/rrfs-test/validated_yamls/templates/basic_config/mpasjedi_3dvar.yaml
@@ -25,8 +25,6 @@ variational:
       deallocate non-da fields: true
       interpolation type: unstructured
     gradient norm reduction: 1e-3
-    diagnostics:
-      departures: ombg
     ninner: 50
 final:
   diagnostics:

--- a/rrfs-test/validated_yamls/templates/basic_config/mpasjedi_en3dvar.yaml
+++ b/rrfs-test/validated_yamls/templates/basic_config/mpasjedi_en3dvar.yaml
@@ -25,8 +25,6 @@ variational:
       deallocate non-da fields: true
       interpolation type: unstructured
     gradient norm reduction: 1e-3
-    diagnostics:
-      departures: ombg
     ninner: 50
 final:
   diagnostics:


### PR DESCRIPTION
@HuiLiu-NOAA caught [here](https://github.com/NOAA-EMC/RDASApp/issues/226#issuecomment-2486554312) that the `ombg` diagnostic was accidentally listed twice in the var-based yaml files. Removing it does not impact the results and the EnVar ctest still passes normally (waiting to run FV3-JEDI ctests). But to avoid any confusion, this quick PR is created to remove the duplicate diagnostic. 