### PR TITLE
Phase 3 validation: updates for msonet yamls

### DIFF
--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
@@ -57,8 +57,8 @@
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
-               minvalue: -360
-               maxvalue:  360
+               minvalue: -900
+               maxvalue:  900
 
          # Online domain check
          - filter: Bounds Check
@@ -161,7 +161,7 @@
            apply at iterations: 0,1
            filter variables:
            - name: airTemperature
-           threshold: 5.0
+           threshold: 1.1
            action:
              name: reject
            where:
@@ -175,7 +175,7 @@
            apply at iterations: 0,1
            filter variables:
            - name: airTemperature
-           threshold: 3.5
+           threshold: 0.77
            action:
              name: reject
            where:
@@ -201,7 +201,7 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT06M
+           min_spacing: PT15M
            seed_time: *analysisDate
            category_variable:
              name: MetaData/stationIdentification

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
@@ -57,8 +57,8 @@
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
-               minvalue: -360
-               maxvalue:  360
+               minvalue: -900
+               maxvalue:  900
 
          # Online domain check
          - filter: Bounds Check
@@ -85,7 +85,7 @@
                  xvar:
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
-                 errors: [0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07] 
+                 errors: [0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07]
 
          # Error inflation based on pressure check (setupq.f90)
          - filter: Perform Action
@@ -203,7 +203,7 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT06M
+           min_spacing: PT15M
            seed_time: *analysisDate
            category_variable:
              name: MetaData/stationIdentification

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
@@ -51,8 +51,8 @@
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
-               minvalue: -360
-               maxvalue:  360
+               minvalue: -900
+               maxvalue:  900
 
          # Online domain check
          - filter: Bounds Check
@@ -123,11 +123,11 @@
            - name: stationPressure
            action:
              name: assign error
-             error parameter: 100.0
+             error parameter: 50.0
            where:
            - variable:
                name: ObsErrorData/stationPressure
-             maxvalue: 100.0
+             maxvalue: 50.0
            - variable:
                name: ObsErrorData/stationPressure
              value: is_valid
@@ -155,7 +155,7 @@
            apply at iterations: 0,1
            filter variables:
            - name: stationPressure
-           threshold: 5.0
+           threshold: 4.0
            action:
              name: reject
            where:
@@ -169,7 +169,7 @@
            apply at iterations: 0,1
            filter variables:
            - name: stationPressure
-           threshold: 3.5
+           threshold: 2.8
            action:
              name: reject
            where:
@@ -195,11 +195,11 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT06M
+           min_spacing: PT15M
            seed_time: *analysisDate
            category_variable:
              name: MetaData/stationIdentification
-           defer to post: false
+           defer to post: true
 
          #- filter: GOMsaver
          #  filename: ./data/geovals/msonet_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
@@ -6,7 +6,7 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: @OBSFILE@
+             obsfile: "@OBSFILE@"
          obsdataout:
            engine:
              type: H5File
@@ -373,8 +373,8 @@
            where:
              - variable:
                  name: MetaData/timeOffset # units: s
-               minvalue: -360
-               maxvalue:  360
+               minvalue: -900
+               maxvalue:  900
 
          # Online domain check
          - filter: Bounds Check
@@ -404,7 +404,7 @@
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0]
 
-         # Error inflation based on pressure check (setupw.f90)
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
          - filter: Perform Action
            filter variables:
            - name: windEastward
@@ -422,7 +422,7 @@
                  AddObsHeightToStationElevation: true
                  AssumedSfcWndObsHeight: 10
 
-         # Error inflation based on pressure check (setupw.f90)
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
          - filter: Perform Action
            filter variables:
            - name: windNorthward
@@ -451,7 +451,7 @@
            action:
              name: reject
 
-         # Gross Error Check
+         # Gross Error Check (windEastward)
          - filter: Background Check
            apply at iterations: 0,1
            filter variables:
@@ -460,7 +460,7 @@
            - name: ObsFunction/WindsSPDBCheck
              options:
                wndtype:    [ 288 ]
-               cgross:     [ 5.0 ]
+               cgross:     [ 6.0 ]
                error_min:  [ 1.0 ]
                error_max:  [ 5.0 ]
                variable: windEastward
@@ -471,7 +471,7 @@
              name: reject
            defer to post: true
 
-         # Gross Error Check
+         # Gross Error Check (windNorthward)
          - filter: Background Check
            apply at iterations: 0,1
            filter variables:
@@ -480,7 +480,7 @@
            - name: ObsFunction/WindsSPDBCheck
              options:
                wndtype:    [ 288 ]
-               cgross:     [ 5.0 ]
+               cgross:     [ 6.0 ]
                error_min:  [ 1.0 ]
                error_max:  [ 5.0 ]
                variable: windNorthward
@@ -491,7 +491,7 @@
              name: reject
            defer to post: true
 
-         # Gross Error Check: cgross*0.7 if QualityMarker=3
+         # Gross Error Check (windEastward): cgross*0.7 if QualityMarker=3
          - filter: Background Check
            apply at iterations: 0,1
            filter variables:
@@ -500,7 +500,7 @@
            - name: ObsFunction/WindsSPDBCheck
              options:
                wndtype:    [ 288 ]
-               cgross:     [ 3.5 ]
+               cgross:     [ 4.2 ]
                error_min:  [ 1.0 ]
                error_max:  [ 5.0 ]
                variable: windEastward
@@ -511,7 +511,7 @@
              name: reject
            defer to post: true
 
-         # Gross Error Check: cgross*0.7 if QualityMarker=3
+         # Gross Error Check (windNorthward): cgross*0.7 if QualityMarker=3
          - filter: Background Check
            apply at iterations: 0,1
            filter variables:
@@ -520,7 +520,7 @@
            - name: ObsFunction/WindsSPDBCheck
              options:
                wndtype:    [ 288 ]
-               cgross:     [ 3.5 ]
+               cgross:     [ 4.2 ]
                error_min:  [ 1.0 ]
                error_max:  [ 5.0 ]
                variable: windNorthward
@@ -537,7 +537,7 @@
            filter variables:
            - name: windEastward
            - name: windNorthward
-           min_spacing: PT06M
+           min_spacing: PT15M
            seed_time: *analysisDate
            category_variable:
              name: MetaData/stationIdentification


### PR DESCRIPTION
## Description
Finished Phase 3 testing with great results. Since such extensive testing is done during Phase 2, there is little if any that needs to be done for Phase 3. All of these updates are related to using the updated GSI case (which more accurately reflects the RRFSv1 configuration) or were formatting or improved comments. Phase 3 results start in the associated issue with this https://github.com/NOAA-EMC/RDASApp/issues/80#issuecomment-2523984973

For future: It would be nice to be able to read the info from convinfo instead of hard coding them into each yaml. I bet that capability is part of JCB.

## Issue(s) addressed

- #232 

## Checklist
- [x] I have performed a self-review of my own code.
