### PR TITLE
Bugfix for offline domain check starting Channel variable at 1

### DIFF
--- a/rrfs-test/IODA/offline_domain_check_satrad.py
+++ b/rrfs-test/IODA/offline_domain_check_satrad.py
@@ -258,7 +258,7 @@ else:
 if 'Channel' not in fout.dimensions and channel_size > 0:
     fout.createDimension('Channel', channel_size)
     fout.createVariable('Channel', 'int32', 'Channel', fill_value=fill_value)
-    fout.variables['Channel'][:] = np.arange(channel_size) + 1 #since python indicies start at 0
+    fout.variables['Channel'][:] = obs_ds.variables['Channel'][:]
     for attr in obs_ds.variables['Channel'].ncattrs():  # Attributes for Location variable
         if attr != '_FillValue':
            fout.variables['Channel'].setncattr(attr, obs_ds.variables['Channel'].getncattr(attr))


### PR DESCRIPTION
## Bug Fix Description

This is a quick, one-line fix to solve a problem with the `Channel` variable in the radiance offline domain check. 

**Description of Current Behavior:**
1. `offline_domain_check_satrad.py` starts the `Channel` variable at 1 for the domain checked IODA files. This is incorrect for some radiance obs whose channels start after 1 (e.g., ABI radiances). The incorrect channel list can then lead to errors when using those files in JEDI. 

**Description of Fixed Behavior:**
1. Now just copy the `Channel` variable from the input file. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
