### PR TITLE
add the offline tool to add lon_lat_ps to IODA and updated each jedi yaml to use that as category variable

### DIFF
--- a/rrfs-test/IODA/offline_add_var_to_ioda.py
+++ b/rrfs-test/IODA/offline_add_var_to_ioda.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+import netCDF4 as nc
+import numpy as np
+from timeit import default_timer as timer
+import argparse
+import warnings
+import os
+
+"""
+This program makes a copy of an original IODA file and can add additional
+adhoc variables. This program was originally written to add the
+MetaData/longitude_latitude_pressure for use in l_closeobs duplicate checking
+but others can be added as necessary.
+"""
+
+# Disable warnings
+warnings.filterwarnings('ignore')
+
+# Functions for calculating run times.
+def tic():
+    return timer()
+
+def toc(tic=tic, label=""):
+    toc = timer()
+    elapsed = toc-tic
+    hrs = int(elapsed // 3600)
+    mins = int((elapsed % 3600) // 60)
+    secs = int(elapsed % 3600 % 60)
+    print(f"{label}({elapsed:.2f}s), {hrs:02}:{mins:02}:{secs:02}")
+
+tic1 = tic()
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-o', '--obs', type=str, help='ioda observation file', required=True)
+args = parser.parse_args()
+
+# Assign filenames
+obs_filename = args.obs
+
+obs_ds = nc.Dataset(obs_filename, 'r')
+
+# Extract observation latitudes and longitudes
+obs_lat = obs_ds.groups['MetaData'].variables['latitude'][:]
+obs_lon = obs_ds.groups['MetaData'].variables['longitude'][:]
+obs_lon = np.where(obs_lon < 0, obs_lon + 360, obs_lon)
+obs_prs = obs_ds.groups['MetaData'].variables['pressure'][:]
+
+# Create a new NetCDF file to store the selected data using the more efficient method
+try:
+    outfile = obs_filename.replace('.nc', '_llp.nc')
+except:
+    outfile = obs_filename.replace('.nc4', '_llp.nc4')
+fout = nc.Dataset(outfile, 'w')
+
+# Create dimensions and variables in the new file
+fout.createDimension('Location', len(obs_lat))
+fout.createVariable('Location', 'int64', 'Location')
+fout.variables['Location'][:] = 0
+for attr in obs_ds.variables['Location'].ncattrs():  # Attributes for Location variable
+    fout.variables['Location'].setncattr(attr, obs_ds.variables['Location'].getncattr(attr))
+
+# Copy all non-grouped attributes into the new file
+for attr in obs_ds.ncattrs():  # Attributes for the main file
+    fout.setncattr(attr, obs_ds.getncattr(attr))
+
+# Copy all groups and variables into the new file, keeping only the variables in range
+groups = obs_ds.groups
+for group in groups:
+    g = fout.createGroup(group)
+    for var in obs_ds.groups[group].variables:
+        invar = obs_ds.groups[group].variables[var]
+        try:  # Non-string variables
+            vartype = invar.dtype
+            fill = invar.getncattr('_FillValue')
+            g.createVariable(var, vartype, 'Location', fill_value=fill)
+        except:  # String variables
+            g.createVariable(var, 'str', 'Location')
+        g.variables[var][:] = invar[:][:]
+        # Copy attributes for this variable
+        for attr in invar.ncattrs():
+            if '_FillValue' in attr: continue
+            g.variables[var].setncattr(attr, invar.getncattr(attr))
+
+# Generate longitude_latitude_pressure location strings (for dup checking)
+longitude_latitude_pressure = [f"{lon}_{lat}_{pres}" for lon, lat, pres in zip(obs_lon, obs_lat, obs_prs)]
+longitude_latitude_pressure = np.array(longitude_latitude_pressure)
+
+# Add the longitude_latitude_pressure variable to the file
+var = "longitude_latitude_pressure"
+data = longitude_latitude_pressure
+metadata_group = fout.groups['MetaData']
+metadata_group.createVariable(f"{var}", 'str', 'Location', fill_value=fill)
+metadata_group.variables[f"{var}"][:] = data
+
+# Close the datasets
+obs_ds.close()
+fout.close()
+toc(tic1,label="Time to create new obs file: ")

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
@@ -66,6 +66,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -199,15 +207,6 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
@@ -10,7 +10,7 @@
          obsdataout:
            engine:
              type: H5File
-             obsfile: hofx_adpsfc_airTemperature_187.nc4
+             obsfile: jdiag_adpsfc_airTemperature_187.nc4
              allow overwrite: true
          io pool:
            max pool size: 1
@@ -204,10 +204,10 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT30M
-           seed_time: *analysisDate
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: MetaData/stationIdentification
+             name: "MetaData/longitude_latitude_pressure"
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
@@ -207,7 +207,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
@@ -66,6 +66,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -200,15 +208,6 @@
            - variable:
                name: TempObsErrorData/specificHumidity
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
@@ -208,7 +208,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
@@ -10,7 +10,7 @@
          obsdataout:
            engine:
              type: H5File
-             obsfile: hofx_adpsfc_specificHumidity_187.nc4
+             obsfile: jdiag_adpsfc_specificHumidity_187.nc4
              allow overwrite: true
          io pool:
            max pool size: 1
@@ -205,10 +205,10 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT30M
-           seed_time: *analysisDate
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: MetaData/stationIdentification
+             name: "MetaData/longitude_latitude_pressure"
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
@@ -10,7 +10,7 @@
          obsdataout:
            engine:
              type: H5File
-             obsfile: hofx_adpsfc_stationPressure_187.nc4
+             obsfile: jdiag_adpsfc_stationPressure_187.nc4
              allow overwrite: true
          io pool:
            max pool size: 1
@@ -198,10 +198,10 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT00M
-           seed_time: *analysisDate
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: MetaData/stationIdentification
+             name: "MetaData/longitude_latitude_pressure"
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
@@ -201,7 +201,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
@@ -63,6 +63,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -193,15 +201,6 @@
            - variable:
                name: TempObsErrorData/stationPressure
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
@@ -10,7 +10,7 @@
          obsdataout:
            engine:
              type: H5File
-             obsfile: hofx_adpsfc_winds_287.nc4
+             obsfile: jdiag_adpsfc_winds_287.nc4
              allow overwrite: true
          io pool:
            max pool size: 1
@@ -224,10 +224,10 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT30M
-           seed_time: *analysisDate
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: MetaData/stationIdentification
+             name: "MetaData/longitude_latitude_pressure"
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
@@ -227,7 +227,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
@@ -76,6 +76,17 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -219,15 +230,6 @@
              is_in: 3
            action:
              name: reject
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
@@ -73,6 +73,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -215,15 +223,6 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
@@ -223,7 +223,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
@@ -217,5 +217,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
@@ -73,6 +73,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -216,15 +224,6 @@
            - variable:
                name: TempObsErrorData/specificHumidity
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
@@ -224,7 +224,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
@@ -218,5 +218,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
@@ -259,7 +259,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
@@ -250,5 +250,17 @@
              name: reject
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/adpupa_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
@@ -81,6 +81,17 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -248,18 +259,6 @@
              is_in: 3
            action:
              name: reject
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
@@ -204,7 +204,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -196,15 +204,6 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
@@ -198,5 +198,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircar_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -197,15 +205,6 @@
            - variable:
                name: TempObsErrorData/specificHumidity
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
@@ -199,5 +199,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircar_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
@@ -205,7 +205,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
@@ -219,5 +219,17 @@
              name: reject
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircar_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
@@ -228,7 +228,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
@@ -80,6 +80,17 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -217,18 +228,6 @@
              is_in: 3
            action:
              name: reject
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
@@ -204,7 +204,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -196,15 +204,6 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
@@ -198,5 +198,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
@@ -197,5 +197,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
@@ -203,7 +203,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -85,6 +93,7 @@
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [1.3385, 1.219, 1.0515, 0.8746, 0.73725, 0.66965, 0.66362, 0.66525, 0.65262, 0.63131, 0.59435, 0.54816, 0.51139, 0.49975, 0.51952, 0.59104, 0.71862, 0.85608, 0.95397, 1.0002, 1.0124, 1.0103, 1.0055, 1.0021, 1.0005, 1.0, 0.9999, 0.99991, 0.99994, 1.0, 1.0002, 0.99994, 0.99744]
+
          # Error inflation based on pressure check (setupt.f90)
          - filter: Perform Action
            filter variables:
@@ -195,15 +204,6 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
@@ -204,7 +204,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -196,15 +204,6 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
@@ -198,5 +198,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
@@ -204,7 +204,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -196,15 +204,6 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
@@ -198,5 +198,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -197,15 +205,6 @@
            - variable:
                name: TempObsErrorData/specificHumidity
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
@@ -205,7 +205,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
@@ -199,5 +199,14 @@
              value: is_valid
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
@@ -219,5 +219,17 @@
              name: reject
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
@@ -228,7 +228,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
@@ -80,6 +80,17 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -217,18 +228,6 @@
              is_in: 3
            action:
              name: reject
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
@@ -219,5 +219,17 @@
              name: reject
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
@@ -228,7 +228,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
@@ -80,6 +80,17 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -217,18 +228,6 @@
              is_in: 3
            action:
              name: reject
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
@@ -219,5 +219,17 @@
              name: reject
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
@@ -228,7 +228,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
@@ -80,6 +80,17 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -217,18 +228,6 @@
              is_in: 3
            action:
              name: reject
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
@@ -219,5 +219,17 @@
              name: reject
            defer to post: true
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: "MetaData/longitude_latitude_pressure"
+           defer to post: true
+
          #- filter: GOMsaver
          #  filename: ./data/geovals/aircft_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
@@ -228,7 +228,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
@@ -80,6 +80,17 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -217,18 +228,6 @@
              is_in: 3
            action:
              name: reject
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
@@ -204,7 +204,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -196,15 +204,6 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
@@ -201,10 +201,10 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT15M
-           seed_time: *analysisDate
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: MetaData/stationIdentification
+             name: "MetaData/longitude_latitude_pressure"
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
@@ -206,7 +206,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
@@ -69,6 +69,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -198,15 +206,6 @@
            - variable:
                name: TempObsErrorData/specificHumidity
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
@@ -203,10 +203,10 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT15M
-           seed_time: *analysisDate
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: MetaData/stationIdentification
+             name: "MetaData/longitude_latitude_pressure"
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
@@ -63,6 +63,14 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -190,15 +198,6 @@
            - variable:
                name: TempObsErrorData/stationPressure
              value: is_valid
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
@@ -198,7 +198,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
@@ -195,10 +195,10 @@
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           min_spacing: PT15M
-           seed_time: *analysisDate
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: MetaData/stationIdentification
+             name: "MetaData/longitude_latitude_pressure"
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
@@ -540,7 +540,7 @@
            min_spacing: PT90M
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: "MetaData/longitude_latitude_pressure"
+             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
@@ -537,10 +537,10 @@
            filter variables:
            - name: windEastward
            - name: windNorthward
-           min_spacing: PT15M
-           seed_time: *analysisDate
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
            category_variable:
-             name: MetaData/stationIdentification
+             name: "MetaData/longitude_latitude_pressure"
            defer to post: true
 
          #- filter: GOMsaver

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
@@ -386,6 +386,17 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+
          # Initial error assignment
          - filter: Perform Action
            filter variables:
@@ -529,18 +540,6 @@
              is_in: 3
            action:
              name: reject
-           defer to post: true
-
-         # Duplicate Check
-         - filter: Temporal Thinning
-           apply at iterations: 0,1
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           min_spacing: PT90M
-           seed_time: "2024-05-27T00:00:00Z"
-           category_variable:
-             name: MetaData/longitude_latitude_pressure
            defer to post: true
 
          #- filter: GOMsaver


### PR DESCRIPTION
## Bug Fix Description

**Description of Current Behavior:**
1. The Temporal Thinning filter had previously been configured using `category_variable.name: MetaData/stationIdentification`.
2. It actually isn't clear what that filter was doing and it often produced strange results.

**Description of Fixed Behavior:**
1. A new variable is added to IODA in an offline tool which is provided in this PR. The offline tool is only a temporary solution and the best place to put this will likely be in a python converter. This tool is based on the offline domain check.
2. The new variable `MetaData/longitude_latitude_pressure` is now used as the `category variable` to check for duplicate obs matching the functionality that is in GSI using `l_closeobs` option.

## Issue(s) addressed

- Resolves Issue https://github.com/NOAA-EMC/RDASApp/issues/258

## Additional Info
To run the offline add variable to ioda tool use the command below.
```bash
python ../offline_add_var_to_ioda.py -o $ioda_file
```
The code creates a copy of the IODA with the additional variable. The final ioda will end in `_llp.nc` or `_llp.nc4`.

## Checklist
- [x] I have performed a self-review of my own code.
