### PR TITLE
update the MPAS model to the latest gsl/develop version v8.2.2-2.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,8 +65,8 @@
 	ignore = all
 [submodule "sorc/mpas"]
 	path = sorc/mpas
-	url = https://github.com/MPAS-Dev/MPAS-Model
-	branch = release-stable 
+	url = https://github.com/NOAA-GSL/MPAS-Model
+	branch = gsl/develop
 	ignore = all
 [submodule "sorc/mpas-jedi"]
 	path = sorc/mpas-jedi

--- a/build.sh
+++ b/build.sh
@@ -147,6 +147,8 @@ if [[ $DYCORE == 'MPAS' || $DYCORE == 'FV3andMPAS' ]]; then
   $dir_root/rrfs-test/scripts/link_fv3jedi_expr.sh
 fi
 
+# tweak sorc/mpas/src/core_init_atmosphere/mpas_init_atm_cases.F to make building work
+sed -i -e "5549 s/.*/call mpas_log_write('Interpolating SOILM000')/" sorc/mpas/src/core_init_atmosphere/mpas_init_atm_cases.F
 CMAKE_OPTS+=" -DMPIEXEC_MAX_NUMPROCS:STRING=120 -DBUILD_SUPER_EXE=$BUILD_SUPER_EXE"
 # Configure
 echo "Configuring ..."

--- a/build.sh
+++ b/build.sh
@@ -92,6 +92,9 @@ case ${BUILD_TARGET} in
     ;;
 esac
 
+# tweak sorc/mpas/src/core_init_atmosphere/mpas_init_atm_cases.F to make building work
+sed -i -e "5549 s/.*/call mpas_log_write('Interpolating SOILM000')/" sorc/mpas/src/core_init_atmosphere/mpas_init_atm_cases.F
+
 # Set default number of build jobs based on machine
 if [[ $BUILD_TARGET == 'orion' ]]; then # lower due to memory limit on login nodes
   BUILD_JOBS=${BUILD_JOBS:-4}
@@ -147,8 +150,6 @@ if [[ $DYCORE == 'MPAS' || $DYCORE == 'FV3andMPAS' ]]; then
   $dir_root/rrfs-test/scripts/link_fv3jedi_expr.sh
 fi
 
-# tweak sorc/mpas/src/core_init_atmosphere/mpas_init_atm_cases.F to make building work
-sed -i -e "5549 s/.*/call mpas_log_write('Interpolating SOILM000')/" sorc/mpas/src/core_init_atmosphere/mpas_init_atm_cases.F
 CMAKE_OPTS+=" -DMPIEXEC_MAX_NUMPROCS:STRING=120 -DBUILD_SUPER_EXE=$BUILD_SUPER_EXE"
 # Configure
 echo "Configuring ..."


### PR DESCRIPTION
The rrfs-workflow needs the latest GSL MPAS version to run JEDIVAR correctly.