### PR TITLE
Ioda-converters YAML and Python script for the [3D]-RTMA/URMA SATMAR data

### DIFF
--- a/rrfs-test/IODA/python/bufr2ioda_satmar.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satmar.json
@@ -5,8 +5,7 @@
     "cycle_datetime": "{{ current_cycle | to_YMDH }}",
     "dump_directory": "{{ DMPDIR }}",
     "ioda_directory": "{{ COM_OBS }}",
-    "subsets": [ "NC031122" ],
-    #"subsets": [ "NC031104", "NC0311064", "NC031110", "NC031112", "NC031113", "NC031114", "NC031115", "NC031117", "NC031118", "NC031119", "NC031120", "NC031121", "NC031122", "NC031123", "NC031124", "NC031125", "NC031126", "NC031127", "NC031130" ]
+    "subsets": [ "NC031104", "NC0311064", "NC031110", "NC031112", "NC031113", "NC031114", "NC031115", "NC031117", "NC031118", "NC031119", "NC031120", "NC031121", "NC031122", "NC031123", "NC031124", "NC031125", "NC031126", "NC031127", "NC031130" ]
     "source": "NCEP data tank",
     "data_provider": "U.S. NOAA",
     "data_description": "CNES CRYOSAT-2 OGDR ALTM SSHA W/W H-RS GBL",

--- a/rrfs-test/IODA/python/bufr2ioda_satmar.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satmar.json
@@ -1,0 +1,13 @@
+{
+    "data_format": "bufr_d",
+    "data_type": "satmar",
+    "cycle_type": "urma",
+    "cycle_datetime": "{{ current_cycle | to_YMDH }}",
+    "dump_directory": "{{ DMPDIR }}",
+    "ioda_directory": "{{ COM_OBS }}",
+    "subsets": [ "NC031122" ],
+    #"subsets": [ "NC031104", "NC0311064", "NC031110", "NC031112", "NC031113", "NC031114", "NC031115", "NC031117", "NC031118", "NC031119", "NC031120", "NC031121", "NC031122", "NC031123", "NC031124", "NC031125", "NC031126", "NC031127", "NC031130" ]
+    "source": "NCEP data tank",
+    "data_provider": "U.S. NOAA",
+    "data_description": "CNES CRYOSAT-2 OGDR ALTM SSHA W/W H-RS GBL",
+}

--- a/rrfs-test/IODA/python/bufr2ioda_satmar.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satmar.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+import sys
+import argparse
+import numpy as np
+import numpy.ma as ma
+import calendar
+import json
+import time
+import copy
+import math
+import datetime
+import os
+from datetime import datetime
+from pyioda import ioda_obs_space as ioda_ospace
+from wxflow import Logger
+from pyiodaconv import bufr
+from collections import namedtuple
+import warnings
+# suppress warnings
+warnings.filterwarnings('ignore')
+
+
+def Mask_typ_for_var(typ, var):
+
+    typ_var = copy.deepcopy(typ)
+    for i in range(len(typ_var)):
+        if ma.is_masked(var[i]):
+            typ_var[i] = typ.fill_value
+
+    return typ_var
+
+
+def bufr_to_ioda(config, logger):
+
+    subsets = config["subsets"]
+    logger.debug(f"Checking subsets = {subsets}")
+
+    # Get parameters from configuration
+    data_format = config["data_format"]
+    data_type = config["data_type"]
+    data_description = config["data_description"]
+    data_provider = config["data_provider"]
+    cycle_type = config["cycle_type"]
+    dump_dir = config["dump_directory"]
+    ioda_dir = config["ioda_directory"]
+    cycle = config["cycle_datetime"]
+
+    # Get derived parameters
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+    reference_time = datetime.strptime(cycle, "%Y%m%d%H")
+    reference_time = reference_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # General informaton
+    converter = 'BUFR to IODA Converter'
+    platform_description = 'SATMAR'
+
+    logger.info(f"reference_time = {reference_time}")
+
+    bufrfile = f"{cycle_type}.t{hh}z.{data_type}.tm00.{data_format}"
+    DATA_PATH = os.path.join(dump_dir, bufrfile)
+    if not os.path.isfile(DATA_PATH):
+        logger.info(f"DATA_PATH {DATA_PATH} does not exist")
+        return
+    logger.debug(f"The DATA_PATH is: {DATA_PATH}")
+
+    # ============================================
+    # Make the QuerySet for all the data we want
+    # ============================================
+    start_time = time.time()
+
+    logger.info('Making QuerySet')
+    q = bufr.QuerySet(subsets)
+
+    # ObsType
+    #q.add('observationType', '*/TYP')
+
+    # MetaData
+    q.add('year', '*/YEAR')
+    q.add('month', '*/MNTH')
+    q.add('day', '*/DAYS')
+    q.add('hour', '*/HOUR')
+    q.add('minute', '*/MINU')
+    q.add('second', '*/SECO')
+    # MetaData/Receipt Time
+    q.add('receiptYear', '*/RCYR')
+    q.add('receiptMonth', '*/RCMO')
+    q.add('receiptDay', '*/RCDY')
+    q.add('receiptHour', '*/RCHR')
+    q.add('receiptMinute', '*/RCMI')
+    q.add('latitude', '*/CLATH')
+    q.add('longitude', '*/CLONH')
+    q.add('satelliteIdentifier', '*/SAID')
+    q.add('height', '*/ALTPE')
+
+    # ObsValue
+    q.add('brightnessTemperature', '*/TMBRST')
+    q.add('windSpeed', '*/WSPA')
+    q.add('heightOfWaves', '*/HOWV')
+    q.add('windEastward', '*/UMWV')
+    q.add('windNorthward', '*/VWMV')
+
+    # QualityMarker
+    #q.add('windAlongRadialLineQM', '*/QCRW')
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.debug(f'Running time for making QuerySet : {running_time} seconds')
+
+    # ==============================================================
+    # Open the BUFR file and execute the QuerySet to get ResultSet
+    # Use the ResultSet returned to get numpy arrays of the data
+    # ==============================================================
+    start_time = time.time()
+
+    logger.info('Executing QuerySet to get ResultSet')
+    with bufr.File(DATA_PATH) as f:
+        try:
+            r = f.execute(q)
+        except Exception as err:
+            logger.info(f'Return with {err}')
+            return
+
+    # ObsType
+    logger.debug(" ... Executing QuerySet for LGYCLD: get ObsType ...")
+    #obstyp = r.get('observationType', type='int32')
+    logger.info('Executing QuerySet: get metadata')
+
+    # MetaData
+    clath = r.get('latitude')
+    clonh = r.get('longitude')
+    said = r.get('satelliteIdentifier')
+    altpe = r.get('height')
+
+    # MetaData/Observation Time
+    year = r.get('year')
+    month = r.get('month')
+    day = r.get('day')
+    hour = r.get('hour')
+    minute = r.get('minute')
+    second = r.get('second')
+    # DateTime: seconds since Epoch time
+    # IODA has no support for numpy datetime arrays dtype=datetime64[s]
+    timestamp = r.get_datetime('year', 'month', 'day', 'hour', 'minute', 'second').astype(np.int64)
+    int64_fill_value = np.int64(0)
+    timestamp = ma.array(timestamp)
+    timestamp = ma.masked_values(timestamp, int64_fill_value)
+
+    # MetaData/Receipt Time
+    receiptYear = r.get('receiptYear')
+    receiptMonth = r.get('receiptMonth')
+    receiptDay = r.get('receiptDay')
+    receiptHour = r.get('receiptHour')
+    receiptMinute = r.get('receiptMinute')
+    logger.debug(f" ... Executing QuerySet: get datatime: receipt time ...")
+    receipttime = r.get_datetime('receiptYear', 'receiptMonth', 'receiptDay', 'receiptHour', 'receiptMinute').astype(np.int64)
+    int64_fill_value = np.int64(0)
+    receipttime = ma.array(receipttime)
+    receipttime = ma.masked_values(receipttime, int64_fill_value)
+
+    # ObsValue
+    tmbrst  = r.get('brightnessTemperature')
+    wspa    = r.get('windSpeed')
+    howv    = r.get('heightOfWaves')
+    umwv    = r.get('windEastward')
+    vwmv    = r.get('windNorthward')
+
+
+    # QualityMarker
+    #qcrw    = r.get('windAlongRadialLineQM')
+
+    logger.info('Executing QuerySet Done!')
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Running time for executing QuerySet to get ResultSet : {running_time} seconds")
+
+    logger.debug('Executing QuerySet: Check BUFR variable generic dimension and type')
+    # Check BUFR variable generic dimension and type
+    logger.debug(f'     clath         shape = {clath.shape}')
+    logger.debug(f'     clonh         shape = {clonh.shape}')
+    logger.debug(f'     said          shape = {said.shape}')
+    logger.debug(f'     altpe         shape = {altpe.shape}')
+
+    logger.debug(f'     rcyr          shape = {receiptYear.shape}')
+    logger.debug(f'     rcmo          shape = {receiptMonth.shape}')
+    logger.debug(f'     rcdy          shape = {receiptDay.shape}')
+    logger.debug(f'     rchr          shape = {receiptHour.shape}')
+    logger.debug(f'     rcmi          shape = {receiptMinute.shape}')
+
+    logger.debug(f'     tmbrst        shape = {tmbrst.shape}')
+    logger.debug(f'     wspa      	  shape = {wspa.shape}')
+    logger.debug(f'     howv      	  shape = {howv.shape}')
+    logger.debug(f'     umwv      	  shape = {umwv.shape}')
+    logger.debug(f'     vwmv      	  shape = {vwmv.shape}')
+
+    #logger.debug(f'     qcrw      	  shape = {qcrw.shape}')
+
+    logger.debug(f'     clath         type = {clath.dtype}')
+    logger.debug(f'     clonh         type = {clonh.dtype}')
+    logger.debug(f'     said          type = {said.dtype}')
+    logger.debug(f'     altpe         type = {altpe.dtype}')
+
+    logger.debug(f'     rcyr          type  = {receiptYear.dtype}')
+    logger.debug(f'     rcmo          type  = {receiptMonth.dtype}')
+    logger.debug(f'     rcdy          type  = {receiptDay.dtype}')
+    logger.debug(f'     rchr          type  = {receiptHour.dtype}')
+    logger.debug(f'     rcmi          type  = {receiptMinute.dtype}')
+
+    logger.debug(f'     tmbrst        type = {tmbrst.dtype}')
+    logger.debug(f'     wspa          type = {wspa.dtype}')
+    logger.debug(f'     howv          type = {howv.dtype}')
+    logger.debug(f'     umwv          type = {umwv.dtype}')
+    logger.debug(f'     vwmv          type = {vwmv.dtype}')
+
+    #logger.debug(f'     qcrw         type = {qcrw.dtype}')
+
+    # Mask Certain Variables
+    logger.debug(f"Mask typ for certain variables where data is available...")
+
+    # =====================================
+    # Create IODA ObsSpace
+    # Write IODA output
+    # =====================================
+
+    # Create the dimensions
+    dims = {'Location': np.arange(0, clath.shape[0])}
+
+    # Create IODA ObsSpace
+    iodafile = f"{cycle_type}.t{hh}z.{data_type}.tm00.api.nc"
+    OUTPUT_PATH = os.path.join(ioda_dir, iodafile)
+    logger.info(f"Create output file: {OUTPUT_PATH}")
+    obsspace = ioda_ospace.ObsSpace(OUTPUT_PATH, mode='w', dim_dict=dims)
+
+    # Create Global attributes
+    logger.debug(' ... ... Create global attributes')
+    obsspace.write_attr('sourceFiles', bufrfile)
+    obsspace.write_attr('description', data_description)
+
+    # Create IODA variables
+    logger.debug(' ... ... Create variables: name, type, units, and attributes')
+
+    # MetaData: Datetime
+    obsspace.create_var('MetaData/dateTime', dtype=timestamp.dtype, fillval=timestamp.fill_value) \
+        .write_attr('units', 'seconds since 1970-01-01T00:00:00Z') \
+        .write_attr('long_name', 'Datetime') \
+        .write_data(timestamp)
+
+    # MetaData: ReceiptTime
+    obsspace.create_var('MetaData/receiptTime', dtype=timestamp.dtype, fillval=timestamp.fill_value) \
+        .write_attr('units', 'seconds since 1970-01-01T00:00:00Z') \
+        .write_attr('long_name', 'Receipt Time') \
+        .write_data(receipttime)
+
+    # MetaData: Latitude
+    obsspace.create_var('MetaData/latitude', dtype=clath.dtype, fillval=clath.fill_value) \
+        .write_attr('units', 'degrees_north') \
+        .write_attr('valid_range', np.array([-90, 90], dtype=np.float32)) \
+        .write_attr('long_name', 'Latitude') \
+        .write_data(clath)
+
+    # MetaData: Longitude
+    obsspace.create_var('MetaData/longitude', dtype=clonh.dtype, fillval=clonh.fill_value) \
+        .write_attr('units', 'degrees_east') \
+        .write_attr('valid_range', np.array([-180, 180], dtype=np.float32)) \
+        .write_attr('long_name', 'Longitude') \
+        .write_data(clonh)
+
+    # MetaData: Satellite Identifier
+    obsspace.create_var('MetaData/satelliteIdentifier', dtype=said.dtype, fillval=said.fill_value) \
+        .write_attr('long_name', 'Satellite Identifier') \
+        .write_data(said)
+
+    # MetaData: Height
+    obsspace.create_var('MetaData/height', dtype=altpe.dtype, fillval=altpe.fill_value) \
+        .write_attr('units', 'm') \
+        .write_attr('long_name', 'Altitude (Platform to Ellipsoid)') \
+        .write_data(altpe)    
+
+    # ObsValue: Brightness Temperature 
+    obsspace.create_var('ObsValue/brightnessTemperature', dtype=tmbrst.dtype, fillval=tmbrst.fill_value) \
+        .write_attr('units', 'K') \
+        .write_attr('long_name', 'Brightness temperature') \
+        .write_data(tmbrst)
+
+    # ObsValue: Wind Speed
+    obsspace.create_var('ObsValue/windSpeed', dtype=wspa.dtype, fillval=wspa.fill_value) \
+        .write_attr('units', 'm s-1') \
+        .write_attr('long_name', 'Wind Speed') \
+        .write_data(wspa)
+
+    # ObsValue: Height Of Waves
+    obsspace.create_var('ObsValue/heightOfWaves', dtype=howv.dtype, fillval=howv.fill_value) \
+        .write_attr('units', 'm') \
+        .write_attr('long_name', 'Height Of Waves') \
+        .write_data(howv)
+
+    # ObsValue: Eastward Wind
+    obsspace.create_var('ObsValue/windEastward', dtype=umwv.dtype, fillval=umwv.fill_value) \
+        .write_attr('units', 'm s-1') \
+        .write_attr('long_name', 'Eastward Wind') \
+        .write_data(umwv)
+
+    # ObsValue: Northward Wind
+    obsspace.create_var('ObsValue/windNorthward', dtype=vwmv.dtype, fillval=vwmv.fill_value) \
+        .write_attr('units', 'm s-1') \
+        .write_attr('long_name', 'Northward Wind') \
+        .write_data(vwmv)
+
+    # QualityMarker: Wind Along Radial Line Quality
+    #obsspace.create_var('QlalityMarker/windAlongRadialLineQM', dtype=qcrw.dtype, fillval=qcrw.fill_value) \
+    #    .write_attr('units', '') \
+    #    .write_attr('long_name', 'windAlongRadialLineQM') \
+    #    .write_data(qcrw)
+
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Running time for splitting and output IODA: {running_time} seconds")
+
+    logger.info("All Done!")
+
+
+if __name__ == '__main__':
+
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, help='Input JSON configuration', required=True)
+    parser.add_argument('-v', '--verbose', help='print debug logging information',
+                        action='store_true')
+    args = parser.parse_args()
+
+    log_level = 'DEBUG' if args.verbose else 'INFO'
+    logger = Logger('BUFR2IODA_satmar.py', level=log_level, colored_log=True)
+
+    with open(args.config, "r") as json_file:
+        config = json.load(json_file)
+
+    bufr_to_ioda(config, logger)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Total running time: {running_time} seconds")

--- a/rrfs-test/IODA/python/bufr2ioda_satmar.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satmar.py
@@ -77,9 +77,6 @@ def bufr_to_ioda(config, logger):
     logger.info('Making QuerySet')
     q = bufr.QuerySet(subsets)
 
-    # ObsType
-    #q.add('observationType', '*/TYP')
-
     # MetaData
     q.add('year', '*/YEAR')
     q.add('month', '*/MNTH')
@@ -105,9 +102,6 @@ def bufr_to_ioda(config, logger):
     q.add('windEastward', '*/UMWV')
     q.add('windNorthward', '*/VWMV')
 
-    # QualityMarker
-    #q.add('windAlongRadialLineQM', '*/QCRW')
-
     end_time = time.time()
     running_time = end_time - start_time
     logger.debug(f'Running time for making QuerySet : {running_time} seconds')
@@ -128,7 +122,6 @@ def bufr_to_ioda(config, logger):
 
     # ObsType
     logger.debug(" ... Executing QuerySet for LGYCLD: get ObsType ...")
-    #obstyp = r.get('observationType', type='int32')
     logger.info('Executing QuerySet: get metadata')
 
     # MetaData
@@ -170,10 +163,6 @@ def bufr_to_ioda(config, logger):
     umwv    = r.get('windEastward')
     vwmv    = r.get('windNorthward')
 
-
-    # QualityMarker
-    #qcrw    = r.get('windAlongRadialLineQM')
-
     logger.info('Executing QuerySet Done!')
     end_time = time.time()
     running_time = end_time - start_time
@@ -198,8 +187,6 @@ def bufr_to_ioda(config, logger):
     logger.debug(f'     umwv      	  shape = {umwv.shape}')
     logger.debug(f'     vwmv      	  shape = {vwmv.shape}')
 
-    #logger.debug(f'     qcrw      	  shape = {qcrw.shape}')
-
     logger.debug(f'     clath         type = {clath.dtype}')
     logger.debug(f'     clonh         type = {clonh.dtype}')
     logger.debug(f'     said          type = {said.dtype}')
@@ -216,8 +203,6 @@ def bufr_to_ioda(config, logger):
     logger.debug(f'     howv          type = {howv.dtype}')
     logger.debug(f'     umwv          type = {umwv.dtype}')
     logger.debug(f'     vwmv          type = {vwmv.dtype}')
-
-    #logger.debug(f'     qcrw         type = {qcrw.dtype}')
 
     # Mask Certain Variables
     logger.debug(f"Mask typ for certain variables where data is available...")
@@ -310,13 +295,6 @@ def bufr_to_ioda(config, logger):
         .write_attr('units', 'm s-1') \
         .write_attr('long_name', 'Northward Wind') \
         .write_data(vwmv)
-
-    # QualityMarker: Wind Along Radial Line Quality
-    #obsspace.create_var('QlalityMarker/windAlongRadialLineQM', dtype=qcrw.dtype, fillval=qcrw.fill_value) \
-    #    .write_attr('units', '') \
-    #    .write_attr('long_name', 'windAlongRadialLineQM') \
-    #    .write_data(qcrw)
-
 
     end_time = time.time()
     running_time = end_time - start_time

--- a/rrfs-test/IODA/yaml/bufr_ncep_satmar.yaml
+++ b/rrfs-test/IODA/yaml/bufr_ncep_satmar.yaml
@@ -1,0 +1,137 @@
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "/work2/noaa/da/pkumar/ORION/RDASApp/urma.t00z.satmar.tm00.bufr_d"
+        #obsdatain: "./testinput_satmar/urma.t00z.satmar.tm00.bufr_d"
+
+      exports:
+        subsets:
+          - NC031122
+        variables:
+          # MetaData
+          timestamp:
+            datetime:
+              year: "*/YEAR"
+              month: "*/MNTH"
+              day: "*/DAYS"
+              hour: "*/HOUR"
+              minute: "*/MINU"
+              second: "*/SECO"
+          receipttime:
+            datetime:
+              year: "*/RCYR"
+              month: "*/RCMO"
+              day: "*/RCDY"
+              hour: "*/RCHR"
+              minute: "*/RCMI"
+          longitude:
+            query: "[*/CLON, */CLONH]"
+          latitude:
+            query: "[*/CLAT, */CLATH]"
+          satelliteIdentifier:
+            query: "*/SAID"
+          height: 
+            query: "*/ALTPE"
+
+          # ObsValue
+          brightnessTemperature:
+            query: "*/TMBRST"
+          windSpeed:
+            query: "*/WSPA"
+          heightOfWaves: 
+            query: "*/HOWV"
+          windEastward:
+            query: "*/UMWV"
+          windNorthward:
+            query: "*/VWMV"    
+          
+          # QualityMarker 
+          #windAlongRadialLineQM: 
+          #query: "*/QCRW"
+
+    ioda:
+      backend: netcdf
+      obsdataout: "/work2/noaa/da/pkumar/ORION/RDASApp/urma.t00z.satmar.tm00.nc"
+      #obsdataout: "./urma.t00z.satmar.tm00.nc"
+
+      variables:
+        # MetaData
+        - name: "MetaData/dateTime"
+          coordinates: "longitude latitude"
+          source: variables/timestamp
+          longName: "Datetime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/dataReceiptTime"
+          coordinates: "longitude latitude"
+          source: variables/receipttime
+          longName: "Data Receipt Time"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "MetaData/latitude"
+          coordinates: "longitude latitude"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degree_north"
+          range: [-90, 90]
+
+        - name: "MetaData/longitude"
+          coordinates: "longitude latitude"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degree_east"
+          range: [-180, 180]
+
+        - name: "MetaData/satelliteIdentifier"
+          coordinates: "longitude latitude"
+          source: variables/satelliteIdentifier
+          longName: "Satellite Identifier"
+
+        - name: "MetaData/height"
+          coordinates: "longitude latitude"
+          source: variables/height
+          longName: "Altitude (Platform to Ellipsoid)"
+          units: "m"
+
+        # ObsValue
+        - name: "ObsValue/brightnessTemperature"
+          coordinates: "longitude latitude Channel"
+          source: variables/brightnessTemperature
+          longName: "Brightness temperature"
+          units: "K"
+
+        - name: "ObsValue/windSpeed"
+          coordinates: "longitude latitude"
+          source: variables/windSpeed
+          longName: "Wind Speed from Altimeter"
+          units: "m s-1"
+
+        - name: "ObsValue/heightOfWaves"
+          coordinates: "longitude latitude"
+          source: variables/heightOfWaves
+          longName: "Height Of Waves"
+          units: "m"
+
+        - name: "ObsValue/windEastward"
+          coordinates: "longitude latitude"
+          source: variables/windEastward
+          longName: "Eastward Wind"
+          units: "m s-1"
+
+        - name: "ObsValue/windNorthward"
+          coordinates: "longitude latitude"
+          source: variables/windNorthward
+          longName: "Northward Wind"
+          units: "m s-1"
+
+        # QualityMarker
+        #- name: "QualityMarker/unfoldingVelocity"
+        #coordinates: "longitude latitude"
+        #source: variables/windAlongRadialLineQM
+        #longName: "Quality Marker For Wind Along Radial Line"

--- a/rrfs-test/IODA/yaml/bufr_ncep_satmar.yaml
+++ b/rrfs-test/IODA/yaml/bufr_ncep_satmar.yaml
@@ -6,9 +6,7 @@
 observations:
   - obs space:
       name: bufr
-
-      obsdatain: "/work2/noaa/da/pkumar/ORION/RDASApp/urma.t00z.satmar.tm00.bufr_d"
-        #obsdatain: "./testinput_satmar/urma.t00z.satmar.tm00.bufr_d"
+      obsdatain: "./testinput_satmar/urma.t00z.satmar.tm00.bufr_d"
 
       exports:
         subsets:
@@ -50,15 +48,11 @@ observations:
             query: "*/UMWV"
           windNorthward:
             query: "*/VWMV"    
-          
-          # QualityMarker 
-          #windAlongRadialLineQM: 
-          #query: "*/QCRW"
+
 
     ioda:
       backend: netcdf
-      obsdataout: "/work2/noaa/da/pkumar/ORION/RDASApp/urma.t00z.satmar.tm00.nc"
-      #obsdataout: "./urma.t00z.satmar.tm00.nc"
+      obsdataout: "./urma.t00z.satmar.tm00.nc"
 
       variables:
         # MetaData
@@ -129,9 +123,3 @@ observations:
           source: variables/windNorthward
           longName: "Northward Wind"
           units: "m s-1"
-
-        # QualityMarker
-        #- name: "QualityMarker/unfoldingVelocity"
-        #coordinates: "longitude latitude"
-        #source: variables/windAlongRadialLineQM
-        #longName: "Quality Marker For Wind Along Radial Line"


### PR DESCRIPTION
- This PR adds an ioda-converters YAML and Python script for SATMAR BUFR DUMP data.

- These converters can be be used to transform SATMAR BUFR data into IODA (netCDF) format.

- The following three files are new:

1. ~/IODA/yaml/bufr_ncep_satmar.yaml
2. ~/IODA/python/bufr2ioda_satmar.py
3. ~/IODA/python/bufr2ioda_satmar.json

- Validation for the output observation and IODA variable naming has been performed. ioda-converters:  https://github.com/JCSDA-internal/ioda-converters/issues/1596

- A few basic mnemonics/variables were included into the converters, users can add more variables as needed.