### PR TITLE
Phase 1 validation: sfcshp (182/282) yamls

### DIFF
--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
@@ -55,8 +55,9 @@
            where:
            - variable: QualityMarker/airTemperature
              is_in: 4-15
+           - variable: QualityMarker/airTemperature
              value: is_not_valid
-             where operator: or
+           where operator: or
            action:
              name: reject
              name: reduce obs space

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
@@ -1,0 +1,275 @@
+     - obs space:
+         name: sfcshp_airTemperature_182
+         distribution:
+           name: "@DISTRIBUTION@"
+           halo size: 300e3
+         obsdatain:
+           engine:
+             type: H5File
+             #obsfile: "data/obs/ioda_sfcshp.nc"
+             obsfile: "obsout/sfcship_tsen_obs_2024052700_dc.nc4"
+           obsgrouping:
+             group variables: ["stationIdentification"]
+             sort variable: "pressure"
+             sort order: "descending"
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: jdiag_sfcshp_airTemperature_182.nc4
+             allow overwrite: true
+         io pool:
+           max pool size: 1
+         observed variables: [airTemperature]
+         simulated variables: [airTemperature]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           #gsi geovals:
+           #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+           #  levels_are_top_down: False
+           variables:
+           - name: airTemperature
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 300e3 # orig
+
+       obs filters:
+         # ------------------
+         # airTemperature (182)
+         # ------------------
+         # Reject all obs with QualityMarker > 3
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: airTemperature
+           where:
+           - variable: QualityMarker/airTemperature
+             is_in: 4-15
+           action:
+             name: reject
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Domain Check
+           apply at iterations: 0,1
+           where:
+             - variable:
+                 name: MetaData/timeOffset # units: s
+               minvalue: -5400
+               maxvalue:  5400
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: airTemperature
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           action:
+             name: reduce obs space
+
+         # Online regional domain check
+         - filter: Bounds Check
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           where:
+           - variable: ObsType/airTemperature
+             is_in: 182
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054]
+
+         # Error inflation based on pressure check (setupt.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           where:
+           - variable: ObsType/airTemperature
+             is_in: 182
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: airTemperature
+                 inflation factor: 8.0
+
+#         # Error inflation based on errormod (qcmod.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: airTemperature
+#           where:
+#           - variable: ObsType/airTemperature
+#             is_in: 182
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorConventional
+#               options:
+#                 inflate variables: [airTemperature]
+#                 pressure: MetaData/pressure
+
+         # Error inflation when QualityMarker == 3 (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: QualityMarker/airTemperature
+             is_in: 3
+
+         # Error inflation when observation pressure < 100 hPa (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 10000.0
+
+         # Bounds Check (ObsError)
+         - filter: Bounds Check
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name:  ObsErrorData/airTemperature
+           minvalue: 0.0
+           action:
+             name: reduce obs space
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           filter variables:
+           - name: airTemperature
+           minvalue: 100
+           maxvalue: 400
+           action:
+             name: reduce obs space
+
+         # Create temporary ObsErrorData
+         - filter: Variable Assignment
+           apply at iterations: 0,1
+           assignments:
+           - name: TempObsErrorData/airTemperature
+             type: float
+             function:
+               name: ObsFunction/Arithmetic
+               options:
+                 variables:
+                 - name: ObsErrorData/airTemperature
+           defer to post: true
+
+         # Set ObsError set "error parameter" if < "max value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: airTemperature
+           action:
+             name: assign error
+             error parameter: 1.0
+           where:
+           - variable:
+               name: ObsErrorData/airTemperature
+             maxvalue: 1.0
+           - variable:
+               name: ObsErrorData/airTemperature
+             value: is_valid
+           defer to post: true
+
+         # Set ObsError set "error parameter" if > "min value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: airTemperature
+           action:
+             name: assign error
+             error parameter: 3.0
+           where:
+           - variable:
+               name: ObsErrorData/airTemperature
+             minvalue: 3.0
+           - variable:
+               name: ObsErrorData/airTemperature
+             value: is_valid
+           defer to post: true
+
+         # Gross Error Check
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: airTemperature
+           threshold: 5.0
+           action:
+             name: reject
+           where:
+           - variable: ObsType/airTemperature
+           - variable: QualityMarker/airTemperature
+             is_not_in: 3
+           defer to post: true
+
+         # Gross Error Check: cgross*0.7 if QualityMarker=3
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: airTemperature
+           threshold: 3.5
+           action:
+             name: reject
+           where:
+           - variable: ObsType/airTemperature
+           - variable: QualityMarker/airTemperature
+             is_in: 3
+           defer to post: true
+
+         # Re-assign err ObsErrorData <--- TempObsErrorData after gross error check.
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: airTemperature
+           action:
+             name: assign error
+             error function: TempObsErrorData/airTemperature
+           where:
+           - variable:
+               name: TempObsErrorData/airTemperature
+             value: is_valid
+           defer to post: true
+
+         #- filter: GOMsaver
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
@@ -55,9 +55,10 @@
            where:
            - variable: QualityMarker/airTemperature
              is_in: 4-15
+             value: is_not_valid
+             where operator: or
            action:
              name: reject
-           action:
              name: reduce obs space
 
          # Time window filter

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
@@ -55,7 +55,6 @@
            where:
            - variable: QualityMarker/airTemperature
              is_in: 4-15
-           - variable: QualityMarker/airTemperature
              value: is_not_valid
            where operator: or
            action:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
@@ -6,8 +6,7 @@
          obsdatain:
            engine:
              type: H5File
-             #obsfile: "data/obs/ioda_sfcshp.nc"
-             obsfile: "obsout/sfcship_tsen_obs_2024052700_dc.nc4"
+             obsfile: "data/obs/ioda_sfcshp.nc"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
@@ -55,9 +55,10 @@
            where:
            - variable: QualityMarker/specificHumidity
              is_in: 4-15
+             value: is_not_valid
+             where operator: or
            action:
              name: reject
-           action:
              name: reduce obs space
 
          # Time window filter

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
@@ -1,0 +1,276 @@
+     - obs space:
+         name: sfcshp_specificHumidity_182
+         distribution:
+           name: "@DISTRIBUTION@"
+           halo size: 300e3
+         obsdatain:
+           engine:
+             type: H5File
+             #obsfile: "data/obs/ioda_sfcshp.nc"
+             obsfile: "obsout/sfcship_q_obs_2024052700_dc.nc4"
+           obsgrouping:
+             group variables: ["stationIdentification"]
+             sort variable: "pressure"
+             sort order: "descending"
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: jdiag_sfcshp_specificHumidity_182.nc4
+             allow overwrite: true
+         io pool:
+           max pool size: 1
+         observed variables: [specificHumidity]
+         simulated variables: [specificHumidity]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           #gsi geovals:
+           #  filename: "obsout/sfcship_q_geoval_2024052700.nc4"
+           #  levels_are_top_down: False
+           variables:
+           - name: specificHumidity
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 300e3 # orig
+
+       obs filters:
+         # ------------------
+         # specificHumidity (182)
+         # ------------------
+         # Reject all obs with QualityMarker > 3
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: specificHumidity
+           where:
+           - variable: QualityMarker/specificHumidity
+             is_in: 4-15
+           action:
+             name: reject
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Domain Check
+           apply at iterations: 0,1
+           where:
+             - variable:
+                 name: MetaData/timeOffset # units: s
+               minvalue: -5400
+               maxvalue:  5400
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: specificHumidity
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           action:
+             name: reduce obs space
+
+         # Online regional domain check
+         - filter: Bounds Check
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           where:
+           - variable: ObsType/specificHumidity
+             is_in: 182
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912]
+
+         # Error inflation based on pressure check (setupq.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           where:
+           - variable: ObsType/specificHumidity
+             is_in: 182
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: specificHumidity
+                 inflation factor: 8.0
+                 request_saturation_specific_humidity_geovals: true
+
+#         # Error inflation based on errormod (qcmod.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: specificHumidity
+#           where:
+#           - variable: ObsType/specificHumidity
+#             is_in: 182
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorConventional
+#               options:
+#                 inflate variables: [specificHumidity]
+#                 pressure: MetaData/pressure
+
+         # Error inflation when QualityMarker == 3 (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: QualityMarker/specificHumidity
+             is_in: 3
+
+         # Error inflation when observation pressure < 100 hPa (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 10000.0
+
+         # Bounds Check (ObsError)
+         - filter: Bounds Check
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name:  ObsErrorData/specificHumidity
+           minvalue: 0.0
+           action:
+             name: reduce obs space
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           filter variables:
+           - name: specificHumidity
+           minvalue: 0.0
+           maxvalue: 1.0
+           action:
+             name: reduce obs space
+
+         # Create temporary ObsErrorData
+         - filter: Variable Assignment
+           apply at iterations: 0,1
+           assignments:
+           - name: TempObsErrorData/specificHumidity
+             type: float
+             function:
+               name: ObsFunction/Arithmetic
+               options:
+                 variables:
+                 - name: ObsErrorData/specificHumidity
+           defer to post: true
+
+         # Set ObsError set "error parameter" if < "max value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: assign error
+             error parameter: 5.0
+           where:
+           - variable:
+               name: ObsErrorData/specificHumidity
+             maxvalue: 5.0
+           - variable:
+               name: ObsErrorData/specificHumidity
+             value: is_valid
+           defer to post: true
+
+         # Set ObsError set "error parameter" if > "min value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: assign error
+             error parameter: 50.0
+           where:
+           - variable:
+               name: ObsErrorData/specificHumidity
+             minvalue: 50.0
+           - variable:
+               name: ObsErrorData/specificHumidity
+             value: is_valid
+           defer to post: true
+
+         # Gross Error Check
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: specificHumidity
+           threshold: 7.0
+           action:
+             name: reject
+           where:
+           - variable: ObsType/specificHumidity
+           - variable: QualityMarker/specificHumidity
+             is_not_in: 3
+           defer to post: true
+
+         # Gross Error Check: cgross*0.7 if QualityMarker=3
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: specificHumidity
+           threshold: 4.9
+           action:
+             name: reject
+           where:
+           - variable: ObsType/specificHumidity
+           - variable: QualityMarker/specificHumidity
+             is_in: 3
+           defer to post: true
+
+         # Re-assign err ObsErrorData <--- TempObsErrorData after gross error check.
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: assign error
+             error function: TempObsErrorData/specificHumidity
+           where:
+           - variable:
+               name: TempObsErrorData/specificHumidity
+             value: is_valid
+           defer to post: true
+
+         #- filter: GOMsaver
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
@@ -55,7 +55,6 @@
            where:
            - variable: QualityMarker/specificHumidity
              is_in: 4-15
-           - variable: QualityMarker/specificHumidity
              value: is_not_valid
            where operator: or
            action:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
@@ -6,8 +6,7 @@
          obsdatain:
            engine:
              type: H5File
-             #obsfile: "data/obs/ioda_sfcshp.nc"
-             obsfile: "obsout/sfcship_q_obs_2024052700_dc.nc4"
+             obsfile: "data/obs/ioda_sfcshp.nc"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
@@ -55,8 +55,9 @@
            where:
            - variable: QualityMarker/specificHumidity
              is_in: 4-15
+           - variable: QualityMarker/specificHumidity
              value: is_not_valid
-             where operator: or
+           where operator: or
            action:
              name: reject
              name: reduce obs space

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_180.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_180.yaml
@@ -171,8 +171,8 @@
            test variables:
            - name:  ObsErrorData/stationPressure
            minvalue: 0.0
-           #action:
-           #  name: reduce obs space
+           action:
+             name: reduce obs space
 
          # Bounds Check (ObsValue)
          - filter: Bounds Check
@@ -180,8 +180,8 @@
            - name: stationPressure
            minvalue: 20000.0
            maxvalue: 120000.0
-           #action:
-           #  name: reduce obs space
+           action:
+             name: reduce obs space
 
          # Create temporary ObsErrorData
          - filter: Variable Assignment

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
@@ -48,8 +48,9 @@
            where:
            - variable: QualityMarker/stationPressure
              is_in: 4-15
+           - variable: QualityMarker/stationPressure
              value: is_not_valid
-             where operator: or
+           where operator: or
            action:
              name: reject
              name: reduce obs space

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
@@ -6,8 +6,7 @@
          obsdatain:
            engine:
              type: H5File
-             #obsfile: "data/obs/ioda_sfcshp.nc"
-             obsfile: "obsout/sfcship_ps_obs_2024052700_dc.nc4"
+             obsfile: "data/obs/ioda_sfcshp.nc"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
@@ -48,9 +48,10 @@
            where:
            - variable: QualityMarker/stationPressure
              is_in: 4-15
+             value: is_not_valid
+             where operator: or
            action:
              name: reject
-           action:
              name: reduce obs space
 
          # Time window filter

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
@@ -1,0 +1,269 @@
+     - obs space:
+         name: sfcshp_stationPressure_180
+         distribution:
+           name: "@DISTRIBUTION@"
+           halo size: 300e3
+         obsdatain:
+           engine:
+             type: H5File
+             #obsfile: "data/obs/ioda_sfcshp.nc"
+             obsfile: "obsout/sfcship_ps_obs_2024052700_dc.nc4"
+           obsgrouping:
+             group variables: ["stationIdentification"]
+             sort variable: "pressure"
+             sort order: "descending"
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: jdiag_sfcshp_stationPressure_180.nc4
+             allow overwrite: true
+         io pool:
+           max pool size: 1
+         observed variables: [stationPressure]
+         simulated variables: [stationPressure]
+
+       obs operator:
+         name: SfcPCorrected
+         da_psfc_scheme: GSI
+         geovar_sfc_geomz: geopotential_height_at_surface
+         geovar_geomz: geopotential_height
+       linear obs operator:
+         name: Identity
+
+       obs error:
+         covariance model: diagonal
+
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 300e3 # orig
+
+       obs filters:
+         # ------------------
+         # stationPressure (180)
+         # ------------------
+         # Reject all obs with QualityMarker > 3
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: QualityMarker/stationPressure
+             is_in: 4-15
+           action:
+             name: reject
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Domain Check
+           apply at iterations: 0,1
+           where:
+             - variable:
+                 name: MetaData/timeOffset # units: s
+               minvalue: -5400
+               maxvalue:  5400
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           action:
+             name: reduce obs space
+
+         # Online regional domain check
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 180
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 53.89, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11, 1E11]
+
+         # Error inflation based on pressure check (setupps.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 180
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorSfcPressure
+               options:
+                 geovar_geomz: geopotential_height
+                 geovar_sfc_geomz: geopotential_height_at_surface
+                 #station_altitude: height
+
+#         # Error inflation based on errormod (qcmod.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: stationPressure
+#           where:
+#           - variable: ObsType/stationPressure
+#             is_in: 180
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorConventional
+#               options:
+#                 inflate variables: [stationPressure]
+#                 pressure: MetaData/pressure
+
+         # Error inflation when QualityMarker == 3 (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: QualityMarker/stationPressure
+             is_in: 3
+
+         # Error inflation when observation pressure < 100 hPa (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 10000.0
+
+         # Bounds Check (ObsError)
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name:  ObsErrorData/stationPressure
+           minvalue: 0.0
+           action:
+             name: reduce obs space
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           filter variables:
+           - name: stationPressure
+           minvalue: 20000.0
+           maxvalue: 120000.0
+           action:
+             name: reduce obs space
+
+         # Create temporary ObsErrorData
+         - filter: Variable Assignment
+           apply at iterations: 0,1
+           assignments:
+           - name: TempObsErrorData/stationPressure
+             type: float
+             function:
+               name: ObsFunction/Arithmetic
+               options:
+                 variables:
+                 - name: ObsErrorData/stationPressure
+           defer to post: true
+
+         # Set ObsError set "error parameter" if < "max value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error parameter: 100.0
+           where:
+           - variable:
+               name: ObsErrorData/stationPressure
+             maxvalue: 100.0
+           - variable:
+               name: ObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         # Set ObsError set "error parameter" if > "min value"
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error parameter: 300.0
+           where:
+           - variable:
+               name: ObsErrorData/stationPressure
+             minvalue: 300.0
+           - variable:
+               name: ObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         # Gross Error Check
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           threshold: 4.0
+           action:
+             name: reject
+           where:
+           - variable: ObsType/stationPressure
+           - variable: QualityMarker/stationPressure
+             is_not_in: 3
+           defer to post: true
+
+         # Gross Error Check: cgross*0.7 if QualityMarker=3
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           threshold: 2.8
+           action:
+             name: reject
+           where:
+           - variable: ObsType/stationPressure
+           - variable: QualityMarker/stationPressure
+             is_in: 3
+           defer to post: true
+
+         # Re-assign err ObsErrorData <--- TempObsErrorData after gross error check.
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: stationPressure
+           action:
+             name: assign error
+             error function: TempObsErrorData/stationPressure
+           where:
+           - variable:
+               name: TempObsErrorData/stationPressure
+             value: is_valid
+           defer to post: true
+
+         #- filter: GOMsaver
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
@@ -48,7 +48,6 @@
            where:
            - variable: QualityMarker/stationPressure
              is_in: 4-15
-           - variable: QualityMarker/stationPressure
              value: is_not_valid
            where operator: or
            action:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_280.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_280.yaml
@@ -62,7 +62,7 @@
              is_in: 4-15
            action:
              name: reject
-         #    name: reduce obs space
+             name: reduce obs space
 
          # Time window filter
          - filter: Domain Check
@@ -72,17 +72,12 @@
                  name: MetaData/timeOffset # units: s
                minvalue: -5400
                maxvalue:  5400
-         #  action:
-         #    name: reduce obs space
+           action:
+             name: reduce obs space
 
          # Duplicate Check
          - filter: Temporal Thinning
            apply at iterations: 0,1
-           #where:
-           #  - variable:
-           #      name: MetaData/height
-           #    minvalue: 0
-           #    maxvalue: 10 
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -91,8 +86,8 @@
            seed_time: "2024-05-27T00:00:00Z"
            category_variable:
              name: MetaData/longitude_latitude_pressure
-           #action:
-             #name: reduce obs space
+           action:
+             name: reduce obs space
 
          # Online domain check
          - filter: Bounds Check
@@ -129,10 +124,6 @@
            where:
            - variable: ObsType/windEastward
              is_in: 280
-           #  - variable:
-           #      name: MetaData/height
-           #    minvalue: 0
-           #    maxvalue: 10
 #           - variable: MetaData/dumpReportType # variable not in GSI-IODA
 #             is_not_in: 522, 523, 531
            action:
@@ -163,8 +154,8 @@
                  variable: windNorthward
                  inflation factor: 4.0
                  SetSfcWndObsHeight: true
-                 AddObsHeightToStationElevation: false
-                 AssumedSfcWndObsHeight: 20
+                 AddObsHeightToStationElevation: true
+                 AssumedSfcWndObsHeight: 10
 
 #         # Error inflation (windEastward) based on pressure check (setupw.f90)
 #         - filter: Perform Action
@@ -274,8 +265,8 @@
            test variables:
            - name:  ObsErrorData/windEastward
            minvalue: 0.0
-           #action:
-           #  name: reduce obs space
+           action:
+             name: reduce obs space
 
          # Bounds Check (ObsValue)
          - filter: Bounds Check
@@ -286,8 +277,8 @@
            maxvalue: 130
            action:
              name: reject
-           #action:
-           #  name: reduce obs space
+           action:
+             name: reduce obs space
 
          # Gross Error Check (windEastward)
          - filter: Background Check

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
@@ -60,8 +60,9 @@
            where:
            - variable: QualityMarker/windEastward
              is_in: 4-15
+           - variable: QualityMarker/windEastward
              value: is_not_valid
-             where operator: or
+           where operator: or
            action:
              name: reject
              name: reduce obs space

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
@@ -60,7 +60,6 @@
            where:
            - variable: QualityMarker/windEastward
              is_in: 4-15
-           - variable: QualityMarker/windEastward
              value: is_not_valid
            where operator: or
            action:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
@@ -60,6 +60,8 @@
            where:
            - variable: QualityMarker/windEastward
              is_in: 4-15
+             value: is_not_valid
+             where operator: or
            action:
              name: reject
              name: reduce obs space
@@ -233,7 +235,6 @@
            maxvalue: 130
            action:
              name: reject
-           action:
              name: reduce obs space
 
          # Gross Error Check (windEastward)

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
@@ -1,0 +1,321 @@
+     - obs space:
+         name: sfcshp_winds_282
+         distribution:
+           name: "@DISTRIBUTION@"
+           halo size: 300e3
+         obsdatain:
+           engine:
+             type: H5File
+             #obsfile: "data/obs/ioda_sfcshp.nc"
+             obsfile: "obsout/sfcship_uv_obs_2024052700_dc.nc4"
+           obsgrouping:
+             group variables: ["stationIdentification"]
+             sort variable: "pressure"
+             sort order: "descending"
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: jdiag_sfcshp_winds_282.nc4
+             allow overwrite: true
+         io pool:
+           max pool size: 1
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           hofx_scaling: true
+           hofx scaling field: wind_reduction_factor_at_10m
+           hofx scaling field group: GeoVaLs
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           #gsi geovals:
+           #  filename: "obsout/sfcship_uv_geoval_2024052700.nc4"
+           #  levels_are_top_down: False
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs localizations:
+         - localization method: Horizontal Gaspari-Cohn
+           lengthscale: 300e3 # orig
+
+       obs filters:
+         # ------------------
+         # wind (282)
+         # ------------------
+         # Reject all obs with QualityMarker > 3
+         - filter: Perform Action
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: QualityMarker/windEastward
+             is_in: 4-15
+           action:
+             name: reject
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Domain Check
+           apply at iterations: 0,1
+           where:
+             - variable:
+                 name: MetaData/timeOffset # units: s
+               minvalue: -5400
+               maxvalue:  5400
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT60M
+           tolerance: PT0H
+           seed_time: "2024-05-27T00:00:00Z"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           action:
+             name: reduce obs space
+
+         # Online domain check
+         - filter: Bounds Check
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 282
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079, 1.079]
+
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 282
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+                 SetSfcWndObsHeight: true
+                 AddObsHeightToStationElevation: true
+                 AssumedSfcWndObsHeight: 10
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 282
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+                 SetSfcWndObsHeight: true
+                 AddObsHeightToStationElevation: true
+                 AssumedSfcWndObsHeight: 10
+
+#         # Error inflation (windEastward) based on errormod (qcmod.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: windEastward
+#           where:
+#           - variable: ObsType/windEastward
+#             is_in: 282
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorConventional
+#               options:
+#                 inflate variables: [windEastward]
+#                 test QCflag: QualityMarker
+#                 test QCthreshold: 3
+#                 distance threshold: 0
+#                 pressure: MetaData/pressure
+
+#         # Error inflation (windNorthward) based on errormod (qcmod.f90)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: windNorthward
+#           where:
+#           - variable: ObsType/windNorthward
+#             is_in: 282
+#           action:
+#             name: inflate error
+#             inflation variable:
+#               name: ObsFunction/ObsErrorFactorConventional
+#               options:
+#                 inflate variables: [windNorthward]
+#                 test QCflag: QualityMarker
+#                 test QCthreshold: 3
+#                 distance threshold: 0
+#                 pressure: MetaData/pressure
+
+         # Error inflation when QualityMarker == 3 (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: QualityMarker/windEastward
+             is_in: 3
+
+         # Error inflation when observation pressure < 50 hPa (read_prepbufr.f90)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: inflate error
+             inflation factor: 1.2
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 5000.0
+
+         # Bounds Check (ObsError)
+         - filter: Bounds Check
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  ObsErrorData/windEastward
+           minvalue: 0.0
+           action:
+             name: reduce obs space
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -130
+           maxvalue: 130
+           action:
+             name: reject
+           action:
+             name: reduce obs space
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 282 ]
+               cgross:     [ 6.0 ]
+               error_min:  [ 1.0 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           where:
+           - variable: QualityMarker/windEastward
+             is_not_in: 3
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 282 ]
+               cgross:     [ 6.0 ]
+               error_min:  [ 1.0 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           where:
+           - variable: QualityMarker/windNorthward
+             is_not_in: 3
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windEastward): cgross*0.7 if QualityMarker=3
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 282 ]
+               cgross:     [ 4.2 ]
+               error_min:  [ 1.0 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           where:
+           - variable: QualityMarker/windEastward
+             is_in: 3
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward): cgross*0.7 if QualityMarker=3
+         - filter: Background Check
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 282 ]
+               cgross:     [ 4.2 ]
+               error_min:  [ 1.0 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           where:
+           - variable: QualityMarker/windNorthward
+             is_in: 3
+           action:
+             name: reject
+           defer to post: true
+
+         #- filter: GOMsaver
+         #  filename: ./data/geovals/sfcshp_geovals_rrfs.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
@@ -6,8 +6,7 @@
          obsdatain:
            engine:
              type: H5File
-             #obsfile: "data/obs/ioda_sfcshp.nc"
-             obsfile: "obsout/sfcship_uv_obs_2024052700_dc.nc4"
+             obsfile: "data/obs/ioda_sfcshp.nc"
            obsgrouping:
              group variables: ["stationIdentification"]
              sort variable: "pressure"


### PR DESCRIPTION
## Description
Sfcshp 282 yaml passed phase 1 validation ([this comment](https://github.com/NOAA-EMC/RDASApp/issues/294#issuecomment-2690897154)). As noted in that comment, there were no observation for airTemperature, specificHumidity and stationPressure to test. There were 9 obs for winds to test. Luckily the yamls should follow very closely to type 180/280, but I am unable to do a thorough validation testing of these at the moment. I did make the changes in certain settings such as obs error and gross error settings for all 4 yamls. The point of this PR is to establish these yamls in RDASApp. This won't affect cycling DA results because we will only use configurations that have passed phase 3 validation.

Additionally included in this PR, some typos were fixed for the 180/280 yamls. This includes

- I had some reduced obs space parts commented out for debugging. I added them back in to be consistent with other yamls.
- Things that I had tested that were commented out. So just removing those extra comments.
- One actual bug where I specified the wrong ob height computation for northward wind that I forgot to change back in my testing.

## Issue(s) addressed
- https://github.com/NOAA-EMC/RDASApp/issues/294

## Checklist
- [x] I have performed a self-review of my own code.
