### PR TITLE
hotfix for rrfs-workflow - make all missing QualityMarker to 15

### DIFF
--- a/rrfs-test/IODA/offline_ioda_tweak.py
+++ b/rrfs-test/IODA/offline_ioda_tweak.py
@@ -7,10 +7,11 @@ import warnings
 import os
 
 """
-This program makes a copy of an original IODA file and can add additional
+This program makes a copy of an original IODA file and can add/modify additional
 adhoc variables. This program was originally written to add the
 MetaData/longitude_latitude_pressure for use in l_closeobs duplicate checking
 but others can be added as necessary.
+3/4/2025: change all QualityMarker with missing values to 15
 """
 
 # Disable warnings
@@ -66,6 +67,10 @@ for attr in obs_ds.ncattrs():  # Attributes for the main file
 # Copy all groups and variables into the new file, keeping only the variables in range
 groups = obs_ds.groups
 for group in groups:
+    if group == "QualityMarker":
+      qc_group = True
+    else:
+      qc_group = False
     g = fout.createGroup(group)
     for var in obs_ds.groups[group].variables:
         invar = obs_ds.groups[group].variables[var]
@@ -75,7 +80,13 @@ for group in groups:
             g.createVariable(var, vartype, 'Location', fill_value=fill)
         except:  # String variables
             g.createVariable(var, 'str', 'Location')
-        g.variables[var][:] = invar[:][:]
+        #
+        if qc_group and vartype == "int32" :
+          np_invar = np.array(invar)
+          np_invar[(np_invar < 0) | (np_invar > 15)] = 15
+          g.variables[var][:] = np_invar.astype(invar.dtype)
+        else:
+          g.variables[var][:] = invar[:][:]
         # Copy attributes for this variable
         for attr in invar.ncattrs():
             if '_FillValue' in attr: continue


### PR DESCRIPTION
Add the modification capability into `offline_add_var_to_ioda.py` and rename it to `offline_ioda_tweak.py`