### PR TITLE
Update yamls to comment out ObsErrorFactorPressureCheck for specificHumidity (MPAS-JEDI) and update halo radius

### DIFF
--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_181.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_181.yaml
@@ -110,21 +110,21 @@
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912]
 
-         # Error inflation based on pressure check (setupq.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: specificHumidity
-           where:
-           - variable: ObsType/specificHumidity
-             is_in: 181
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: specificHumidity
-                 inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: true
+#          # Error inflation based on pressure check (setupq.f90)
+#          - filter: Perform Action
+#            filter variables:
+#            - name: specificHumidity
+#            where:
+#            - variable: ObsType/specificHumidity
+#              is_in: 181
+#            action:
+#              name: inflate error
+#              inflation variable:
+#                name: ObsFunction/ObsErrorFactorPressureCheck
+#                options:
+#                  variable: specificHumidity
+#                  inflation factor: 8.0
+#                  request_saturation_specific_humidity_geovals: true
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
@@ -107,21 +107,21 @@
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912]
 
-         # Error inflation based on pressure check (setupq.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: specificHumidity
-           where:
-           - variable: ObsType/specificHumidity
-             is_in: 187
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: specificHumidity
-                 inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: true
+#          # Error inflation based on pressure check (setupq.f90)
+#          - filter: Perform Action
+#            filter variables:
+#            - name: specificHumidity
+#            where:
+#            - variable: ObsType/specificHumidity
+#              is_in: 187
+#            action:
+#              name: inflate error
+#              inflation variable:
+#                name: ObsFunction/ObsErrorFactorPressureCheck
+#                options:
+#                  variable: specificHumidity
+#                  inflation factor: 8.0
+#                  request_saturation_specific_humidity_geovals: true
                  # The new feature "surface observation error ramp"
                  # needs to be added to UFO to align with the ramp
                  # options for temperature and humidity in GSI.

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
@@ -110,21 +110,21 @@
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.056103, 0.063026, 0.073388, 0.086305, 0.099672, 0.1121, 0.12347, 0.13337, 0.14214, 0.15031, 0.15641, 0.1594, 0.15962, 0.16026, 0.16419, 0.17154, 0.1798, 0.18754, 0.19339, 0.19701, 0.19887, 0.19966, 0.19993, 0.2, 0.2, 0.2, 0.19999, 0.19999, 0.19999, 0.20001, 0.20004, 0.19999, 0.19949]
 
-         # Error inflation based on pressure check (setupq.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: specificHumidity
-           where:
-           - variable: ObsType/specificHumidity
-             is_in: 120
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: specificHumidity
-                 inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: true
+#          # Error inflation based on pressure check (setupq.f90)
+#          - filter: Perform Action
+#            filter variables:
+#            - name: specificHumidity
+#            where:
+#            - variable: ObsType/specificHumidity
+#              is_in: 120
+#            action:
+#              name: inflate error
+#              inflation variable:
+#                name: ObsFunction/ObsErrorFactorPressureCheck
+#                options:
+#                  variable: specificHumidity
+#                  inflation factor: 8.0
+#                  request_saturation_specific_humidity_geovals: true
 
          # Error inflation based on errormod (qcmod.f90)
          - filter: Perform Action

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
@@ -110,21 +110,21 @@
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.19455, 0.19064, 0.18488, 0.17877, 0.17342, 0.16976, 0.16777, 0.16696, 0.16605, 0.16522, 0.16637, 0.17086, 0.17791, 0.18492, 0.18996, 0.19294, 0.19447, 0.19597, 0.19748, 0.19866, 0.19941, 0.19979, 0.19994, 0.19999, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
 
-         # Error inflation based on pressure check (setupq.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: specificHumidity
-           where:
-           - variable: ObsType/specificHumidity
-             is_in: 133
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: specificHumidity
-                 inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: true
+#          # Error inflation based on pressure check (setupq.f90)
+#          - filter: Perform Action
+#            filter variables:
+#            - name: specificHumidity
+#            where:
+#            - variable: ObsType/specificHumidity
+#              is_in: 133
+#            action:
+#              name: inflate error
+#              inflation variable:
+#                name: ObsFunction/ObsErrorFactorPressureCheck
+#                options:
+#                  variable: specificHumidity
+#                  inflation factor: 8.0
+#                  request_saturation_specific_humidity_geovals: true
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
@@ -110,21 +110,21 @@
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.10178, 0.090966, 0.082655, 0.078617, 0.078063, 0.079308, 0.08107, 0.082841, 0.084912, 0.088692, 0.095913, 0.10801, 0.12459, 0.14281, 0.15959, 0.17319, 0.1832, 0.19002, 0.19437, 0.19699, 0.19847, 0.19926, 0.19966, 0.19985, 0.19993, 0.19996, 0.19997, 0.19995, 0.19992, 0.19988, 0.19981, 0.19963, 0.19899]
 
-         # Error inflation based on pressure check (setupq.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: specificHumidity
-           where:
-           - variable: ObsType/specificHumidity
-             is_in: 134
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: specificHumidity
-                 inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: true
+#          # Error inflation based on pressure check (setupq.f90)
+#          - filter: Perform Action
+#            filter variables:
+#            - name: specificHumidity
+#            where:
+#            - variable: ObsType/specificHumidity
+#              is_in: 134
+#            action:
+#              name: inflate error
+#              inflation variable:
+#                name: ObsFunction/ObsErrorFactorPressureCheck
+#                options:
+#                  variable: specificHumidity
+#                  inflation factor: 8.0
+#                  request_saturation_specific_humidity_geovals: true
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
@@ -2,6 +2,7 @@
          name: amsua_n19
          distribution:
            name: "@DISTRIBUTION@"
+           halo size: 300e3
          obsdatain:
            engine:
              type: H5File
@@ -9,7 +10,7 @@
          obsdataout:
            engine:
              type: H5File
-             obsfile: jdiag_amsua_n19.2024052700.nc4 
+             obsfile: jdiag_amsua_n19.nc
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &amsua_n19_channels 1-15

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
@@ -2,6 +2,7 @@
          name: atms_n20
          distribution:
            name: "@DISTRIBUTION@"
+           halo size: 300e3
          obsdatain:
            engine:
              type: H5File

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
@@ -110,21 +110,21 @@
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07]
 
-         # Error inflation based on pressure check (setupq.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: specificHumidity
-           where:
-           - variable: ObsType/specificHumidity
-             is_in: 188
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: specificHumidity
-                 inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: true
+#          # Error inflation based on pressure check (setupq.f90)
+#          - filter: Perform Action
+#            filter variables:
+#            - name: specificHumidity
+#            where:
+#            - variable: ObsType/specificHumidity
+#              is_in: 188
+#            action:
+#              name: inflate error
+#              inflation variable:
+#                name: ObsFunction/ObsErrorFactorPressureCheck
+#                options:
+#                  variable: specificHumidity
+#                  inflation factor: 8.0
+#                  request_saturation_specific_humidity_geovals: true
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/rrfs-test/validated_yamls/templates/obtype_config/rassda_airTemperature_126.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/rassda_airTemperature_126.yaml
@@ -2,7 +2,7 @@
          name: rassda_airTemperature_126
          distribution:
            name: "@DISTRIBUTION@"
-           halo size: 100e3
+           halo size: 300e3
          obsdatain:
            engine:
              type: H5File

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_180.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_180.yaml
@@ -110,21 +110,21 @@
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912]
 
-         # Error inflation based on pressure check (setupq.f90)
-         - filter: Perform Action
-           filter variables:
-           - name: specificHumidity
-           where:
-           - variable: ObsType/specificHumidity
-             is_in: 180
-           action:
-             name: inflate error
-             inflation variable:
-               name: ObsFunction/ObsErrorFactorPressureCheck
-               options:
-                 variable: specificHumidity
-                 inflation factor: 8.0
-                 request_saturation_specific_humidity_geovals: true
+#          # Error inflation based on pressure check (setupq.f90)
+#          - filter: Perform Action
+#            filter variables:
+#            - name: specificHumidity
+#            where:
+#            - variable: ObsType/specificHumidity
+#              is_in: 180
+#            action:
+#              name: inflate error
+#              inflation variable:
+#                name: ObsFunction/ObsErrorFactorPressureCheck
+#                options:
+#                  variable: specificHumidity
+#                  inflation factor: 8.0
+#                  request_saturation_specific_humidity_geovals: true
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/rrfs-test/validated_yamls/templates/obtype_config/vadwnd_winds_224.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/vadwnd_winds_224.yaml
@@ -2,7 +2,7 @@
          name: vadwnd_winds_224
          distribution:
            name: "@DISTRIBUTION@"
-           halo size: 100e3
+           halo size: 300e3
          obsdatain:
            engine:
              type: H5File


### PR DESCRIPTION
## Description
I have found some additional repeatability issues with PR #298 that are causing ctest failures on Jet. However there is a need to get some of those yaml updates committed sooner for use in rrfs-workflow. So this PR contains just the yaml updates from #298 while the repeatability issues are further investigated. 

Included in these changes are: 
1) Commenting out the `ObsErrorFactorPressureCheck` filter for specificHumidity yamls used in MPAS-JEDI
2) Updating the halo radius to 300 km for some lingering yamls missed earlier
3) Changing the jdiag name for `amsua_n19.yaml` to match our new standard. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
