### PR TITLE
Hotfix for offline domain check outputting masked longitude info

### DIFF
--- a/rrfs-test/IODA/offline_domain_check.py
+++ b/rrfs-test/IODA/offline_domain_check.py
@@ -268,11 +268,20 @@ for group in groups:
             g.createVariable(var, vartype, 'Location', fill_value=fill)
         except:  # String variables
             g.createVariable(var, 'str', 'Location')
-        g.variables[var][:] = invar[:][inside_indices]
+        # Make sure lat/lon are not masked
+        if var in ['latitude', 'longitude']: 
+            g.variables[var][:] = invar[:][inside_indices].data
+        else:
+            g.variables[var][:] = invar[:][inside_indices]
         # Copy attributes for this variable
         for attr in invar.ncattrs():
             if '_FillValue' in attr: continue
             g.variables[var].setncattr(attr, invar.getncattr(attr))
+
+# Finally add global attribute with the settings used to run this domain check
+fout.setncattr('Orig_obs_file', obs_filename)
+fout.setncattr('Grid_file', grid_filename)
+fout.setncattr('Shrink_factor',hull_shrink_factor)
 
 # Close the datasets
 obs_ds.close()

--- a/rrfs-test/IODA/offline_domain_check_satrad.py
+++ b/rrfs-test/IODA/offline_domain_check_satrad.py
@@ -333,6 +333,11 @@ g = fout.createGroup('ObsError')
 g.createVariable('brightnessTemperature', vartype, dimensions, fill_value=fill)
 g.variables['brightnessTemperature'][:,:] = 999
 
+# Finally add global attribute with the settings used to run this domain check
+fout.setncattr('Orig_obs_file', obs_filename)
+fout.setncattr('Grid_file', grid_filename)
+fout.setncattr('Shrink_factor',hull_shrink_factor
+
 # Close the datasets
 obs_ds.close()
 fout.close()


### PR DESCRIPTION
## Bug Fix Description
This PR fixes an issue with the offline domain check outputing masked longitude data for ZTD obs. 

I also added a few global attributes to the output file so that we can track the hull shrink factor and which domain (mpas or jedi) was used for the check. 

**Description of Current Behavior:**
- Running `offline_domain_check.py` on ZTD obs outputs all masked longitude data

**Description of Fixed Behavior:**
- We now output the unmasked latitude and longitude data for the offline domain check. We still leave other variables masked if the data are bad. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
