### PR TITLE
Add bufr-query as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,8 @@
 	url = https://github.com/JCSDA/mpas-jedi
 	branch = develop
 	ignore = all
+[submodule "sorc/bufr-query"]
+	path = sorc/bufr-query
+	url = https://github.com/NOAA-EMC/bufr-query.git
+	branch = develop
+	igore = all

--- a/.gitmodules
+++ b/.gitmodules
@@ -77,4 +77,4 @@
 	path = sorc/bufr-query
 	url = https://github.com/NOAA-EMC/bufr-query.git
 	branch = develop
-	igore = all
+	ignore = all

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -105,6 +105,9 @@ endif()
     ecbuild_bundle( PROJECT iodaconv SOURCE "../sorc/iodaconv" )
   endif()
 
+# EMC BUFR-query library
+  ecbuild_bundle( PROJECT bufr-query SOURCE "../sorc/bufr-query" )
+
 # rdas tests and super executables
   ecbuild_bundle( PROJECT rrfs-test SOURCE "../rrfs-test" )
   if(BUILD_SUPER_EXE)


### PR DESCRIPTION
## Description

This PR adds bufr-query as a submodule in RDASApp so that `bufr2netcdf.x` can be compiled for converting radiance observations. 

I added the submodule at the latest develop branch. This built for me just fine with the current version of RDASApp. However, GDASApp uses a much older commit from 8 months ago ([here](https://github.com/noaa-emc/bufr-query/tree/97367fcd59adf4863aba1a52189e20f9f66451af)). @xyzemc Would you mind testing if this hash included in this PR works for you? I would prefer to keep the later version unless there is a reason to do otherwise. 

Note: this PR was originally opened as #334 but I used the wrong branch to push from. It is reopened here. 

## Issue(s) addressed
#333 

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
