### PR TITLE
fix a typo: 180->182 in sfcshp_stationPressure_182.yaml

### DIFF
--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
@@ -1,5 +1,5 @@
      - obs space:
-         name: sfcshp_stationPressure_180
+         name: sfcshp_stationPressure_182
          distribution:
            name: "@DISTRIBUTION@"
            halo size: 300e3


### PR DESCRIPTION
## Bug Fix Description
There is a typo in `sfcshp_stationPressure_182.yaml`

## Issue(s) addressed
none

## Dependencies (if applicable)
none

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
