### PR TITLE
bugfix in longitude valid range (0, 360)

### DIFF
--- a/rrfs-test/IODA/python/bufr2ioda_ztd.py
+++ b/rrfs-test/IODA/python/bufr2ioda_ztd.py
@@ -278,7 +278,7 @@ def bufr_to_ioda(config, logger):
 
     obsspace.create_var('MetaData/longitude', dtype=lon.dtype, fillval=lon.fill_value) \
         .write_attr('units', 'degrees_east') \
-        .write_attr('valid_range', np.array([-180, 180])) \
+        .write_attr('valid_range', np.array([0, 360])) \
         .write_attr('long_name', 'Longitude') \
         .write_data(lon)
 


### PR DESCRIPTION
* [Bugfix](?expand=1&template=bugfix_pr.md)
Fixed the longitude valid range from (-180, 180) to (0, 360) after the change of the longitude values.  This bug caused masked longitude after the "offline_domain_check".  Now, this issue is resolved, and the "offline_domain_check" can be reverted to its original form.
