### PR TITLE
use one observer for t183, q183 and uv284

### DIFF
--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_183.yaml
@@ -6,7 +6,9 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: "data/obs/ioda_adpsfc.nc"
+             obsfiles:
+             - data/obs/ioda_adpsfc.nc
+             - data/obs/ioda_sfcshp.nc
              #obsfile: "obsout/sfcship_tsen_obs_2024052700_dc.nc4"
            obsgrouping:
              group variables: ["stationIdentification"]

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_183.yaml
@@ -6,7 +6,9 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: "data/obs/ioda_adpsfc.nc"
+             obsfiles:
+             - data/obs/ioda_adpsfc.nc
+             - data/obs/ioda_sfcshp.nc
              #obsfile: "obsout/sfcship_q_obs_2024052700_dc.nc4"
            obsgrouping:
              group variables: ["stationIdentification"]

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_284.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_284.yaml
@@ -6,7 +6,9 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: "data/obs/ioda_adpsfc.nc"
+             obsfiles:
+             - data/obs/ioda_adpsfc.nc
+             - data/obs/ioda_sfcshp.nc
              #obsfile: "obsout/sfcship_uv_obs_2024052700_dc.nc4"
            obsgrouping:
              group variables: ["stationIdentification"]


### PR DESCRIPTION
## Description
As described in issue# https://github.com/NOAA-EMC/RDASApp/issues/354, It is expected to use one observer for t183, q183 and uv284, no matter whether the observations have a msgtype of `ADPSFC` or `SFCSHP`

JEDI provides the `obsfiles` keyword to handle this kind of situation, and we follow this rule in this PR

## Issue(s) addressed
Resolves/Results are documented in Issue # https://github.com/NOAA-EMC/RDASApp/issues/354

## Dependencies (if applicable)
none

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
