### PR TITLE
[feature & bugfix] Add passivate options and fixes associated with ctests 

### DIFF
--- a/rrfs-test/validated_yamls/gen_yaml_ctest.sh
+++ b/rrfs-test/validated_yamls/gen_yaml_ctest.sh
@@ -71,7 +71,7 @@ for basic_config in "${!basic_configs[@]}"; do
             new_path=$(echo "$int_path" | sed "s/solver/observer/gI")
             obs_filename_new="obsfile: ${new_path}"
             # Old obs file name to replace
-            obsline=`grep "obsfile: data\/obs\/ioda" templates/obtype_config/${config}`
+            obsline=`grep "obsfile: \"data\/obs\/ioda" templates/obtype_config/${config}`
             trimmed=$(echo "$obsline" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
             obs_filename=${trimmed}
             # Replace

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
@@ -13,7 +13,7 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_abi_g16.nc
+             obsfile: "data/obs/ioda_abi_g16.nc"
              missing file action: "warn"
          obsdataout:
            engine:

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
@@ -13,7 +13,7 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_abi_g18.nc
+             obsfile: "data/obs/ioda_abi_g18.nc"
              missing file action: "warn"
          obsdataout:
            engine:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_181.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_181.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (181)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_183.yaml
@@ -49,6 +49,13 @@
          # ------------------
          # airTemperature (183)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
@@ -45,6 +45,13 @@
          # ------------------
          # airTemperature (187)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_181.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_181.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # specificHumidity (181)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_183.yaml
@@ -49,6 +49,13 @@
          # ------------------
          # specificHumidity (183)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
@@ -45,6 +45,13 @@
          # ------------------
          # specificHumidity (187)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_181.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_181.yaml
@@ -41,6 +41,13 @@
          # ------------------
          # stationPressure (181)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
@@ -41,6 +41,13 @@
          # ------------------
          # stationPressure (187)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_281.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_281.yaml
@@ -52,6 +52,14 @@
          # ------------------
          # wind (281)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_284.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_284.yaml
@@ -50,6 +50,14 @@
          # ------------------
          # wind (284)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (287)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (120)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_132.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_132.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (132)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # specificHumidity (120)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_132.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_132.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # specificHumidity (132)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_stationPressure_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_stationPressure_120.yaml
@@ -41,6 +41,13 @@
          # ------------------
          # stationPressure (120)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (220)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_232.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_232.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (232)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (133)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # specificHumidity (133)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (233)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (130)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (131)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (134)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (135)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # specificHumidity (134)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (230)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (231)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (234)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (235)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
@@ -9,7 +9,7 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_amsua_n19.nc
+             obsfile: "data/obs/ioda_amsua_n19.nc"
              missing file action: "warn"
          obsdataout:
            engine:

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
@@ -19,7 +19,7 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_atms_n20.nc
+             obsfile: "data/obs/ioda_atms_n20.nc"
              missing file action: "warn"
          obsdataout:
            engine:

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
@@ -19,7 +19,7 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_atms_npp.nc
+             obsfile: "data/obs/ioda_atms_npp.nc"
              missing file action: "warn"
          obsdataout:
            engine:

--- a/rrfs-test/validated_yamls/templates/obtype_config/gnss_zenithTotalDelay.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/gnss_zenithTotalDelay.yaml
@@ -8,7 +8,7 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_gnss_ztd.nc
+             obsfile: "data/obs/ioda_gnss_ztd.nc"
              missing file action: "warn"
 
          obsgrouping:

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (188)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # specificHumidity (188)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
@@ -41,6 +41,13 @@
          # ------------------
          # stationPressure (188)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
@@ -314,6 +314,17 @@
            - variable: MetaData/stationIdentification
              is_in: ["KBIT","KBRX","KHLD","KBFU","KCMS","KPER","KDRC"]
 
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: QCflagsData/windEastward
+             is_in: 0
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/proflr_winds_227.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/proflr_winds_227.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (227)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/rassda_airTemperature_126.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/rassda_airTemperature_126.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (126)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_180.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_180.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (180)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # airTemperature (182)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_183.yaml
@@ -49,6 +49,13 @@
          # ------------------
          # airTemperature (183)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: airTemperature
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_180.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_180.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # specificHumidity (180)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
@@ -48,6 +48,13 @@
          # ------------------
          # specificHumidity (182)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_183.yaml
@@ -49,6 +49,13 @@
          # ------------------
          # specificHumidity (183)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: specificHumidity
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_180.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_180.yaml
@@ -41,6 +41,13 @@
          # ------------------
          # stationPressure (180)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
@@ -41,6 +41,13 @@
          # ------------------
          # stationPressure (182)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: stationPressure
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_280.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_280.yaml
@@ -52,6 +52,14 @@
          # ------------------
          # wind (280)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
@@ -52,6 +52,14 @@
          # ------------------
          # wind (282)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_284.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_284.yaml
@@ -50,6 +50,14 @@
          # ------------------
          # wind (284)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/vadwnd_winds_224.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/vadwnd_winds_224.yaml
@@ -49,6 +49,14 @@
          # ------------------
          # wind (224)
          # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           action:
+             name: accept # accept, reject, passivate
+
          # Reject all obs with QualityMarker > 3
          - filter: RejectList
            apply at iterations: 0,1


### PR DESCRIPTION
## Description

- This is a follow up PR to #326 in which the filter block to optionally passivate (monitor) observations is created for the prepbufr observation types.
- While making this PR, it was found a bug was unintentionally introduced to the ctests with PR #326 and thus all ioda.nc file names will have double quotes and the gen_yaml_ctest.sh now properly handles that.

All of the added filter blocks are identical which the exception of msonet_winds_288. This needed a special filter block to correctly passivate options which checks `if QCflagsData/windEastward  == 0`. This special case is because of the use of `AcceptLists` rather than only `RejectLists`. All filter blocks are currently set to `accept` by default which does not change results.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
