### PR TITLE
Quick bugfix for satellite radiance offline domain check

### DIFF
--- a/rrfs-test/IODA/offline_domain_check_satrad.py
+++ b/rrfs-test/IODA/offline_domain_check_satrad.py
@@ -336,7 +336,7 @@ g.variables['brightnessTemperature'][:,:] = 999
 # Finally add global attribute with the settings used to run this domain check
 fout.setncattr('Orig_obs_file', obs_filename)
 fout.setncattr('Grid_file', grid_filename)
-fout.setncattr('Shrink_factor',hull_shrink_factor
+fout.setncattr('Shrink_factor',hull_shrink_factor)
 
 # Close the datasets
 obs_ds.close()


### PR DESCRIPTION

## Bug Fix Description
Now that we are testing adding the satellite radiance obs to rrfs-workflow, @xyzemc caught a bug with the offline domain check. This PR resolves the error caused by a missing parenthesis introduced in PR #336. 

**Description of Current Behavior:**

`offline_domain_check_satrad.py`  crashes with: 

```
./offline_domain_check_satrad.py", line 342
    obs_ds.close()
    ^
SyntaxError: invalid syntax
```

**Description of Fixed Behavior:**

The missing parenthesis is added to resolve the syntax error 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
