### PR TITLE
Small updates to `update_ctest_inputs.sh` to link new obs into the ctest run directories and load a correct python version

### DIFF
--- a/ush/update_ctest_inputs.sh
+++ b/ush/update_ctest_inputs.sh
@@ -28,13 +28,19 @@ CMAKE_CURRENT_BINARY_DIR=${RDASApp}/build/rrfs-test
 rrfs_test_data_local=${CMAKE_SOURCE_DIR}/rrfs-test-data/
 src_yaml=${CMAKE_SOURCE_DIR}/rrfs-test/testinput
 
+# Source RDAS modules so that we don't have any python version issues in gen_yaml_ctest.sh
+source load_rdas.sh
+
 # First run the gen_yaml script to regenerate the ctest yamls
 currdir=`pwd`
 cd ${RDASApp}/rrfs-test/validated_yamls
 ./gen_yaml_ctest.sh
 cd ${currdir}
 
-if [[ $DYCORE == "FV3JEDI" || $DYCORE == "BOTH" ]]; then 
+if [[ $DYCORE == "FV3JEDI" || $DYCORE == "BOTH" ]]; then
+   # Relink fix into expr in case new obs are added
+   echo "Linking in test data for FV3-JEDI case"
+   ${RDASApp}/rrfs-test/scripts/link_fv3jedi_expr.sh
    for ctest in "${rrfs_fv3jedi_tests[@]}"; do
       case=${ctest}
       echo "Updating ${case}..."
@@ -47,9 +53,12 @@ if [[ $DYCORE == "FV3JEDI" || $DYCORE == "BOTH" ]]; then
       ln -snf ${CMAKE_SOURCE_DIR}/rrfs-test/testoutput ${casedir}/testoutput
       cp ${src_yaml}/${case}.yaml ${casedir}
    done
-fi 
+fi
 
-if [[ $DYCORE == "MPASJEDI" || $DYCORE == "BOTH" ]]; then 
+if [[ $DYCORE == "MPASJEDI" || $DYCORE == "BOTH" ]]; then
+   # Relink fix into expr in case new obs are added
+   echo "Linking in test data for MPAS-JEDI case"
+   ${RDASApp}/rrfs-test/scripts/link_mpasjedi_expr.sh
    for ctest in "${rrfs_mpasjedi_tests[@]}"; do
       case=${ctest}
       echo "Updating ${case}..."


### PR DESCRIPTION
## Description
This PR contains some small updates to `ush/update_ctest_inputs.sh` to make it easier for developers to update the ctests input files (e.g., yamls, input observations) without rebuilding RDASApp. Specifically,

1. The linking scripts (`link_fv3jedi_expr.sh` and `link_mpasjedi_expr.sh`) are now run in `ush/update_ctest_inputs.sh`. This ensures that any new observations added to the staged data will make it into the data directories for the ctests. This was previously only done within `build.sh`.
2. The RDAS modules are loaded in `ush/update_ctest_inputs.sh` to ensure that a python version is loaded with access to the yaml module. This is needed to run `gen_yaml_cest.sh` that calls the `commentQC.py` python code. 

I also added some notes to the wiki page [here](https://github.com/NOAA-EMC/RDASApp/wiki/Updating-the-RDASApp-ctests-(adding-new-obs-or-updating-test-reference-files)) to clarify the naming convention for any new observation types being added. We need the obs names to follow a certain format so that the script that replaces the IODA filename with the jdiag name for the GETKF solver can be executed correctly.

Thanks to @keenaneure for helping find these issues. Hopefully this will make it even easier for future developers to update the ctests or add new observation types. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
