### PR TITLE
port RDASApp to Ursa - step 1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ while getopts "p:c:m:j:t:hvfsx" opt; do
 done
 
 case ${BUILD_TARGET} in
-  hera | orion | hercules | jet | gaea | wcoss2 )
+  hera | orion | hercules | jet | gaea | wcoss2 | ursa )
     echo "Building RDASApp on $BUILD_TARGET"
     echo "  Build initiated `date`"
     [[ "${BUILD_TARGET}" != *gaea* ]] && source $dir_root/ush/module-setup.sh

--- a/modulefiles/RDAS/ursa.gnu.lua
+++ b/modulefiles/RDAS/ursa.gnu.lua
@@ -6,18 +6,17 @@ local pkgName    = myModuleName()
 local pkgVersion = myModuleVersion()
 local pkgNameVer = myModuleFullName()
 
-prepend_path("MODULEPATH", '/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core')
+prepend_path("MODULEPATH", '/contrib/spack-stack/spack-stack-1.9.1/envs/ue-gcc-11.4.1/install/modulefiles/Core')
 
-load("stack-oneapi/2024.2.1")
+load("stack-gcc/11.4.1")
 load("stack-python/3.11.7")
-load("stack-intel-oneapi-mpi/2021.13")
+load("stack-openmpi/4.1.6")
 load("jedi-mpas-env/1.0.0")
 load("jedi-fv3-env/1.0.0")
 
-
-setenv("CC","mpiicc")
-setenv("FC","mpiifort")
-setenv("CXX","mpiicpc")
+setenv("CC","mpicc")
+setenv("FC","mpif90")
+setenv("CXX","mpicxx")
 
 local mpiexec = '/apps/slurm_hera/default/bin/srun'
 local mpinproc = '-n'

--- a/modulefiles/RDAS/ursa.gnu.lua
+++ b/modulefiles/RDAS/ursa.gnu.lua
@@ -18,7 +18,7 @@ setenv("CC","mpicc")
 setenv("FC","mpif90")
 setenv("CXX","mpicxx")
 
-local mpiexec = '/apps/slurm_hera/default/bin/srun'
+local mpiexec = '/apps/slurm/default/bin/srun'
 local mpinproc = '-n'
 setenv('MPIEXEC_EXEC', mpiexec)
 setenv('MPIEXEC_NPROC', mpinproc)

--- a/modulefiles/RDAS/ursa.intel.lua
+++ b/modulefiles/RDAS/ursa.intel.lua
@@ -19,7 +19,7 @@ setenv("CC","mpiicc")
 setenv("FC","mpiifort")
 setenv("CXX","mpiicpc")
 
-local mpiexec = '/apps/slurm_hera/default/bin/srun'
+local mpiexec = '/apps/slurm/default/bin/srun'
 local mpinproc = '-n'
 setenv('MPIEXEC_EXEC', mpiexec)
 setenv('MPIEXEC_NPROC', mpinproc)

--- a/modulefiles/RDAS/ursa.intel.lua
+++ b/modulefiles/RDAS/ursa.intel.lua
@@ -1,0 +1,29 @@
+help([[
+Load environment for running the RDAS application with Intel compilers and MPI.
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+prepend_path("MODULEPATH", '/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core')
+
+load("stack-oneapi/2024.2.1")
+load("stack-python/3.11.7")
+load("stack-intel-oneapi-mpi/2021.13")
+load("jedi-mpas-env/1.0.0")
+
+
+setenv("CC","mpiicc")
+setenv("FC","mpiifort")
+setenv("CXX","mpiicpc")
+
+local mpiexec = '/apps/slurm_hera/default/bin/srun'
+local mpinproc = '-n'
+setenv('MPIEXEC_EXEC', mpiexec)
+setenv('MPIEXEC_NPROC', mpinproc)
+
+whatis("Name: ".. pkgName)
+whatis("Version: ".. pkgVersion)
+whatis("Category: RDASApp")
+whatis("Description: Load all libraries needed for RDASApp")

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -30,6 +30,9 @@ case $(hostname -f) in
   hfe1[0-2]) MACHINE_ID=hera ;; ### hera10-12
   hecflow01) MACHINE_ID=hera ;; ### heraecflow01
 
+  ufe*) MACHINE_ID=ursa ;;
+  uecflow01) MACHINE_ID=ursa ;;
+
   s4-submit.ssec.wisc.edu) MACHINE_ID=s4 ;; ### s4
 
   fe[1-8]) MACHINE_ID=jet ;; ### jet01-8
@@ -75,6 +78,9 @@ elif [[ -d /mnt/lfs5 ]]; then
 elif [[ -d /scratch1 ]]; then
   # We are on NOAA Hera
   MACHINE_ID=hera
+elif [[ -d /scratch3 ]]; then
+  # We are on NOAA Ursa
+  MACHINE_ID=ursa
 elif [[ -d /work ]]; then
   # We are on MSU Orion or Hercules
   if [[ -d /apps/other ]]; then

--- a/ush/init.sh
+++ b/ush/init.sh
@@ -11,6 +11,9 @@ case ${MACHINE_ID} in
   hera)
     RDAS_DATA=/scratch1/NCEPDEV/fv3-cam/RDAS_DATA
     ;;
+  ursa)
+    RDAS_DATA=/scratch4/BMC/rtrr/RDAS_DATA
+    ;;
   jet)
     RDAS_DATA=/lfs5/BMC/nrtrr/RDAS_DATA
     ;;

--- a/ush/linter_yamlcheck.sh
+++ b/ush/linter_yamlcheck.sh
@@ -10,7 +10,7 @@ case ${MACHINE_ID} in
   hera)
     EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
     ;;
-  hera)
+  ursa)
     EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
     ;;
   jet)

--- a/ush/linter_yamlcheck.sh
+++ b/ush/linter_yamlcheck.sh
@@ -10,6 +10,9 @@ case ${MACHINE_ID} in
   hera)
     EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
     ;;
+  hera)
+    EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    ;;
   jet)
     EXEC_DIR=/lfs6/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
     ;;

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -15,6 +15,13 @@ elif [[ $MACHINE_ID = hera* ]] ; then
     fi
     module purge
 
+elif [[ $MACHINE_ID = ursa* ]] ; then
+    # We are on NOAA Hera
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/lmod/init/bash
+    fi
+    module purge
+
 elif [[ $MACHINE_ID = orion* ]] ; then
     # We are on Orion
     if ( ! eval module help > /dev/null 2>&1 ) ; then

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -16,7 +16,7 @@ elif [[ $MACHINE_ID = hera* ]] ; then
     module purge
 
 elif [[ $MACHINE_ID = ursa* ]] ; then
-    # We are on NOAA Hera
+    # We are on NOAA Ursa
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/lmod/init/bash
     fi


### PR DESCRIPTION
## Description
Port RDASApp to the NOAA new RDHPCS `Ursa`
Only spac-stack 1.9.1 is available on Ursa, so we must use this version.
Fix files (RDAS_DATA) have been transferred to Ursa

Try to use a simplified Lua file if possible:
```
prepend_path("MODULEPATH", '/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core')

load("stack-oneapi/2024.2.1")
load("stack-python/3.11.7")
load("stack-intel-oneapi-mpi/2021.13")
load("jedi-mpas-env/1.0.0")
load("jedi-fv3-env/1.0.0")
```

## Issue(s) addressed
None

## Dependencies (if applicable)
NOne
