### PR TITLE
use `-t NO` to skip downloading bufr_query test data

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ usage() {
   echo "  -s  only build a subset of the bundle  DEFAULT: NO"
   echo "  -m  select dycore                      DEFAULT: FV3andMPAS"
   echo "  -x  build super executables            DEFAULT: NO"
-  echo "  -t  include/generate RRFS ctest data   DEFAULT: YES"
+  echo "  -t  include RRFS,BUFR_QUERY test data  DEFAULT: YES"
   echo "  -d  compile in the debug mode          DEFAULT: NO"
   echo "  -h  display this message and quit"
   echo
@@ -47,7 +47,8 @@ BUILD_SUPER_EXE="NO"
 BUILD_RRFS_TEST="YES"
 DYCORE="FV3andMPAS"
 COMPILER="${COMPILER:-intel}"
-DEBUG_STR=""
+DEBUG_OPT=""
+BUFRQUERY_OPT=""
 
 while getopts "p:c:m:j:t:hvfsxd" opt; do
   case $opt in
@@ -65,12 +66,15 @@ while getopts "p:c:m:j:t:hvfsxd" opt; do
       ;;
     t)
       BUILD_RRFS_TEST=$OPTARG
+      if [[ "$OPTARG" == "NO" ]]; then
+        BUFRQUERY_OPT="-DSKIP_DOWNLOAD_TEST_DATA=ON"
+      fi
       ;;
     v)
       BUILD_VERBOSE=YES
       ;;
     d)
-      DEBUG_STR="-DCMAKE_BUILD_TYPE=Debug"
+      DEBUG_OPT="-DCMAKE_BUILD_TYPE=Debug"
       ;;
     f)
       CLEAN_BUILD=YES
@@ -94,7 +98,7 @@ case ${BUILD_TARGET} in
     [[ "${BUILD_TARGET}" != *gaea* ]] && source $dir_root/ush/module-setup.sh
     module use $dir_root/modulefiles
     module load RDAS/$BUILD_TARGET.$COMPILER
-    CMAKE_OPTS+=" ${DEBUG_STR} -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON -DMACHINE_ID=$MACHINE_ID"
+    CMAKE_OPTS+=" ${DEBUG_OPT} ${BUFRQUERY_OPT} -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON -DMACHINE_ID=$MACHINE_ID"
     module list
     ;;
   *)


### PR DESCRIPTION
## Description
As shown in the output examples below,  `bufr_query-0.0.1.tgz` test data will be downloaded in the build step.
This PR adds the function to skip downloading the bufr_query test data by setting `SKIP_DOWNLOAD_TEST_DATA=ON`.
It reuses the existing `-t` option.  
`build.sh -t NO` will skip downloading the bufr_query data and skip generating the rrfs-test data.


```
-- Adding bundle project bufr-query      
-- ---------------------------------------------------------
-- [bufr_query] (0.0.4)                  
-- Feature TESTS enabled                 
-- Found OpenMP_CXX: -qopenmp (found version "5.0")
-- Found OpenMP_Fortran: -qopenmp (found version "5.0")
-- Found OpenMP: TRUE (found version "5.0")
-- Found NetCDF: /autofs/ncrc-svm1_proj/epic/spack-stack/c6/spack-stack-1.6.0/envs/unified-env/install/intel/2023.2.0/netcdf-cxx4-4.3.1-2nfkojj/include (found version
"4.9.2") found components: CXX
-- FindNetCDF defines targets:
--   - NetCDF::NetCDF_CXX [/autofs/ncrc-svm1_proj/epic/spack-stack/c6/spack-stack-1.6.0/envs/unified-env/install/intel/2023.2.0/netcdf-cxx4-4.3.1-2nfkojj/lib/libnetcd$
_c++4.so]
-- Found bufr: /autofs/ncrc-svm1_proj/epic/spack-stack/c6/spack-stack-1.6.0/envs/unified-env/install/intel/2023.2.0/bufr-12.0.1-aq4gepn/lib64/libbufr_4.so (found vers$
on "12.0.1")
-- Downloading: /tmp/gge/test/rrfs-workflow/sorc/RDASApp/build/bufr-query/test/bufr_query-0.0.1.tgz
-- [download 0% complete]
-- [download 1% complete]
-- [download 2% complete]
-- [download 3% complete]
-- [download 4% complete]
-- [download 5% complete]
-- [download 6% complete]
-- [download 7% complete]
-- [download 8% complete]
-- [download 9% complete]
-- [download 10% complete]
-- [download 11% complete]
-- [download 12% complete]
-- [download 13% complete]
-- [download 14% complete]
-- [download 15% complete]
-- [download 16% complete]
-- [download 17% complete]
-- [download 18% complete]
-- [download 19% complete]
-- [download 20% complete]
-- [download 21% complete]
-- [download 22% complete]
-- [download 23% complete]
-- [download 24% complete]
```


## Issue(s) addressed
None

## Dependencies (if applicable)
None