### PR TITLE
Add Domain Check filter to remove the data with missing hofx

### DIFF
--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
@@ -225,6 +225,21 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+       # Toss data if the hofx has missing value
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         where:
+         - variable:
+             name: brightnessTemperature@HofX
+             channels: *abi_g16_channels
+           value: is_valid
+           minvalue: 50
+           maxvalue: 500
+         action:
+           name: reject
+
        # Surface type check
        # Toss channels 7,11-16 over land
        - filter: RejectList

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
@@ -225,18 +225,18 @@
            minvalue: 0.0
            maxvalue: 0.5
 
-       # Toss data if the hofx has missing value
+       #Toss data if the hofx is missing or outside of range
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
            channels: *abi_g16_channels
          where:
          - variable:
-             name: brightnessTemperature@HofX
+             name: HofX/brightnessTemperature
              channels: *abi_g16_channels
            value: is_valid
-           minvalue: 50
-           maxvalue: 500
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
@@ -225,7 +225,7 @@
            minvalue: 0.0
            maxvalue: 0.5
 
-       # Toss data if the hofx has missing value
+       # Toss data if the hofx is missing or outside of range
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
@@ -235,8 +235,8 @@
              name: brightnessTemperature@HofX
              channels: *abi_g18_channels
            value: is_valid
-           minvalue: 50
-           maxvalue: 500
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
@@ -225,6 +225,21 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+       # Toss data if the hofx has missing value
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         where:
+         - variable:
+             name: brightnessTemperature@HofX
+             channels: *abi_g18_channels
+           value: is_valid
+           minvalue: 50
+           maxvalue: 500
+         action:
+           name: reject
+
        # Surface type check
        # Toss channels 7,11-16 over land
        - filter: RejectList

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
@@ -269,6 +269,21 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+       # Toss the data if the hofx has missing value
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_n20_channels
+         where:
+         - variable:
+             name: brightnessTemperature@HofX
+             channels: *atms_n20_channels
+           value: is_valid
+           minvalue: 50
+           maxvalue: 500
+         action:
+           name: reject
+
        # Step 0-C: Assign Initial All-Sky Observation Error
        - filter: Perform Action
          filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
@@ -248,13 +248,18 @@
                  channels: *atms_n20_channels
                coefs: [1, -1]
 
-       - filter: Bounds Check
+        # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
-         #- name: brightnessTemperature
-         - name: HofX/brightnessTemperature
+         - name: brightnessTemperature
            channels: *atms_n20_channels
-         minvalue: 50.00001
-         maxvalue: 449.99999
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_n20_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
@@ -268,21 +273,6 @@
            flag all filter variables if any test variable is out of bounds: true
            minvalue: 0.0
            maxvalue: 0.5
-
-       # Toss the data if the hofx has missing value
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *atms_n20_channels
-         where:
-         - variable:
-             name: brightnessTemperature@HofX
-             channels: *atms_n20_channels
-           value: is_valid
-           minvalue: 50
-           maxvalue: 500
-         action:
-           name: reject
 
        # Step 0-C: Assign Initial All-Sky Observation Error
        - filter: Perform Action

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
@@ -275,6 +275,21 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+       # Toss the data if the hofx has missing value
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         where:
+         - variable:
+             name: brightnessTemperature@HofX
+             channels: *atms_npp_channels
+           value: is_valid
+           minvalue: 50
+           maxvalue: 500
+         action:
+           name: reject
+
        # Step 0-C: Assign Initial All-Sky Observation Error
        - filter: Perform Action
          filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
@@ -254,13 +254,18 @@
                  channels: *atms_n21_channels
                coefs: [1, -1]
 
-       - filter: Bounds Check
+       # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
-         #- name: brightnessTemperature
-         - name: HofX/brightnessTemperature
+         - name: brightnessTemperature
            channels: *atms_n21_channels
-         minvalue: 50.00001
-         maxvalue: 449.99999
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_n21_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
@@ -274,21 +279,6 @@
            flag all filter variables if any test variable is out of bounds: true
            minvalue: 0.0
            maxvalue: 0.5
-
-       # Toss the data if the hofx has missing value
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *atms_n21_channels
-         where:
-         - variable:
-             name: brightnessTemperature@HofX
-             channels: *atms_n21_channels
-           value: is_valid
-           minvalue: 50
-           maxvalue: 500
-         action:
-           name: reject
 
        # Step 0-C: Assign Initial All-Sky Observation Error
        - filter: Perform Action

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
@@ -279,11 +279,11 @@
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
-           channels: *atms_npp_channels
+           channels: *atms_n21_channels
          where:
          - variable:
              name: brightnessTemperature@HofX
-             channels: *atms_npp_channels
+             channels: *atms_n21_channels
            value: is_valid
            minvalue: 50
            maxvalue: 500

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
@@ -270,6 +270,21 @@
            minvalue: 0.0
            maxvalue: 0.5
 
+       # Toss the data if the hofx has missing value
+       - filter: Domain Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *atms_npp_channels
+         where:
+         - variable:
+             name: brightnessTemperature@HofX
+             channels: *atms_npp_channels
+           value: is_valid
+           minvalue: 50
+           maxvalue: 500
+         action:
+           name: reject
+
        # Step 0-C: Assign Initial All-Sky Observation Error
        - filter: Perform Action
          filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
@@ -249,13 +249,18 @@
                  channels: *atms_npp_channels
                coefs: [1, -1]
 
-       - filter: Bounds Check
+       # Toss the data if the hofx is missing or outside of range
+       - filter: Domain Check
          filter variables:
-         #- name: brightnessTemperature
-         - name: HofX/brightnessTemperature
+         - name: brightnessTemperature
            channels: *atms_npp_channels
-         minvalue: 50.00001
-         maxvalue: 449.99999
+         where:
+         - variable:
+             name: HofX/brightnessTemperature
+             channels: *atms_npp_channels
+           value: is_valid
+           minvalue: 50.00001
+           maxvalue: 449.99999
          action:
            name: reject
 
@@ -269,21 +274,6 @@
            flag all filter variables if any test variable is out of bounds: true
            minvalue: 0.0
            maxvalue: 0.5
-
-       # Toss the data if the hofx has missing value
-       - filter: Domain Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *atms_npp_channels
-         where:
-         - variable:
-             name: brightnessTemperature@HofX
-             channels: *atms_npp_channels
-           value: is_valid
-           minvalue: 50
-           maxvalue: 500
-         action:
-           name: reject
 
        # Step 0-C: Assign Initial All-Sky Observation Error
        - filter: Perform Action


### PR DESCRIPTION

* As described in (https://github.com/NOAA-EMC/RDASApp/issues/398), the JEDI crashed at some cycles caused by the missing hofx when assimilating satellite radiance data. This issue has been investigated and confirmed that it is originated from MPAS model forecast caused the inverse pressure at the lowest two model levels on the high altitude terrain. Before the actual bug being fixed, a QC filter is required to exclude this situation that could cause JEDI crash during the retro experiment cycles.
* This Domain Check filter has been added to abi_g16, abi_g18, atms_npp, atms_n20, and atms_n21 jedi yaml file.
 ```
# Toss data if the hofx has missing value
       - filter: Domain Check
         filter variables:
         - name: brightnessTemperature
           channels: *abi_g16_channels
         where:
         - variable:
             name: brightnessTemperature@HofX
             channels: *abi_g16_channels
           value: is_valid
           minvalue: 50
           maxvalue: 500
         action:
           name: reject


```