### PR TITLE
[bugfix] Convert timeOffset to units of seconds

### DIFF
--- a/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.py
+++ b/rrfs-test/IODA/python/bufr2ioda_adpupa_prepbufr.py
@@ -176,7 +176,7 @@ def bufr_to_ioda(config, logger):
 
     # Time variable
     hrdr = r.get('timeOffset', 'prepbufrDataLevelCategory', type='float')
-    toff = hrdr
+    toff = np.round(hrdr*3600.)
     ulan = r.get('releaseTime')
     ulan = np.int64(ulan*3600)
 


### PR DESCRIPTION
## Bug Fix Description

**Description of Current Behavior:**
- The python converter for ADPUPA computes timeOffset in units of hours

**Description of Fixed Behavior:**
- Convert to units of seconds as expected in the jedivar.yaml