### PR TITLE
hotfix for the latest GAEA HPC update

### DIFF
--- a/modulefiles/RDAS/gaea.intel.lua
+++ b/modulefiles/RDAS/gaea.intel.lua
@@ -67,6 +67,7 @@ load("py-pyyaml/6.0")
 load("py-scipy/1.11.3")
 load("py-xarray/2023.7.0")
 
+unload("cray-libsci")
 setenv("CC","cc")
 setenv("FC","ftn")
 setenv("CXX","CC")


### PR DESCRIPTION
## Bug Fix Description
The Gaea system has been updated in the latest maintenance, and RDASApp failed to build.
This PR addresses this.

## Issue(s) addressed
None

## Dependencies (if applicable)
None