### PR TITLE
Update path to `RDAS_DATA` on WCOSS2

### DIFF
--- a/ush/init.sh
+++ b/ush/init.sh
@@ -6,7 +6,7 @@ basedir="$(dirname "$ushdir")"
 
 case ${MACHINE_ID} in
   wcoss2)
-    RDAS_DATA=/lfs/h2/emc/da/noscrub/Ting.Lei/dr-rdas-data/RDAS_DATA
+    RDAS_DATA=/lfs/h2/emc/lam/noscrub/RDAS_DATA
     ;;
   hera)
     RDAS_DATA=/scratch4/BMC/rtrr/RDAS_DATA


### PR DESCRIPTION
## Description
With https://github.com/NOAA-EMC/rrfs-workflow/pull/893, we updated the paths to `FIX_RRFS2` and `RRFS2_RETRO_DATA` now that we have settled on a permanent location to store those data on WCOSS2. This PR correspondingly updates the path to `RDAS_DATA` that is now saved in the same location. 

## Issue(s) addressed
N/A

## Dependencies (if applicable)
None

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
