### PR TITLE
 Remove references to `/scratch[1,2]` on Hera and update EVA modulefile to now use spack-stack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,3 +78,8 @@
 	url = https://github.com/NOAA-EMC/bufr-query.git
 	branch = develop
 	ignore = all
+[submodule "sorc/wxflow"]
+	path = sorc/wxflow
+	url = https://github.com/NOAA-EMC/wxflow.git
+        branch = develop
+        ignore = all

--- a/modulefiles/EVA/hera.lua
+++ b/modulefiles/EVA/hera.lua
@@ -8,11 +8,26 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-prepend_path("MODULEPATH", '/scratch1/NCEPDEV/da/python/opt/modulefiles/stack')
+prepend_path("MODULEPATH", '/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core')
 
-load("hpc/1.2.0")
-load("miniconda3/4.6.14")
-load("eva/1.0.0")
+load("stack-intel/2021.5.0")
+load("stack-intel-oneapi-mpi/2021.5.1")
+load("stack-python/3.10.13")
+load("py-jinja2/3.0.3")
+load("py-netcdf4/1.5.8")
+load("py-pybind11/2.11.0")
+load("py-pycodestyle/2.11.0")
+load("py-pyyaml/6.0")
+load("py-scipy/1.11.3")
+load("py-xarray/2023.7.0")
+load("py-matplotlib/3.7.3")
+load("py-cartopy/0.21.1")
+
+-- And load additional modules (e.g., seaborn) from our new RDASAppPy env
+local venv_path = "/scratch3/NCEPDEV/fv3-cam/RDASAppPy"
+setenv("VIRTUAL_ENV", venv_path)
+prepend_path("PATH", pathJoin(venv_path, "bin"))
+prepend_path("PYTHONPATH", pathJoin(venv_path, "lib/python3.10/site-packages"))
 
 whatis("Name: ".. pkgName)
 whatis("Version: ".. pkgVersion)

--- a/modulefiles/RDAS/hera.gnu.lua
+++ b/modulefiles/RDAS/hera.gnu.lua
@@ -71,9 +71,6 @@ load("py-pyyaml/6.0")
 load("py-scipy/1.11.3")
 load("py-xarray/2023.7.0")
 
--- hack for wxflow
-prepend_path("PYTHONPATH", "/scratch1/NCEPDEV/da/python/gdasapp/wxflow/20240307/src")
-
 setenv("CC","mpicc")
 setenv("FC","mpif90")
 setenv("CXX","mpicxx")

--- a/modulefiles/RDAS/hera.intel.lua
+++ b/modulefiles/RDAS/hera.intel.lua
@@ -71,9 +71,6 @@ load("py-pyyaml/6.0")
 load("py-scipy/1.11.3")
 load("py-xarray/2023.7.0")
 
--- hack for wxflow
-prepend_path("PYTHONPATH", "/scratch1/NCEPDEV/da/python/gdasapp/wxflow/20240307/src")
-
 setenv("CC","mpiicc")
 setenv("FC","mpiifort")
 setenv("CXX","mpiicpc")

--- a/modulefiles/RDAS/jet.gnu.lua
+++ b/modulefiles/RDAS/jet.gnu.lua
@@ -72,9 +72,6 @@ load("py-pyyaml/6.0")
 load("py-scipy/1.12.0")
 load("py-xarray/2023.7.0")
 
--- hack for wxflow
-prepend_path("PYTHONPATH", "/lfs5/BMC/nrtrr/RDAS_DATA/python/20240307")
-
 setenv("CC","mpicc")
 setenv("FC","mpif90")
 setenv("CXX","mpicxx")

--- a/modulefiles/RDAS/jet.intel.lua
+++ b/modulefiles/RDAS/jet.intel.lua
@@ -72,9 +72,6 @@ load("py-pyyaml/6.0")
 load("py-scipy/1.11.3")
 load("py-xarray/2023.7.0")
 
--- hack for wxflow
-prepend_path("PYTHONPATH", "/lfs5/BMC/nrtrr/RDAS_DATA/python/20240307")
-
 setenv("CC","mpiicc")
 setenv("FC","mpiifort")
 setenv("CXX","mpiicpc")

--- a/rrfs-test/IODA/python/run_bufr2ioda.sh
+++ b/rrfs-test/IODA/python/run_bufr2ioda.sh
@@ -44,6 +44,9 @@ fi
 PYIODALIB=`echo $DIR_ROOT/build/lib/python3.*`
 export PYTHONPATH=${PYIODALIB}:${PYTHONPATH}
 
+# add wxflow libraries
+export PYTHONPATH="${PYTHONPATH}:${DIR_ROOT}/sorc/wxflow/src"
+
 #----- python and json -----
 # first specify what observation types will be processed by a script
 BUFR_py="msonet_prepbufr"

--- a/rrfs-test/IODA/python/run_bufr2ioda_radiance.sh
+++ b/rrfs-test/IODA/python/run_bufr2ioda_radiance.sh
@@ -12,7 +12,7 @@ ulimit -a
 #   4  RDASApp/rrfs-test/IODA/yaml/bufr_1bamua_mapping.yaml
 #                                                                       #
 #########################################################################
-RDASApp_dir=/scratch1/NCEPDEV/stmp2/Xiaoyan.Zhang/RDASApp_obsforge
+readonly RDASApp_dir=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )/../../.." && pwd -P)
 
 # ===============================
 # Load obsForge required modules

--- a/rrfs-test/scripts/setup_experiment.sh
+++ b/rrfs-test/scripts/setup_experiment.sh
@@ -145,7 +145,7 @@ if [[ $GSI_TEST_DATA == "YES" ]]; then
   echo "  --> gsi data on $MACHINE_ID"
   cd $YOUR_EXPERIMENT_DIR
   if [[ $MACHINE_ID == "hera" ]]; then
-    rsync -a /scratch2/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/staged-data/gsi_2022052619 .
+    rsync -a /scratch4/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/staged-data/gsi_2022052619 .
   elif [[ $MACHINE_ID == "orion" ]]; then
     rsync -a /work/noaa/fv3-cam/dlippi/RRFSv2/staged-data/gsi_2022052619 .
   elif [[ $MACHINE_ID == "jet" ]]; then

--- a/rrfs-test/scripts/setup_experiment.sh
+++ b/rrfs-test/scripts/setup_experiment.sh
@@ -49,7 +49,7 @@ fi
 
 case ${MACHINE_ID} in
   hera)
-    RDAS_DATA=/scratch1/NCEPDEV/fv3-cam/RDAS_DATA
+    RDAS_DATA=/scratch4/BMC/rtrr/RDAS_DATA
     ;;
   jet)
     RDAS_DATA=/lfs4/BMC/nrtrr/RDAS_DATA

--- a/rrfs-test/scripts/setup_gsi_parallel.sh
+++ b/rrfs-test/scripts/setup_gsi_parallel.sh
@@ -38,7 +38,7 @@ echo -e "\tYOUR_PATH_TO_GSI=$YOUR_PATH_TO_GSI"
 # Get current machine so we can find GSI fix data 
 case ${MACHINE_ID} in
   hera)
-    RDAS_DATA=/scratch1/NCEPDEV/fv3-cam/RDAS_DATA
+    RDAS_DATA=/scratch4/BMC/rtrr/RDAS_DATA
     ;;
   jet)
     RDAS_DATA=/lfs4/BMC/nrtrr/RDAS_DATA

--- a/rrfs-test/ush/diagnostics_and_graphics/run_convert_diags.sh
+++ b/rrfs-test/ush/diagnostics_and_graphics/run_convert_diags.sh
@@ -31,7 +31,7 @@ EDATE=2024050623
 # V2 retro experiment details (similar to rrfs-workflow/workflow/exp.setup)
 VERSION="v2.0.9"
 EXP_NAME="baseline1_3denvar12km209"
-OPSROOT="/scratch2/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/workflow/${VERSION}"
+OPSROOT="/scratch4/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/workflow/${VERSION}"
 COMROOT="${OPSROOT}/exp/${EXP_NAME}/com"
 DATAROOT="${OPSROOT}/exp/${EXP_NAME}/stmp"
 JDIAGDIR="${DATAROOT}"
@@ -39,7 +39,7 @@ JDIAGDIR="${DATAROOT}"
 # RRFSv1 EXP_NAME (RRFSv1 = benchmark)
 CTL_VERSION="v0.8.6"
 CTL_NAME="CONUS13km_ColdStart00-12Z_133-233TQW"
-DATA_SOURCE="/scratch1/BMC/wrfruc/rli/RRFS_V1/rrfs.${CTL_VERSION}/${CTL_NAME}/stmp"
+DATA_SOURCE="/scratch3/BMC/wrfruc/Ruifang.Li/RRFS_V1/rrfs.${CTL_VERSION}/${CTL_NAME}/stmp"
 CTL_OPSROOT="${OPSROOT}"
 CTL_DATAROOT="${CTL_OPSROOT}/exp/${CTL_NAME}/stmp"
 CTL_JDIAGDIR="${CTL_DATAROOT}"
@@ -48,7 +48,7 @@ CTL_JDIAGDIR="${CTL_DATAROOT}"
 INCLUDE_PATTERN="diag_conv_*.nc4.gz"
 
 # Specify your RDASApp build (mostly for module loads)
-RDASApp="/scratch2/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/PRs/RDASApp.20241204.phase2_sonde"
+RDASApp="/scratch4/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/PRs/RDASApp.20241204.phase2_sonde"
 
 # Specify the diag directories
 #### END OF USER-DEFINED VARIABLES ##########################################
@@ -117,7 +117,7 @@ while [[ ${date} -le ${EDATE} ]]; do
   if [[ ${CONVERT_JDIAG_TO_GDIAG:=NO} == "YES" ]] ; then
     echo "? Working on convert jdiag to gdiag: ${pdy} ${cyc}Z"
     # Array of full file paths (only need to specify _anl files)
-    #jdiags=(/scratch2/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/PRs/RDASApp.20250324.DA_mon/rrfs-test/ush/diagnostics_and_graphics/jedivar_06/jdiag*)
+    #jdiags=(/scratch4/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/PRs/RDASApp.20250324.DA_mon/rrfs-test/ush/diagnostics_and_graphics/jedivar_06/jdiag*)
     jdiags=(${JDIAGDIR}/${pdy}/rrfs_jedivar_${cyc}_${VERSION}/det/jedivar_${cyc}/jdiag*)
     #echo ${jdiags[1]}; exit
 

--- a/rrfs-test/ush/diagnostics_and_graphics/run_diagnostics.sh
+++ b/rrfs-test/ush/diagnostics_and_graphics/run_diagnostics.sh
@@ -51,9 +51,9 @@ export USE_LESS_EQUAL=true #true: <=; false: ==
 # Retro experiment details (similar to rrfs-workflow/workflow/exp.setup)
 VERSION="v2.0.9"
 EXP_NAME="baseline1_3denvar12km209"
-OPSROOT="/scratch2/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/workflow/${VERSION}"
+OPSROOT="/scratch4/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/workflow/${VERSION}"
 #EXP_NAME="baseline1_3dvar12km209"
-#OPSROOT="/scratch2/NCEPDEV/fv3-cam/Xiaoyan.Zhang/noscrub/JEDI/RRFSV2/workflow/${VERSION}"
+#OPSROOT="/scratch4/NCEPDEV/fv3-cam/Xiaoyan.Zhang/noscrub/JEDI/RRFSV2/workflow/${VERSION}"
 #VERSION="v0.8.6"
 #EXP_NAME="CONUS13km_ColdStart00-12Z_133-233TQW"
 COMROOT="${OPSROOT}/exp/${EXP_NAME}/com"
@@ -64,7 +64,7 @@ JDIAGDIR="${COMROOT}"
 # Control experiment details - only used in 2) Two-Experiment Comparison Plots (Retro vs Control)
 #CTL_VERSION="v2.0.9"
 #CTL_NAME="baseline1_3dvar12km209"
-#CTL_OPSROOT="/scratch2/NCEPDEV/fv3-cam/Xiaoyan.Zhang/noscrub/JEDI/RRFSV2/workflow/${CTL_VERSION}"
+#CTL_OPSROOT="/scratch4/NCEPDEV/fv3-cam/Xiaoyan.Zhang/noscrub/JEDI/RRFSV2/workflow/${CTL_VERSION}"
 CTL_VERSION="v0.8.6"
 CTL_NAME="CONUS13km_ColdStart00-12Z_133-233TQW"
 CTL_OPSROOT="${OPSROOT}"
@@ -74,7 +74,7 @@ CTL_LOGDIR="${CTL_COMROOT}/rrfs/${CTL_VERSION}/logs"
 CTL_JDIAGDIR="${CTL_DATAROOT}"
 
 # Specify your RDASApp build (mostly for module loads)
-RDASApp="/scratch2/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/PRs/RDASApp.20241204.phase2_sonde"
+RDASApp="/scratch4/NCEPDEV/fv3-cam/Donald.E.Lippi/RRFSv2/PRs/RDASApp.20241204.phase2_sonde"
 
 # Options only for MAP_DOMAINCOMPARISON_MPAS_FV3
 #MPAS_DOMAIN="${RDASApp}/expr/mpas_2024052700/data/invariant.nc"
@@ -84,7 +84,7 @@ FV3_DOMAIN="${CTL_DATAROOT}/20240506/rrfs_jedivar_01_v0.8.6/det/jedivar_01/grid_
 
 # Options for analysis increment plot
 LEVEL=1 # actual level (not python index; mpas only plots; 1=lowest model level)
-FV3BKG_SOURCE="/scratch1/BMC/wrfruc/rli/RRFS_V1/rrfs.${CTL_VERSION}/${CTL_NAME}/nwges"
+FV3BKG_SOURCE="/scratch3/BMC/wrfruc/Ruifang.Li/RRFS_V1/rrfs.${CTL_VERSION}/${CTL_NAME}/nwges"
 
 # Options for timesereies plot
 BIN=19 # -1: Entire Column, 1: Top Level, 19: Bottom Level (uses same binning as profiles).

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -77,12 +77,15 @@ elif [[ -d /lfs/h1 && ! -d /lfs/h3 ]]; then
 elif [[ -d /mnt/lfs5 ]]; then
   # We are on NOAA Jet
   MACHINE_ID=jet
-elif [[ -d /scratch1 ]]; then
-  # We are on NOAA Hera
-  MACHINE_ID=hera
 elif [[ -d /scratch3 ]]; then
-  # We are on NOAA Ursa
-  MACHINE_ID=ursa
+  # We are on NOAA Hera or Ursa
+  if [[ -d /apps/slurm_hera ]]; then
+    # We are on Hera
+    MACHINE_ID=hera
+  else
+    # We are on Ursa
+    MACHINE_ID=ursa
+  fi
 elif [[ -d /work ]]; then
   # We are on MSU Orion or Hercules
   if [[ -d /apps/other ]]; then

--- a/ush/linter_yamlcheck.sh
+++ b/ush/linter_yamlcheck.sh
@@ -8,7 +8,8 @@ case ${MACHINE_ID} in
     EXEC_DIR=/to/be/added
     ;;
   hera)
-    EXEC_DIR=/scratch1/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
+    # Note: bokeh env installed on Ursa but linter checks still work on Hera
+    EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin
     ;;
   ursa)
     EXEC_DIR=/scratch3/BMC/wrfruc/gge/Miniforge3/envs/bokeh/bin


### PR DESCRIPTION
## Description

This PR removes lingering references to Hera's `/scratch[1,2]` in RDASApp. 

One problem with this transition is that the EVA modules were previously installed only on `/scratch1` and no longer exist. This module is typically loaded by developers to test various python utilities in RDASApp such as the offline domain check, etc. To get around the removal of the EVA modules, `modulefiles/EVA/hera.lua` now loads modules from spack-stack. A python virtual environment is also set up on Hera and loaded through this modulefile to give us access to an extra package needed for some of the diagnostic tools in RDASApp. There should be no change to how this module is loaded (it is still called EVA in RDASApp) and developers should "hopefully" see no impact. 

Additionally, this PR adds `wxflow` as a submodule to RDASApp. This tool is used to run some of the bufr2ioda python tools and was previously sourced in the RDAS modulefiles using pre-installed versions on `/scratch1`. Adding `wxflow` as a git submodule removes the need for sourcing it from pre-installed versions. 

## Issue(s) addressed
#423 

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR - not applicable 
- [ ] Unit tests added/updated (if applicable).
