### PR TITLE
Bugfix to make offline domain check work with various versions of SciPy

### DIFF
--- a/rrfs-test/IODA/offline_domain_check.py
+++ b/rrfs-test/IODA/offline_domain_check.py
@@ -82,7 +82,12 @@ def alpha_shape(points, alpha, only_outer=True):
     edges = set()
     # Loop over triangles:
     # ia, ib, ic = indices of corner points of the triangle
-    for ia, ib, ic in tri.vertices:
+    # Depending on SciPy version, might need tri.simplices or tri.vertices
+    if hasattr(tri, "simplices"):
+        triangles = tri.simplices
+    else:
+        triangles = tri.vertices
+    for ia, ib, ic in triangles:
         pa = points[ia]
         pb = points[ib]
         pc = points[ic]

--- a/rrfs-test/IODA/offline_domain_check_satrad.py
+++ b/rrfs-test/IODA/offline_domain_check_satrad.py
@@ -82,7 +82,12 @@ def alpha_shape(points, alpha, only_outer=True):
     edges = set()
     # Loop over triangles:
     # ia, ib, ic = indices of corner points of the triangle
-    for ia, ib, ic in tri.vertices:
+    # Depending on SciPy version, might need tri.simplices or tri.vertices
+    if hasattr(tri, "simplices"):
+        triangles = tri.simplices
+    else:
+        triangles = tri.vertices
+    for ia, ib, ic in triangles:
         pa = points[ia]
         pb = points[ib]
         pc = points[ic]


### PR DESCRIPTION

## Bug Fix Description

With #424, we switched to using spack-stack on Hera to load the Python modules needed for various RDASApp scripts. This spack-stack installation includes a newer version of SciPy, which changes the Delaunay API and breaks some of the offline domain check code. Thank you @HuiLiu-NOAA for catching this problem.

In older SciPy versions, the Delaunay object stores triangle indices in `tri.vertices`. In newer versions, this attribute has been renamed to `tri.simplices` (with identical content). To make the offline domain check work across different SciPy versions, this PR adds a runtime check that uses whichever attribute is available (`tri.simplices` if present, otherwise `tri.vertices`).

Note: **this change does not affect the domain checks in rrfs-workflow**. The workflow always loads Python modules from spack-stack, so it only requires `tri.simplices` which is already used in the code in that repo. This update is purely to ensure RDASApp scripts can run with both the newer SciPy version from spack-stack and the older SciPy versions still available through the EVA module stack on some machines.

**Description of Current Behavior:**
Offline domain check codes inside RDASApp crash when using later SciPy versions

**Description of Fixed Behavior:**
Offline domain check codes can run no matter the SciPy version

## Issue(s) addressed
N/A

## Dependencies (if applicable)
N/A

## Checklist
- [x] I have performed a self-review of my own code.
