### PR TITLE
Add Spack-installed ncepbufr to EVA on Hera

### DIFF
--- a/modulefiles/EVA/hera.lua
+++ b/modulefiles/EVA/hera.lua
@@ -23,6 +23,9 @@ load("py-xarray/2023.7.0")
 load("py-matplotlib/3.7.3")
 load("py-cartopy/0.21.1")
 
+-- Add Spack-installed ncepbufr to PYTHONPATH
+prepend_path("PYTHONPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/intel/2021.5.0/bufr-12.0.1-nz7jhfd/lib64/python3.10/site-packages")
+
 -- And load additional modules (e.g., seaborn) from our new RDASAppPy env
 local venv_path = "/scratch3/NCEPDEV/fv3-cam/RDASAppPy"
 setenv("VIRTUAL_ENV", venv_path)


### PR DESCRIPTION
## Description
Adds the python module "ncepbufr" to EVA on Hera. Ncepbufr is a python module used for plotting directly from the bufr format and useful for debugging differences between bufr and ioda.

## Issue(s) addressed
N/A

## Dependencies (if applicable)
N/A

## Checklist
- [x] I have performed a self-review of my own code.
