### PR TITLE
Remove virtual or conda environments before building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,18 @@
 # 2 - configure; build; install
 # 4 - optional, run unit tests
 
+# Deactivate virtual env or conda env to prevent build issues
+if [[ -n "$VIRTUAL_ENV" || -n "$CONDA_PREFIX" ]]; then
+  unset VIRTUAL_ENV
+  unset CONDA_PREFIX
+  unset CONDA_DEFAULT_ENV
+  unset CONDA_SHLVL
+  export PATH=$(echo "$PATH" | tr ':' '\n' | grep -vi 'conda' | grep -vi 'miniforge' | paste -sd ':' -)
+  if [[ -n "$LD_LIBRARY_PATH" ]]; then
+    export LD_LIBRARY_PATH=$(echo "$LD_LIBRARY_PATH" | tr ':' '\n' | grep -vi 'conda' | grep -vi 'miniforge' | paste -sd ':' -)
+  fi
+fi
+
 module purge
 set -eu
 START=$(date +%s)


### PR DESCRIPTION

## Description

As found by @keenaneure in #427, building RDASApp can fail if an Anaconda or Python virtual environment is currently active. This happens because environment variables and `PATH` entries from these environments can cause the build to link against incompatible libraries. The build might progress for a while just fine but then fail at a pretty late stage. 

Running module purge alone is not always sufficient to clear out these environments. Here, we add a block to explicitly unset these variables and strip any Conda/Miniforge-related paths from `PATH` and `LD_LIBRARY_PATH` before the build starts, ensuring a clean and consistent build environment.

Note: I originally tried using `deactivate` and `conda deactivate` as discussed in #427, but these commands often fail in non-interactive build shells because the shell functions they depend on are not loaded (e.g., `conda init` or `source conda.sh`). The new approach avoids that problem by directly unsetting the relevant variables and cleaning the environment, which works regardless of whether the deactivate commands are available.

I tested this by loading @keenaneure's Miniforge3 environment and then building RDASApp. Everything ran successfully and all executables were built. 

## Issue(s) addressed
#427 

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
