### PR TITLE
[Bugfix] fix to build JCB step

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -186,6 +186,7 @@ if [[ $BUILD_JCB == 'YES' ]]; then
   PYTHONPATH="${PYTHONPATH}:$dir_root/sorc/jcb/src/:$dir_root/build/lib/python3.*:${dir_root}/sorc/wxflow/src"
   cd $dir_root/sorc/jcb/src/jcb/configuration/apps/rdas/test/client_integration
   python run.py
+  cd ${BUILD_DIR}
 fi
 
 # Create super yamls and link in test data


### PR DESCRIPTION
## Bug Fix Description

**Description of Current Behavior:**
1. At the end of the recently added BUILD_JCB step `cd ${BUILD_DIR}` was missing. This was causing build errors when using the `./build.sh -t NO` option. "`-t NO`" turns off `BUILD_RRFS_TEST` which defaults to `YES` which has the `cd ${BUILD_DIR}` step and why in testing this error wasn't caught.

**Description of Fixed Behavior:**
1. Now the system builds in the correct path.
