### PR TITLE
add `empty obs space action: "skip output"` for all observers

### DIFF
--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
@@ -16,6 +16,7 @@
              obsfile: "data/obs/ioda_abi_g16.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_abi_g16.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
@@ -16,6 +16,7 @@
              obsfile: "data/obs/ioda_abi_g18.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_abi_g18.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_181.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_181.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_airTemperature_181.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_183.yaml
@@ -14,6 +14,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_airTemperature_183.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_airTemperature_187.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_airTemperature_187.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_181.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_181.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_specificHumidity_181.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_183.yaml
@@ -14,6 +14,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_specificHumidity_183.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_specificHumidity_187.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_specificHumidity_187.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_181.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_181.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_stationPressure_181.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_stationPressure_187.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_stationPressure_187.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_281.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_281.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_winds_281.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_284.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_284.yaml
@@ -14,6 +14,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_winds_284.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpsfc_winds_287.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_winds_287.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_120.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_airTemperature_120.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_132.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_airTemperature_132.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_airTemperature_132.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_120.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_specificHumidity_120.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_132.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_specificHumidity_132.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_specificHumidity_132.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_stationPressure_120.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_stationPressure_120.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_stationPressure_120.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_220.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_winds_220.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_232.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/adpupa_winds_232.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_adpupa_winds_232.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_airTemperature_133.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_airTemperature_133.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_specificHumidity_133.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_specificHumidity_133.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircar_winds_233.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircar_winds_233.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_130.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_airTemperature_130.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_131.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_airTemperature_131.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_134.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_airTemperature_134.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_airTemperature_135.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_airTemperature_135.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_specificHumidity_134.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_specificHumidity_134.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_230.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_winds_230.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_231.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_winds_231.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_234.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_winds_234.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/aircft_winds_235.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_aircft_winds_235.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-b.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-b.yaml
@@ -12,6 +12,7 @@
              obsfile: "data/obs/ioda_amsua_metop-b.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_amsua_metop-b.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-c.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-c.yaml
@@ -12,6 +12,7 @@
              obsfile: "data/obs/ioda_amsua_metop-c.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_amsua_metop-c.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
@@ -12,6 +12,7 @@
              obsfile: "data/obs/ioda_amsua_n19.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_amsua_n19.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
@@ -22,6 +22,7 @@
              obsfile: "data/obs/ioda_atms_n20.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_atms_n20.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
@@ -28,6 +28,7 @@
              obsfile: "data/obs/ioda_atms_n21.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_atms_n21.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
@@ -22,6 +22,7 @@
              obsfile: "data/obs/ioda_atms_npp.nc"
              missing file action: "warn"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_atms_npp.nc4

--- a/rrfs-test/validated_yamls/templates/obtype_config/gnss_zenithTotalDelay.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/gnss_zenithTotalDelay.yaml
@@ -16,6 +16,7 @@
            sort variable: "pressure"
            sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_gnss_ztd.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_airTemperature_188.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_airTemperature_188.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_specificHumidity_188.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_specificHumidity_188.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_stationPressure_188.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_stationPressure_188.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/msonet_winds_288.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_msonet_winds_288.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/proflr_winds_227.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/proflr_winds_227.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_proflr_winds_227.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/rassda_airTemperature_126.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/rassda_airTemperature_126.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_rassda_airTemperature_126.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_180.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_180.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_airTemperature_180.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_182.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_airTemperature_182.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_airTemperature_183.yaml
@@ -14,6 +14,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_airTemperature_183.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_180.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_180.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_specificHumidity_180.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_182.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_specificHumidity_182.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_183.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_specificHumidity_183.yaml
@@ -14,6 +14,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_specificHumidity_183.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_180.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_180.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_stationPressure_180.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_stationPressure_182.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_stationPressure_182.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_280.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_280.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_winds_280.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_282.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_winds_282.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_284.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/sfcshp_winds_284.yaml
@@ -14,6 +14,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_winds_284.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/vadwnd_winds_224.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/vadwnd_winds_224.yaml
@@ -13,6 +13,7 @@
              sort variable: "pressure"
              sort order: "descending"
          obsdataout:
+           empty obs space action: "skip output"
            engine:
              type: H5File
              obsfile: jdiag_vadwnd_winds_224.nc


### PR DESCRIPTION
## Description
PR https://github.com/JCSDA-internal/ioda/pull/1446 added the capability to skip writing out jdiag files for empty obs space.
Writing out jdiag files for empty obs space causes confusions for lots of end users. NSSL users also shared a similar concern.
This PR adds `empty obs space action: "skip output"` to the `obsdataout` section for all observers.

## Issue(s) addressed
None

## Dependencies (if applicable)
None
