### PR TITLE
update satellite radiance observers to get satbias files from `satbias_in` and write to `satbias_out`

### DIFF
--- a/fix/expr_data/fv3_2024052700/data/satbias_in
+++ b/fix/expr_data/fv3_2024052700/data/satbias_in
@@ -1,0 +1,1 @@
+../../../.agent/expr_data/satbias_in_20250914

--- a/fix/expr_data/mpas_2024052700/satbias_in
+++ b/fix/expr_data/mpas_2024052700/satbias_in
@@ -1,0 +1,1 @@
+../../.agent/expr_data/satbias_in_20250914

--- a/rrfs-test/scripts/link_fv3jedi_expr.sh
+++ b/rrfs-test/scripts/link_fv3jedi_expr.sh
@@ -27,7 +27,9 @@ cp ${RDASApp}/rrfs-test/ush/fv3jedi_increment_fulldom.py .
 rm -rf data; mkdir data
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/data/* data/
 # link correct ioda files
-rm -rf data/obs; mkdir  data/obs
+rm -rf data/{obs,satbias_in}
+mkdir -p data/{obs,satbias_in,satbias_out}
+ln -snf ${RDASApp}/fix/expr_data/${exprname}/data/satbias_in/* data/satbias_in/
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/data/obs/* data/obs/  # keep this line for now to be backward compatible
 for dcfile in data/obs/ioda*dc.nc; do # link to DA runtime prescribed file names
   dcfile=${dcfile##*obs/}

--- a/rrfs-test/scripts/link_mpasjedi_expr.sh
+++ b/rrfs-test/scripts/link_mpasjedi_expr.sh
@@ -47,11 +47,12 @@ cp ${RDASApp}/rrfs-test/ush/mpasjedi_spread.py .
 
 mkdir -p data
 cd data
-mkdir -p bumploc obs ens
+mkdir -p bumploc obs ens satbias_in satbias_out
 ln -snf ${RDASApp}/fix/bumploc/${BUMPLOC} bumploc/${BUMPLOC}
 ln -snf ${RDASApp}/fix/B_static/L55_20241204 B_static
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/bkg/mpasout.2024-05-27_00.00.00.nc .
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/invariant.nc invariant.nc
+ln -snf ${RDASApp}/fix/expr_data/${exprname}/satbias_in/* satbias_in/
 # link the correct ioda files
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/obs/* obs/  # keep this line for now to be backward compatible
 ln -snf ${RDASApp}/fix/expr_data/${exprname}/obs/ioda_msonet.nc obs/ioda_msonet_ctest.nc

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
@@ -47,14 +47,14 @@
   # Observation Bias Correction (VarBC)
   # -----------------------------------
        obs bias:
-         input file: data/obs/abi_g16.satbias.nc4
-         output file: out_abi_g16.satbias.nc4
+         input file: data/satbias_in/abi_g16.satbias.nc
+         output file: data/satbias_out/abi_g16.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &abi_g16_tlapse data/obs/abi_g16.tlapse.txt
+             tlapse: &abi_g16_tlapse data/satbias_in/abi_g16.tlapse.txt
            - name: lapseRate
              tlapse: *abi_g16_tlapse
            - name: emissivityJacobian
@@ -75,11 +75,11 @@
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/abi_g16.satbias_cov.nc4
+             input file: data/satbias_in/abi_g16.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_abi_g16.satbias_cov.nc4
+           output file: data/satbias_out/abi_g16.satbias_cov.nc
 
   # Observation Filters (QC)
   # ------------------------

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
@@ -47,14 +47,14 @@
   # Observation Bias Correction (VarBC)
   # -----------------------------------
        obs bias:
-         input file: data/obs/abi_g18.satbias.nc4
-         output file: out_abi_g18.satbias.nc4
+         input file: data/satbias_in/abi_g18.satbias.nc
+         output file: data/satbias_out/abi_g18.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &abi_g18_tlapse data/obs/abi_g18.tlapse.txt
+             tlapse: &abi_g18_tlapse data/satbias_in/abi_g18.tlapse.txt
            - name: lapseRate
              tlapse: *abi_g18_tlapse
            - name: emissivityJacobian
@@ -75,11 +75,11 @@
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/abi_g18.satbias_cov.nc4
+             input file: data/satbias_in/abi_g18.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_abi_g18.satbias_cov.nc4
+           output file: data/satbias_out/abi_g18.satbias_cov.nc
 
   # Observation Filters (QC)
   # ------------------------

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-b.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-b.yaml
@@ -36,14 +36,14 @@
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
        obs bias:
-         input file: data/obs/amsua_metop-b.satbias.nc4
-         output file: out_amsua_metop-b.satbias.nc4
+         input file: data/satbaias_in/amsua_metop-b.satbias.nc
+         output file: data/satbaias_out/amsua_metop-b.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &amsua_metop-b_tlapse data/obs/amsua_metop-b.tlapse.txt
+             tlapse: &amsua_metop-b_tlapse data/satbias_in/amsua_metop-b.tlapse.txt
            - name: lapseRate
              tlapse: *amsua_metop-b_tlapse
            - name: emissivityJacobian
@@ -60,11 +60,11 @@
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/amsua_metop-b.satbias_cov.nc4
+             input file: data/satbias_in/amsua_metop-b.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_amsua_metop-b.satbias_cov.nc4
+           output file: data/satbias_out/amsua_metop-b.satbias_cov.nc
        obs pre filters:
        # Step 0-A: Create Diagnostic Flags
        - filter: Create Diagnostic Flags

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-b.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-b.yaml
@@ -36,8 +36,8 @@
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
        obs bias:
-         input file: data/satbaias_in/amsua_metop-b.satbias.nc
-         output file: data/satbaias_out/amsua_metop-b.satbias.nc
+         input file: data/satbias_in/amsua_metop-b.satbias.nc
+         output file: data/satbias_out/amsua_metop-b.satbias.nc
          variational bc:
            predictors:
            - name: constant

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-b.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-b.yaml
@@ -2,6 +2,10 @@
          name: amsua_metop-b
          _anchor_channels: &amsua_metop-b_channels 1-15
          _anchor_use_flag: &amsua_metop-b_use_flag [ -1,  -1,  -1,  -1,  -1, -1, -1,  1,  1,  1,  -1,   -1,   -1, -1,  -1 ]
+         _anchor_error: &amsua_metop-b_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
          _anchor_obserr_bound_max: &amsua_metop-b_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
          distribution:
            name: "@DISTRIBUTION@"
@@ -179,9 +183,7 @@
            channels: *amsua_metop-b_channels
            options:
              channels: *amsua_metop-b_channels
-             obserr_clearsky: [ 2.500, 2.200, 2.000, 0.550, 0.300,
-                                0.230, 0.230, 0.250, 0.250, 0.350,
-                                0.400, 0.550, 0.800, 3.000, 3.500]
+             obserr_clearsky: *amsua_metop-b_error
              clwret_function:
                name: ObsFunction/CLWRetMW
                options:
@@ -333,9 +335,8 @@
                    err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
                             0.300,  0.230,  0.250,  0.250,  0.350,
                             0.400,  0.550,  0.800,  3.000, 18.000]
-               obserr_clearsky: [2.500, 2.200, 2.000, 0.550, 0.300,
-                                  0.230, 0.230, 0.250, 0.250, 0.350,
-                                  0.400, 0.550, 0.800, 3.000, 3.500]
+               obserr_clearsky: *amsua_metop-b_error
+
        #  Gross check
        - filter: Background Check
          filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-c.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-c.yaml
@@ -36,14 +36,14 @@
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
        obs bias:
-         input file: data/obs/amsua_metop-c.satbias.nc4
-         output file: out_amsua_metop-c.satbias.nc4
+         input file: data/satbias_in/amsua_metop-c.satbias.nc
+         output file: data/satbias_out/amsua_metop-c.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &amsua_metop-c_tlapse data/obs/amsua_metop-c.tlapse.txt
+             tlapse: &amsua_metop-c_tlapse data/satbias_in/amsua_metop-c.tlapse.txt
            - name: lapseRate
              tlapse: *amsua_metop-c_tlapse
            - name: emissivityJacobian
@@ -60,11 +60,11 @@
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/amsua_metop-c.satbias_cov.nc4
+             input file: data/satbias_in/amsua_metop-c.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_amsua_metop-c.satbias_cov.nc4
+           output file: data/satbias_out/amsua_metop-c.satbias_cov.nc
        obs pre filters:
        # Step 0-A: Create Diagnostic Flags
        - filter: Create Diagnostic Flags

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-c.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_metop-c.yaml
@@ -2,6 +2,10 @@
          name: amsua_metop-c
          _anchor_channels: &amsua_metop-c_channels 1-15
          _anchor_use_flag: &amsua_metop-c_use_flag [ 1,  1,  1,  1,  1, 1, 1,  1,  1,  1, -1,  -1,  -1, 1,  1 ]
+         _anchor_error: &amsua_metop-c_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
          _anchor_obserr_bound_max: &amsua_metop-c_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
          distribution:
            name: "@DISTRIBUTION@"
@@ -179,9 +183,7 @@
            channels: *amsua_metop-c_channels
            options:
              channels: *amsua_metop-c_channels
-             obserr_clearsky: [ 2.500, 2.200, 2.000, 0.550, 0.300,
-                                0.230, 0.230, 0.250, 0.250, 0.350,
-                                0.400, 0.550, 0.800, 3.000, 3.500]
+             obserr_clearsky: *amsua_metop-c_error
              clwret_function:
                name: ObsFunction/CLWRetMW
                options:
@@ -333,9 +335,8 @@
                    err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
                             0.300,  0.230,  0.250,  0.250,  0.350,
                             0.400,  0.550,  0.800,  3.000, 18.000]
-               obserr_clearsky: [2.500, 2.200, 2.000, 0.550, 0.300,
-                                  0.230, 0.230, 0.250, 0.250, 0.350,
-                                  0.400, 0.550, 0.800, 3.000, 3.500]
+               obserr_clearsky: *amsua_metop-c_error
+
        #  Gross check
        - filter: Background Check
          filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
@@ -36,14 +36,14 @@
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
        obs bias:
-         input file: data/obs/amsua_n19.satbias.nc4
-         output file: out_amsua_n19.satbias.nc4
+         input file: data/satbias_in/amsua_n19.satbias.nc
+         output file: data/satbias_out/amsua_n19.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &amsua_n19_tlapse data/obs/amsua_n19.tlapse.txt
+             tlapse: &amsua_n19_tlapse data/satbias_in/amsua_n19.tlapse.txt
            - name: lapseRate
              tlapse: *amsua_n19_tlapse
            - name: emissivityJacobian
@@ -60,11 +60,11 @@
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/amsua_n19.satbias_cov.nc4
+             input file: data/satbias_in/amsua_n19.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_amsua_n19.satbias_cov.nc4
+           output file: data/satbias_out/amsua_n19.satbias_cov.nc
        obs pre filters:
        # Step 0-A: Create Diagnostic Flags
        - filter: Create Diagnostic Flags

--- a/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/amsua_n19.yaml
@@ -2,6 +2,10 @@
          name: amsua_n19
          _anchor_channels: &amsua_n19_channels 1-15
          _anchor_use_flag: &amsua_n19_use_flag [ 1,  1,  1,  1,  1, 1, -1, -1,  1,  1, -1,  -1,  -1,  1,  1 ]
+         _anchor_error: &amsua_n19_error [
+             2.500, 2.200, 2.000, 0.550, 0.300,
+             0.230, 0.230, 0.250, 0.250, 0.350,
+             0.400, 0.550, 0.800, 3.000, 3.500]
          _anchor_obserr_bound_max: &amsua_n19_obserr_bound_max [4.5, 4.5, 4.5, 2.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.5, 3.5, 4.5, 4.5, 4.5]
          distribution:
            name: "@DISTRIBUTION@"
@@ -179,9 +183,7 @@
            channels: *amsua_n19_channels
            options:
              channels: *amsua_n19_channels
-             obserr_clearsky: [ 2.500, 2.200, 2.000, 0.550, 0.300,
-                                0.230, 0.230, 0.250, 0.250, 0.350,
-                                0.400, 0.550, 0.800, 3.000, 3.500]
+             obserr_clearsky: *amsua_n19_error
              clwret_function:
                name: ObsFunction/CLWRetMW
                options:
@@ -333,9 +335,7 @@
                    err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
                             0.300,  0.230,  0.250,  0.250,  0.350,
                             0.400,  0.550,  0.800,  3.000, 18.000]
-               obserr_clearsky: [2.500, 2.200, 2.000, 0.550, 0.300,
-                                  0.230, 0.230, 0.250, 0.250, 0.350,
-                                  0.400, 0.550, 0.800, 3.000, 3.500]
+               obserr_clearsky: *amsua_n19_error
        #  Gross check
        - filter: Background Check
          filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
@@ -7,6 +7,12 @@
                1,  1,  1, -1, -1,
                1,  1,  1,  1,  1,
                1,  1]
+         _anchor_error: &atms_n20_error [
+             4.500,  4.500,  4.500,  2.500,  0.550,
+             0.300,  0.300,  0.400,  0.400,  0.400,
+             0.450,  0.450,  0.550,  0.800,  4.000,
+             4.000,  4.000,  3.500,  3.000,  3.000,
+             3.000,  3.000]
          _anchor_obserr_bound_max: &atms_n20_obserr_bound_max
              [4.5, 4.5, 3.0, 3.0, 1.0,
               1.0, 1.0, 1.0, 1.0, 1.0,
@@ -365,11 +371,7 @@
              channels: *atms_n20_channels
              options:
                channels: *atms_n20_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               obserr_clearsky: *atms_n20_error
                clwret_function:
                  name: CLWRetFromObs@DerivedMetaData
                obserr_function:
@@ -484,11 +486,7 @@
                obserr_function:
                  name: InitialObsError@DerivedMetaData
                  channels: *atms_n20_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               obserr_clearsky: *atms_n20_error
 
        - filter: Perform Action
          filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n20.yaml
@@ -46,14 +46,14 @@
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
        obs bias:
-         input file:  data/obs/atms_n20.satbias.nc4
-         output file: out_atms_n20.satbias.nc4
+         input file:  data/satbias_in/atms_n20.satbias.nc
+         output file: data/satbias_out/atms_n20.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &atms_n20_tlapse  data/obs/atms_n20.tlapse.txt
+             tlapse: &atms_n20_tlapse  data/satbias_in/atms_n20.tlapse.txt
            - name: lapseRate
              tlapse: *atms_n20_tlapse
            - name: emissivityJacobian
@@ -70,11 +70,11 @@
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/atms_n20.satbias_cov.nc4
+             input file: data/satbias_in/atms_n20.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_atms_n20.satbias_cov.nc4
+           output file: data/satbias_out/atms_n20.satbias_cov.nc
 
        obs pre filters:
        # Step 0-A: Create Diagnostic Flags

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_n21.yaml
@@ -52,14 +52,14 @@
          - localization method: Horizontal Gaspari-Cohn
            lengthscale: 200e3 # orig
        obs bias:
-         input file:  data/obs/atms_n21.satbias.nc4
-         output file: out_atms_n21.satbias.nc4
+         input file:  data/satbias_in/atms_n21.satbias.nc
+         output file: data/satbias_out/atms_n21.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &atms_n21_tlapse  data/obs/atms_n21.tlapse.txt
+             tlapse: &atms_n21_tlapse  data/satbias_in/atms_n21.tlapse.txt
            - name: lapseRate
              tlapse: *atms_n21_tlapse
            - name: emissivityJacobian
@@ -76,11 +76,11 @@
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/atms_n21.satbias_cov.nc4
+             input file: data/satbias_in/atms_n21.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_atms_n21.satbias_cov.nc4
+           output file: data/satbias_out/atms_n21.satbias_cov.nc
 
        obs pre filters:
        # Step 0-A: Create Diagnostic Flags

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
@@ -7,6 +7,12 @@
                1,  1,  1, -1, -1,
                1,  1,  1,  1,  1,
                1,  1]
+         _anchor_error: &atms_npp_error [
+             4.500,  4.500,  4.500,  2.500,  0.550,
+             0.300,  0.300,  0.400,  0.400,  0.400,
+             0.450,  0.450,  0.550,  0.800,  4.000,
+             4.000,  4.000,  3.500,  3.000,  3.000,
+             3.000,  3.000]
          _anchor_obserr_bound_max: &atms_npp_obserr_bound_max
              [4.5, 4.5, 3.0, 3.0, 1.0,
               1.0, 1.0, 1.0, 1.0, 1.0,
@@ -366,11 +372,7 @@
              channels: *atms_npp_channels
              options:
                channels: *atms_npp_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               obserr_clearsky: *atms_npp_error
                clwret_function:
                  name: CLWRetFromObs@DerivedMetaData
                obserr_function:
@@ -485,11 +487,7 @@
                obserr_function:
                  name: InitialObsError@DerivedMetaData
                  channels: *atms_npp_channels
-               obserr_clearsky:  [ 4.500,  4.500,  4.500,  2.500,  0.550,
-                                   0.300,  0.300,  0.400,  0.400,  0.400,
-                                   0.450,  0.450,  0.550,  0.800,  4.000,
-                                   4.000,  4.000,  3.500,  3.000,  3.000,
-                                   3.000,  3.000]
+               obserr_clearsky: *atms_npp_error
 
        - filter: Perform Action
          filter variables:

--- a/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/atms_npp.yaml
@@ -47,14 +47,14 @@
            lengthscale: 200e3 # orig
 
        obs bias:
-         input file:  data/obs/atms_npp.satbias.nc4
-         output file: out_atms_npp.satbias.nc4
+         input file:  data/satbias_in/atms_npp.satbias.nc
+         output file: data/satbias_out/atms_npp.satbias.nc
          variational bc:
            predictors:
            - name: constant
            - name: lapseRate
              order: 2
-             tlapse: &atms_npp_tlapse  data/obs/atms_npp.tlapse.txt
+             tlapse: &atms_npp_tlapse  data/satbias_in/atms_npp.tlapse.txt
            - name: lapseRate
              tlapse: *atms_npp_tlapse
            - name: emissivityJacobian
@@ -71,11 +71,11 @@
            step size: 1.0e-4
            largest analysis variance: 10000.0
            prior:
-             input file: data/obs/atms_npp.satbias_cov.nc4
+             input file: data/satbias_in/atms_npp.satbias_cov.nc
              inflation:
                ratio: 1.1
                ratio for small dataset: 2.0
-           output file: out_atms_npp.satbias_cov.nc4
+           output file: data/satbias_out/atms_npp.satbias_cov.nc
 
        obs pre filters:
        # Step 0-A: Create Diagnostic Flags


### PR DESCRIPTION
## Description
update satellite radiance observers to read stabias files from the `satbias_in` directory and write out to the `satbias_out` directory so as to be consistent with rrfs-workflow.  
change all ".nc4" to ".nc" to be consistent across all observers.
fix files are staged and link scripts are updated accordingly.

## Issue(s) addressed
None

## Dependencies (if applicable)
None
