### PR TITLE
Hotfix to load `py-jinja2` on Ursa 

### DIFF
--- a/modulefiles/RDAS/ursa.intel.lua
+++ b/modulefiles/RDAS/ursa.intel.lua
@@ -13,6 +13,7 @@ load("stack-python/3.11.7")
 load("stack-intel-oneapi-mpi/2021.13")
 load("jedi-mpas-env/1.0.0")
 load("jedi-fv3-env/1.0.0")
+load("py-jinja2/3.1.4")
 
 
 setenv("CC","mpiicc")


### PR DESCRIPTION
## Bug Fix Description

Currently, RDASApp crashes when being built on Ursa due to not having the `py-jinja2` library needed for running JCB. This PR resolves the crash by adding a one line change to load `py-jinja2` through spack-stack. 

See https://github.com/NOAA-EMC/rrfs-workflow/pull/976 for additional discussion on this bug. 

**Description of Current Behavior:**
RDASApp crashes during `build.sh` on Ursa. 

**Description of Fixed Behavior:**
RDASApp can now build successfully on Ursa after loading `py-jinja2`. 

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
