### PR TITLE
Feature/rrfsv1 updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -194,9 +194,13 @@ if [[ $BUILD_JCB == 'YES' ]]; then
   cd $dir_root/sorc/jcb
   python jcb_client_init.py
   # Build an example jedi.yaml
-  PYTHONPATH="${PYTHONPATH}:$dir_root/sorc/jcb/src/:$dir_root/build/lib/python3.*:${dir_root}/sorc/wxflow/src"
-  cd $dir_root/sorc/jcb/src/jcb/configuration/apps/rdas/test/client_integration
-  python run.py
+  #PYTHONPATH="${PYTHONPATH}:$dir_root/sorc/jcb/src/:$dir_root/build/lib/python3.*:${dir_root}/sorc/wxflow/src"
+  #cd $dir_root/sorc/jcb/src/jcb/configuration/apps/rdas/test/client_integration
+  #python run.py
+  # Link the RDASApp/parm/jcb-rdas regular folder instead of submodule
+  cd $dir_root/sorc/jcb/src/jcb/configuration/apps/
+  mv rdas rdas.bak
+  ln -sf $dir_root/parm/jcb-rdas rdas
   cd ${BUILD_DIR}
 fi
 

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_3dvar_outer_loop_1.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_3dvar_outer_loop_1.yaml.j2
@@ -2,11 +2,11 @@
   gradient norm reduction: {{gradient_norm_reduction}}
   geometry:
     fms initialization:
-      namelist filename: {{atmosphere_fv3jedi_files_path}}/fmsmpp.nml
-      field table filename: {{atmosphere_fv3jedi_files_path}}/field_table
-    namelist filename: {{atmosphere_fv3jedi_files_path}}/input_lam_C775_NP16X10.nml
-    field metadata override: "Data/fieldmetadata/tlei-gfs-restart.yaml"
-    akbk: {{atmosphere_fv3jedi_files_path}}/fix/akbk66.nc
+      namelist filename: fmsmpp.nml
+      field table filename: field_table
+    namelist filename: input_lam_C775_NP16X10.nml
+    field metadata override: gfs-restart.yaml
+    akbk: fv3_akbk
     npz: {{atmosphere_npz_anl}}
     layout:
     - {{atmosphere_layout_x}}
@@ -16,4 +16,4 @@
     - {{atmosphere_io_layout_x}}
     ntiles: {{atmosphere_ntiles}}
     fieldsets:
-    - fieldset: {{atmosphere_fv3jedi_files_path}}/fix/dynamics_lam_cmaq.yaml
+    - fieldset: dynamics_lam_cmaq.yaml

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_3dvar_outer_loop_2.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_3dvar_outer_loop_2.yaml.j2
@@ -2,11 +2,11 @@
   gradient norm reduction: {{gradient_norm_reduction}}
   geometry:
     fms initialization:
-      namelist filename: {{atmosphere_fv3jedi_files_path}}/fmsmpp.nml
-      field table filename: {{atmosphere_fv3jedi_files_path}}/field_table
-    namelist filename: {{atmosphere_fv3jedi_files_path}}/input_lam_C775_NP16X10.nml
-    field metadata override: "Data/fieldmetadata/tlei-gfs-restart.yaml"
-    akbk: {{atmosphere_fv3jedi_files_path}}/fix/akbk66.nc
+      namelist filename: fmsmpp.nml
+      field table filename: field_table
+    namelist filename: input_lam_C775_NP16X10.nml
+    field metadata override: gfs-restart.yaml
+    akbk: fv3_akbk
     npz: {{atmosphere_npz_anl}}
     layout:
     - {{atmosphere_layout_x}}
@@ -16,4 +16,4 @@
     - {{atmosphere_io_layout_x}}
     ntiles: {{atmosphere_ntiles}}
     fieldsets:
-    - fieldset: {{atmosphere_fv3jedi_files_path}}/fix/dynamics_lam_cmaq.yaml
+    - fieldset: dynamics_lam_cmaq.yaml

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background.yaml.j2
@@ -1,17 +1,18 @@
 datetime: "{{ atmosphere_background_time_iso }}"
 filetype: fms restart
 datapath: {{ atmosphere_background_path }}
-filename_core: {{atmosphere_background_time_prefix}}fv_core.res.tile1.nc
-filename_trcr: {{atmosphere_background_time_prefix}}fv_tracer.res.tile1.nc
-filename_sfcd: {{atmosphere_background_time_prefix}}sfc_data.nc
-filename_sfcw: {{atmosphere_background_time_prefix}}fv_srf_wnd.res.tile1.nc
-filename_cplr: {{atmosphere_background_time_prefix}}coupler.res
+filename_core: {{atmosphere_background_time_prefix}}{{filename_core}}
+filename_trcr: {{atmosphere_background_time_prefix}}{{filename_trcr}}
+filename_sfcd: {{atmosphere_background_time_prefix}}{{filename_sfcd}}
+filename_sfcw: {{atmosphere_background_time_prefix}}{{filename_sfcw}}
+filename_cplr: {{atmosphere_background_time_prefix}}{{filename_cplr}}
 state variables: {{state_variables}}
 field io names:
   eastward_wind: {{eastward_wind}}
   northward_wind: {{northward_wind}}
   air_temperature: {{air_temperature}}
   air_pressure_thickness: {{air_pressure_thickness}}
+  air_pressure_at_surface: {{air_pressure_at_surface}}
   water_vapor_mixing_ratio_wrt_moist_air: {{water_vapor_mixing_ratio_wrt_moist_air}}
   cloud_liquid_ice: {{cloud_liquid_ice}}
   cloud_liquid_water: {{cloud_liquid_water}}

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3denvar_bump.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3denvar_bump.yaml.j2
@@ -21,11 +21,11 @@ members from template:
       northward_wind_at_surface: {{northward_wind_at_surface}}
     datapath: {{ atmosphere_background_ensemble_path }}
     #filename is datetime templated: true
-    filename_core: {{atmosphere_background_time_prefix}}fv_core.res.tile1.nc
-    filename_trcr: {{atmosphere_background_time_prefix}}fv_tracer.res.tile1.nc
-    filename_sfcd: {{atmosphere_background_time_prefix}}sfc_data.nc
-    filename_sfcw: {{atmosphere_background_time_prefix}}fv_srf_wnd.res.tile1.nc
-    filename_cplr: {{atmosphere_background_time_prefix}}coupler.res
+    filename_core: {{atmosphere_background_time_prefix}}{{filename_core}}
+    filename_trcr: {{atmosphere_background_time_prefix}}{{filename_trcr}}
+    filename_sfcd: {{atmosphere_background_time_prefix}}{{filename_sfcd}}
+    filename_sfcw: {{atmosphere_background_time_prefix}}{{filename_sfcw}}
+    filename_cplr: {{atmosphere_background_time_prefix}}{{filename_cplr}}
   pattern: "%mem%"
   nmembers: {{atmosphere_number_ensemble_members}}
   zero padding: 3

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3dvar_bumpID.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3dvar_bumpID.yaml.j2
@@ -1,0 +1,3 @@
+covariance model: SABER
+saber central block:
+  saber block name: ID

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3dvar_gsibec.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3dvar_gsibec.yaml.j2
@@ -1,0 +1,44 @@
+covariance model: SABER
+saber central block:
+  saber block name: gsi static covariance
+  read:
+    gsi akbk: {{atmosphere_fv3jedi_files_path}}/fix/akbk66.nc
+    gsi error covariance file: berror_stats
+    gsi berror namelist file: gsiparm_regional.anl
+    processor layout x direction: {{atmosphere_layout_gsib_x}}
+    processor layout y direction: {{atmosphere_layout_gsib_y}}
+    debugging deep bypass gsi B error: false
+    debugging mode: false
+    regional mode: true
+saber outer blocks:
+- saber block name: interpolation
+  inner geometry:
+    function space: StructuredColumns
+    custom grid matching gsi:
+      type: rotated_lonlat
+      lats: "252"
+      lons: "420"
+      lat_start: "-29.335138"
+      lat_end: "29.335138"
+      lon_start: "-50.033098"
+      lon_end: "50.033098"
+      north_pole_lat: "128.500001"
+      north_pole_lon: "82.500018"
+    custom partitioner matching gsi:
+      bands: 10  # matches GSI partition for 1 or 2 MPI tasks, but too simplistic in general
+    halo: 1
+  forward interpolator:
+    local interpolator type: oops unstructured grid interpolator
+  inverse interpolator:
+    local interpolator type: oops unstructured grid interpolator
+  state variables to inverse:  # Make sure to also re-order the state passed to GSI-B constructor
+  - eastward_wind
+  - northward_wind
+  - air_temperature
+  - water_vapor_mixing_ratio_wrt_moist_air
+  - air_pressure_at_surface
+  - air_pressure_thickness
+linear variable change:
+  linear variable change name: Control2Analysis
+  input variables: [eastward_wind,northward_wind,virtual_temperature,water_vapor_mixing_ratio_wrt_moist_air,air_pressure_at_surface]
+  output variables: [eastward_wind,northward_wind,air_temperature,water_vapor_mixing_ratio_wrt_moist_air,air_pressure_at_surface]

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3dvar_gsibec.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3dvar_gsibec.yaml.j2
@@ -2,7 +2,7 @@ covariance model: SABER
 saber central block:
   saber block name: gsi static covariance
   read:
-    gsi akbk: {{atmosphere_fv3jedi_files_path}}/fix/akbk66.nc
+    gsi akbk: fv3_akbk
     gsi error covariance file: berror_stats
     gsi berror namelist file: gsiparm_regional.anl
     processor layout x direction: {{atmosphere_layout_gsib_x}}

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_geometry_background.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_geometry_background.yaml.j2
@@ -1,8 +1,8 @@
 fms initialization:
-  namelist filename: {{atmosphere_fv3jedi_files_path}}/fmsmpp.nml
-  field table filename: {{atmosphere_fv3jedi_files_path}}/field_table
-namelist filename: {{atmosphere_fv3jedi_files_path}}/input_lam_C775_NP16X10.nml
-akbk: {{atmosphere_fv3jedi_files_path}}/fix/akbk66.nc
+  namelist filename: fmsmpp.nml
+  field table filename: field_table
+namelist filename: input_lam_C775_NP16X10.nml
+akbk: fv3_akbk
 npz: {{atmosphere_npz_ges}}
 layout: [{{atmosphere_layout_x}}, {{atmosphere_layout_y}}]
 io_layout: [{{atmosphere_io_layout_x}}, {{atmosphere_io_layout_y}}]

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_output.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_output.yaml.j2
@@ -1,4 +1,4 @@
 filetype: fms restart
 datapath: ./
-prefix: hybens3dvar-fv3_lam-C775
+prefix: analysis_jedi
 frequency: {{atmosphere_forecast_timestep}}

--- a/rrfs-test/IODA/offline_ioda_patch.py
+++ b/rrfs-test/IODA/offline_ioda_patch.py
@@ -4,29 +4,33 @@ import numpy as np
 from timeit import default_timer as timer
 import argparse
 import warnings
-import os
 
 """
-This program makes a copy of an original IODA file and can add additional
+This program makes a copy of an original IODA file and can add/modify additional
 adhoc variables. This program was originally written to add the
 MetaData/longitude_latitude_pressure for use in l_closeobs duplicate checking
 but others can be added as necessary.
+3/4/2025: change all QualityMarker with missing values to 15
 """
 
 # Disable warnings
 warnings.filterwarnings('ignore')
 
 # Functions for calculating run times.
+
+
 def tic():
     return timer()
 
+
 def toc(tic=tic, label=""):
     toc = timer()
-    elapsed = toc-tic
+    elapsed = toc - tic
     hrs = int(elapsed // 3600)
     mins = int((elapsed % 3600) // 60)
     secs = int(elapsed % 3600 % 60)
     print(f"{label}({elapsed:.2f}s), {hrs:02}:{mins:02}:{secs:02}")
+
 
 tic1 = tic()
 
@@ -46,9 +50,9 @@ obs_lon = np.where(obs_lon < 0, obs_lon + 360, obs_lon)
 obs_prs = obs_ds.groups['MetaData'].variables['pressure'][:]
 
 # Create a new NetCDF file to store the selected data using the more efficient method
-try:
+if '.nc' in obs_filename:
     outfile = obs_filename.replace('.nc', '_llp.nc')
-except:
+else:
     outfile = obs_filename.replace('.nc4', '_llp.nc4')
 fout = nc.Dataset(outfile, 'w')
 
@@ -66,6 +70,10 @@ for attr in obs_ds.ncattrs():  # Attributes for the main file
 # Copy all groups and variables into the new file, keeping only the variables in range
 groups = obs_ds.groups
 for group in groups:
+    if group == "QualityMarker":
+        qc_group = True
+    else:
+        qc_group = False
     g = fout.createGroup(group)
     for var in obs_ds.groups[group].variables:
         invar = obs_ds.groups[group].variables[var]
@@ -73,15 +81,22 @@ for group in groups:
             vartype = invar.dtype
             fill = invar.getncattr('_FillValue')
             g.createVariable(var, vartype, 'Location', fill_value=fill)
-        except:  # String variables
+        except (AttributeError, KeyError):  # String variables
             g.createVariable(var, 'str', 'Location')
-        if var in ['latitude', 'longitude']:
-            g.variables[var][:] = invar[:][:].data
+        #
+        if qc_group and vartype == "int32":
+            np_invar = np.array(invar)
+            np_invar[(np_invar < 0) | (np_invar > 15)] = 15
+            g.variables[var][:] = np_invar.astype(invar.dtype)
         else:
-            g.variables[var][:] = invar[:][:]
+            if var in ['latitude', 'longitude']:
+                g.variables[var][:] = invar[:][:].data
+            else:
+                g.variables[var][:] = invar[:][:]
         # Copy attributes for this variable
         for attr in invar.ncattrs():
-            if '_FillValue' in attr: continue
+            if '_FillValue' in attr:
+                continue
             g.variables[var].setncattr(attr, invar.getncattr(attr))
 
 # Generate longitude_latitude_pressure location strings (for dup checking)
@@ -98,4 +113,4 @@ metadata_group.variables[f"{var}"][:] = data
 # Close the datasets
 obs_ds.close()
 fout.close()
-toc(tic1,label="Time to create new obs file: ")
+toc(tic1, label="Time to create new obs file: ")

--- a/rrfs-test/IODA/offline_vad_thinning.py
+++ b/rrfs-test/IODA/offline_vad_thinning.py
@@ -253,7 +253,7 @@ def thin_vad_obs(ds, station_filter=None, vad_near_analtime=False):
                         superob[(grp_name, var_name)] = np.mean(valid_data)
                     else:  # vtype == 'int'
                         if grp_name == 'QualityMarker':  # GSI takes the QM from the lowest level in the block
-                            superob[(grp_name, var_name)] = int(valid_data[0])  # GSI method
+                            superob[(grp_name, var_name)] = int(valid_data[0][0])  # GSI method
                         elif grp_name == 'MetaData' and var_name == 'height':  # Sometimes height superob will be float
                             superob[(grp_name, var_name)] = np.mean(valid_data)
                         else:

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_goes.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_goes.py
@@ -73,7 +73,7 @@ def bufr_to_ioda(config, logger):
     data_type = config["data_type"]
     data_description = config["data_description"]
     data_provider = config["data_provider"]
-    cycle_type = config["cycle_type"]
+    #cycle_type = config["cycle_type"]
     dump_dir = config["dump_directory"]
     ioda_dir = config["ioda_directory"]
     cycle = config["cycle_datetime"]


### PR DESCRIPTION
## Description
The purpose of this PR is to add updates for running `bufr2ioda` and `jedivar` in rrfsv1 workflow. 

Key changes include:
- Adding the `atmosphere_background_error_3dvar_gsibec.yaml.j2` for running 3dvar with gsibec.
- A change in build.sh to skip building the example jedivar.yaml AND overwrite the jcb-rdas submodule installed with the `RDASApp/parm/jcb-rdas` regular folder.
- Copies the `offline_ioda_tweak.py` from rrfsv2 renamed as `offline_ioda_patch.py`. This is also a rename and update of the `offline_add_var_to_ioda.py` currently in RDASApp.
- A bug fix to the satwnd python converter found in testing the rrfsv1 workflow.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
