### PR TITLE
Fix placement of the gaea workaround code changes to fix build in rrfs-workflow

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,12 +25,6 @@ dir_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $dir_root/ush/detect_machine.sh
 source $dir_root/ush/init.sh
 
-# temporary bug fix, https://github.com/JCSDA-internal/oops/issues/3030
-ccfile="sorc/oops/src/oops/base/ParameterTraitsObsVariables.cc"
-if ! grep "#include <algorithm>" ${ccfile} >/dev/null; then
-  sed -i -e "s/#include <map>/#include <algorithm>\n#include <map>/" ${ccfile}
-fi
-
 # ==============================================================================
 usage() {
   set +x
@@ -238,6 +232,12 @@ if [[ $BUILD_WORKAROUND == 'YES' ]]; then
   cp ../sorc/_workaround_/saber/Geometry.cc            ../sorc/saber/src/saber/interpolation/Geometry.cc
   # No PR for gsibec yet
   cp ../sorc/_workaround_/gsibec/*                     ../sorc/gsibec/src/gsibec/gsi
+fi
+
+# temporary bug fix, https://github.com/JCSDA-internal/oops/issues/3030
+ccfile="../sorc/oops/src/oops/base/ParameterTraitsObsVariables.cc"
+if ! grep "#include <algorithm>" ${ccfile} >/dev/null; then
+  sed -i -e "s/#include <map>/#include <algorithm>\n#include <map>/" ${ccfile}
 fi
 
 CMAKE_OPTS+=" -DMPIEXEC_MAX_NUMPROCS:STRING=120 -DBUILD_SUPER_EXE=$BUILD_SUPER_EXE -DBUILD_RRFS_TEST=$BUILD_RRFS_TEST"


### PR DESCRIPTION
## Bug Fix Description

**Description of Current Behavior:**
1. The code fails to build from the rrfs-workflow because it couldn't find the path to the source file
```
grep: sorc/oops/src/oops/base/ParameterTraitsObsVariables.cc: No such file or directory
sed: can't read sorc/oops/src/oops/base/ParameterTraitsObsVariables.cc: No such file or directory
make[2]: *** [CMakeFiles/RDASApp.dir/build.make:86: RDASApp/src/RDASApp-stamp/RDASApp-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:995: CMakeFiles/RDASApp.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

**Description of Fixed Behavior:**
1. Now it builds without error
2. The solution was to move it down to the other workaround code section after we have already changed directories to `${BUILD_DIR}`

## Dependencies (if applicable)
https://github.com/NOAA-EMC/rrfs-workflow/pull/986 is dependent on this PR

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
