### PR TITLE
Add rdas_ua2u.x tool to compute u/v from ua/va in FV3 analysis restarts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,7 @@ usage() {
   echo "  -t  include RRFS,BUFR_QUERY test data  DEFAULT: YES"
   echo "  -d  compile in the debug mode          DEFAULT: NO"
   echo "  -w  compile with workaround codes      DEFAULT: YES"
+  echo "  -r  compile rdas tools (ua2u)          DEFAULT: YES"
   echo "  -h  display this message and quit"
   echo
   exit 1
@@ -59,6 +60,7 @@ CLEAN_BUILD="NO"
 BUILD_JCSDA="YES"
 BUILD_SUPER_EXE="NO"
 BUILD_RRFS_TEST="YES"
+BUILD_RDAS_TOOLS="YES"
 DYCORE="FV3andMPAS"
 COMPILER="${COMPILER:-intel}"
 DEBUG_OPT=""
@@ -66,7 +68,7 @@ BUFRQUERY_OPT=""
 BUILD_JCB="YES"
 BUILD_WORKAROUND="YES"
 
-while getopts "p:c:m:j:t:b:w:hvfsxd" opt; do
+while getopts "p:c:m:j:t:b:r:w:hvfsxd" opt; do
   case $opt in
     p)
       INSTALL_PREFIX=$OPTARG
@@ -88,6 +90,9 @@ while getopts "p:c:m:j:t:b:w:hvfsxd" opt; do
       if [[ "$OPTARG" == "NO" ]]; then
         BUFRQUERY_OPT="-DSKIP_DOWNLOAD_TEST_DATA=ON"
       fi
+      ;;
+    r)
+      BUILD_RDAS_TOOLS=$OPTARG
       ;;
     w)
       BUILD_WORKAROUND=$OPTARG
@@ -292,6 +297,13 @@ fi
 ccfile="../sorc/oops/src/oops/base/ParameterTraitsObsVariables.cc"
 if ! grep "#include <algorithm>" ${ccfile} >/dev/null; then
   sed -i -e "s/#include <map>/#include <algorithm>\n#include <map>/" ${ccfile}
+fi
+
+# Build RDAS-specific tools (e.g. rdas_ua2u.x)
+if [[ "$BUILD_RDAS_TOOLS" == "YES" ]]; then
+  CMAKE_OPTS+=" -DBUILD_RDAS_TOOLS=ON"
+else
+  CMAKE_OPTS+=" -DBUILD_RDAS_TOOLS=OFF"
 fi
 
 CMAKE_OPTS+=" -DMPIEXEC_MAX_NUMPROCS:STRING=120 -DBUILD_SUPER_EXE=$BUILD_SUPER_EXE -DBUILD_RRFS_TEST=$BUILD_RRFS_TEST"

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ usage() {
   echo "  -t  include RRFS,BUFR_QUERY test data  DEFAULT: YES"
   echo "  -d  compile in the debug mode          DEFAULT: NO"
   echo "  -w  compile with workaround codes      DEFAULT: YES"
-  echo "  -r  compile rdas tools (ua2u)          DEFAULT: YES"
+  echo "  -r  compile rdas tools (ua2u)          DEFAULT: (fv3:YES; mpas:NO)"
   echo "  -h  display this message and quit"
   echo
   exit 1
@@ -60,7 +60,7 @@ CLEAN_BUILD="NO"
 BUILD_JCSDA="YES"
 BUILD_SUPER_EXE="NO"
 BUILD_RRFS_TEST="YES"
-BUILD_RDAS_TOOLS="YES"
+BUILD_RDAS_TOOLS="NO"
 DYCORE="FV3andMPAS"
 COMPILER="${COMPILER:-intel}"
 DEBUG_OPT=""
@@ -300,6 +300,15 @@ if ! grep "#include <algorithm>" ${ccfile} >/dev/null; then
 fi
 
 # Build RDAS-specific tools (e.g. rdas_ua2u.x)
+# Default: build only if FV3 or FV3andMPAS, or if explicitly requested with -r YES
+if [[ "$BUILD_RDAS_TOOLS" == "YES" ]]; then
+  echo "User override: forcing BUILD_RDAS_TOOLS=ON"
+elif [[ $DYCORE == 'FV3' || $DYCORE == 'FV3andMPAS' ]]; then
+  BUILD_RDAS_TOOLS="YES"
+else
+  BUILD_RDAS_TOOLS="NO"
+fi
+
 if [[ "$BUILD_RDAS_TOOLS" == "YES" ]]; then
   CMAKE_OPTS+=" -DBUILD_RDAS_TOOLS=ON"
 else

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -41,6 +41,10 @@ ecbuild_bundle_initialize()
 # Build bundle source code.
 if(BUILD_RDASBUNDLE)
 
+  if(BUILD_RDAS_TOOLS)
+    ecbuild_bundle( PROJECT rdas_tools.fd SOURCE "../sorc/rdas_tools.fd" )
+  endif()
+
 # jedi-cmake
   ecbuild_bundle( PROJECT jedicmake SOURCE "../sorc/jedicmake" )
   include( jedicmake/cmake/Functions/git_functions.cmake )

--- a/sorc/rdas_tools.fd/CMakeLists.txt
+++ b/sorc/rdas_tools.fd/CMakeLists.txt
@@ -1,0 +1,28 @@
+#=======================================================================
+#$$$ CMAKEFILE DOCUMENTATION BLOCK
+# Biju Thomas
+# Email: biju.thomas@noaa.gov
+#=======================================================================
+
+cmake_minimum_required(VERSION 3.15)
+project(
+  RDAS_TOOLS
+  LANGUAGES C Fortran)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
+set (RDAS_TOOLS_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU)$")
+  message(WARNING "Compiler not officially supported: ${CMAKE_Fortran_COMPILER_ID}")
+endif()
+
+if(NOT CMAKE_C_COMPILER_ID MATCHES "^(Intel|GNU)$")
+  message(WARNING "Compiler not officially supported: ${CMAKE_C_COMPILER_ID}")
+endif()
+
+find_package(NetCDF REQUIRED C Fortran)
+find_package(HDF5 REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(MPI REQUIRED)
+
+add_subdirectory(sorc/rdas_ua2u)

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/CMakeLists.txt
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/CMakeLists.txt
@@ -9,15 +9,16 @@ find_package(ZLIB REQUIRED)
 # --- NetCDF (manual, since no Config file is provided) ---
 if(NOT DEFINED NetCDF_INCLUDE_DIR)
   set(NetCDF_INCLUDE_DIR
-      "/apps/ops/test/spack-stack-nco-1.9/oneapi/2024.2.1/netcdf-fortran-4.6.1-oykkcn7/include")
+      "$ENV{netcdf_fortran_ROOT}/include"
+  )
 endif()
 
 if(NOT DEFINED NetCDF_LIBRARIES)
   file(GLOB NETCDFF_LIB
-    "/apps/ops/test/spack-stack-nco-1.9/oneapi/2024.2.1/netcdf-fortran-4.6.1-oykkcn7/lib/libnetcdff.so*"
+    "$ENV{netcdf_fortran_ROOT}/lib/libnetcdff.so*"
   )
   file(GLOB NETCDFC_LIB
-    "/apps/ops/test/spack-stack-nco-1.9/oneapi/2024.2.1/netcdf-c-4.9.2-zjvomwn/lib/libnetcdf.so*"
+    "$ENV{netcdf_c_ROOT}/lib/libnetcdf.so*"
   )
   set(NetCDF_LIBRARIES
       ${NETCDFF_LIB}
@@ -39,8 +40,6 @@ add_executable(rdas_ua2u.x
   sub_rdas_u_ua.f90
   rdas_ua2u_driver.f90
 )
-
-
 
 # --- Include paths ---
 target_include_directories(rdas_ua2u.x PRIVATE

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/CMakeLists.txt
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.15)
+project(rdas_ua2u LANGUAGES C Fortran)
+
+# --- Required dependencies ---
+find_package(MPI REQUIRED)
+find_package(HDF5 REQUIRED COMPONENTS Fortran)
+find_package(ZLIB REQUIRED)
+
+# --- NetCDF (manual, since no Config file is provided) ---
+if(NOT DEFINED NetCDF_INCLUDE_DIR)
+  set(NetCDF_INCLUDE_DIR
+      "/apps/ops/test/spack-stack-nco-1.9/oneapi/2024.2.1/netcdf-fortran-4.6.1-oykkcn7/include")
+endif()
+
+if(NOT DEFINED NetCDF_LIBRARIES)
+  file(GLOB NETCDFF_LIB
+    "/apps/ops/test/spack-stack-nco-1.9/oneapi/2024.2.1/netcdf-fortran-4.6.1-oykkcn7/lib/libnetcdff.so*"
+  )
+  file(GLOB NETCDFC_LIB
+    "/apps/ops/test/spack-stack-nco-1.9/oneapi/2024.2.1/netcdf-c-4.9.2-zjvomwn/lib/libnetcdf.so*"
+  )
+  set(NetCDF_LIBRARIES
+      ${NETCDFF_LIB}
+      ${NETCDFC_LIB}
+  )
+endif()
+
+message(STATUS "Using NetCDF include: ${NetCDF_INCLUDE_DIR}")
+message(STATUS "Using NetCDF libs: ${NetCDF_LIBRARIES}")
+
+# --- Build executable ---
+add_executable(rdas_ua2u.x
+  module_structure.f90
+  module_mpi.f90
+  sub_wind_process.f90
+  sub_tools.f90
+  sub_grids.f90
+  sub_netcdf.f90
+  sub_rdas_u_ua.f90
+  rdas_ua2u_driver.f90
+)
+
+
+
+# --- Include paths ---
+target_include_directories(rdas_ua2u.x PRIVATE
+  ${NetCDF_INCLUDE_DIR}
+  ${HDF5_INCLUDE_DIRS}
+  ${MPI_Fortran_INCLUDE_DIRS}
+)
+
+# --- Link libraries ---
+target_link_libraries(rdas_ua2u.x
+  ${MPI_Fortran_LIBRARIES}
+  ${HDF5_Fortran_LIBRARIES}
+  ${ZLIB_LIBRARIES}
+  ${NetCDF_LIBRARIES}
+)
+
+set_target_properties(rdas_ua2u.x PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+install(TARGETS rdas_ua2u.x
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/module_mpi.f90
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/module_mpi.f90
@@ -1,0 +1,47 @@
+module module_mpi
+
+!-----------------------------------------------------------------------------
+! PURPOSE: This module provides routines for parallelizing.
+! authors and history:
+!      -- 202102, created by Yonghui Weng
+!------------------------------------------------------------------------------
+   use mpi
+   integer :: nprocs, my_proc_id, comm, ierr
+   integer, dimension(mpi_status_size) :: status
+
+   contains
+
+!-----------------------------------------------------------------------------
+! PURPOSE: to basically set up a communicator for a rectangular mesh.
+!------------------------------------------------------------------------------
+   subroutine parallel_start()
+
+   implicit none
+
+   integer :: mpi_rank, mpi_size
+   integer :: mpi_ierr
+
+   ! Find out our rank and the total number of processors
+   call mpi_init(mpi_ierr)
+   call MPI_Comm_rank(MPI_COMM_WORLD, mpi_rank, mpi_ierr)
+   call MPI_Comm_size(MPI_COMM_WORLD, mpi_size, mpi_ierr)
+   comm = MPI_COMM_WORLD
+   nprocs = mpi_size
+   my_proc_id = mpi_rank
+
+   end subroutine parallel_start
+
+!-----------------------------------------------------------------------------
+! PURPOSE: Free up, deallocate, and for MPI, finalize.
+!------------------------------------------------------------------------------
+   subroutine parallel_finish()
+
+   implicit none
+
+   !integer :: mpi_ierr
+
+   call MPI_Finalize(ierr)
+
+   end subroutine parallel_finish
+
+end module module_mpi

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/module_structure.f90
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/module_structure.f90
@@ -1,0 +1,78 @@
+module constants
+!-----------------------------------------------------------------------------
+! This module defines all parameter and constants for HAFS_DAtool
+! authors and history:
+!       -- 202102, created by Yonghui Weng
+!-----------------------------------------------------------------------------
+  implicit none
+  real, parameter :: g=9.81,                       &! gravitational constant
+                     r_earth=6374.,                &! radius of the earth
+                     pi = 3.1415927,               &!
+                     deg2rad = pi/180.0,           &!
+                     rad2deg = 1.0/deg2rad,        &!
+                     cp=1004.5,                    &! specific heat
+                     rd=287.,                      &! dry air gas constant
+                     rv=461.6,                     &! moist air gas constant
+                     es_alpha = 611.2,             &! saturation vaporpressure
+                     es_beta = 17.67,              &!
+                     es_gamma = 243.5,             &!
+                     missing=9.999e+20               ! missing value
+! parameter to determine interpolation method
+!  integer, parameter :: CONSERVE = 1
+!  integer, parameter :: BILINEAR = 2
+!  integer, parameter :: SPHERICA = 3
+!  integer, parameter :: BICUBIC  = 4
+
+end module constants
+
+!==============================================================================
+module var_type
+!-----------------------------------------------------------------------------
+! define var
+! Yonghui Weng, 20210204
+!-----------------------------------------------------------------------------
+ type grid2d_info
+      integer :: grid_x, grid_y, ntime, grid_xt, grid_yt
+      real*8, allocatable, dimension(:)  :: times
+      character(len=80)     :: times_unit
+      real, allocatable, dimension(:,:)  :: grid_lon, grid_lat, grid_lont, grid_latt, grid_area
+ end type grid2d_info
+
+ type gridmap_info
+      integer :: src_points, dst_points
+      integer, allocatable, dimension(:) :: src_x, src_y   !position in source grid
+      integer, allocatable, dimension(:) :: dst_x, dst_y   !dst grids will be used for smooth, to reduce the gaps
+      real, allocatable, dimension(:)  :: src_weight, dst_weight
+ end type gridmap_info
+
+ type grid_weight_info
+      integer  :: max_points, relaxzone
+      type(gridmap_info),allocatable,dimension(:,:) :: gwt_t, gwt_u, gwt_v
+      real, allocatable, dimension(:,:) :: cangu, sangu, cangv, sangv
+ end type grid_weight_info
+
+ type(grid_weight_info) :: gwt
+
+ type tc_track_info
+      integer               :: vortexrep  ! 1=tc vortex-replacement, others are not
+      real                  :: lat, lon, pmin, vmax
+      real, dimension(2)    :: vortexreplace_r
+ end type tc_track_info
+ type(tc_track_info)    :: tc
+
+ type llxy_cons   !for the generalized transform
+      real                                 :: rlon_min_dd,rlon_max_dd,rlat_min_dd,rlat_max_dd
+      real                                 :: pihalf,sign_pole,rlambda0
+      real                                 :: atilde_x,btilde_x,atilde_y,btilde_y
+      real                                 :: btilde_xinv,btilde_yinv
+      integer                              :: nlon,nlat,nxtilde,nytilde
+      integer, allocatable, dimension(:,:) :: i0_tilde, j0_tilde, ip_tilde, jp_tilde
+      real, allocatable, dimension(:,:)    :: xtilde0, ytilde0, cos_beta_ref, sin_beta_ref, region_lat, region_lon
+      logical:: lallocated = .false.
+ end type llxy_cons
+
+ integer                :: debug_level  ! default is 1, only print basic information
+                                        !            2-9:
+
+end module var_type
+

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/rdas_ua2u_driver.f90
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/rdas_ua2u_driver.f90
@@ -1,0 +1,77 @@
+  program rdas_ua2u
+
+!=========================================================================
+! RDAS_UAUA tool
+! authors and history:
+!      -- 202102, created by Yonghui Weng
+!      -- 202112, added HAVSVI pre- and post-processing by Yonghui Weng
+!      -- 202206, added MPI and openMP by Yonghui Weng
+!      -- 202306, added vi_cloud by JungHoon Shin
+!      -- 202404, added ideal vortex by Weiguo Wang
+!      -- 202410, added fftw_increment by JungHoon Shin, Xu Lu and Yonghui Weng
+!      -- 202411, added u_update_ua and ideal_vortex by Yonghui Weng
+!      -- 202510, donald.e.lippi removed all but u_update_ua adapted for rdas
+!------------------------------------------------------------------------------
+!
+! command convention
+!  rdas_ua2u.x FUNCTION --in_grid=input_grids_file \
+!                       --in_file=input_file \
+!                       --out_file=output_file
+!
+!    3.6) u_update_ua and ua_update_u
+!       * rdas_ua2u.x u_update_ua --in_grid=fv3_grid_spec \
+!                                   --in_file=in_analysis_jedi.fv_core.res.nc
+!                                   --out_file=out_analysis_jedi.fv_core.res.nc
+!
+!       * rdas_ua2u.x ua_update_u --in_grid=fv3_grid_spec \
+!                                   --in_file=in_analysis_jedi.fv_core.res.nc
+!                                   --out_file=out_analysis_jedi.fv_core.res.nc
+!
+!=========================================================================
+  use module_mpi
+
+  implicit none
+  integer :: i, j, n
+  character(len=2500) :: actions='w', arg, in_grid='w', in_file='w', out_file='w'
+
+  call parallel_start()
+
+  if (iargc() < 2) then
+     if (my_proc_id == 0) then
+       write(*,'(a)') 'Usage: rdas_ua2u.x <u_update_ua|ua_update_u> --in_grid=GRID.nc --in_file=RESTART.nc [--out_file=OUT.nc]'
+     endif
+     call parallel_finish()
+     stop
+  endif
+
+  call getarg(1, actions)
+  do i = 2, iargc()
+     call getarg(i, arg)
+     j = index(trim(arg), '=', .true.);   n = len_trim(arg)
+     if (j > 1) then
+       select case (arg(1:j-1))
+         case ('--in_grid');  in_grid  = arg(j+1:n)
+         case ('--in_file','-i'); in_file = arg(j+1:n)
+         case ('--out_file'); out_file = arg(j+1:n)
+       end select
+     end if
+  end do
+
+  if (trim(actions) /= 'u_update_ua' .and. trim(actions) /= 'ua_update_u') then
+     if (my_proc_id == 0) write(*,'(a)') 'ERROR: action must be u_update_ua or ua_update_u'
+     call parallel_finish()
+     stop
+  end if
+  if (trim(in_grid) == 'w' .or. trim(in_file) == 'w') then
+     if (my_proc_id == 0) write(*,'(a)') 'ERROR: --in_grid and --in_file are required'
+     call parallel_finish()
+     stop
+  end if
+
+  if (my_proc_id == 0) then
+     write(*,'(a)') '--- u/a update on '//trim(in_file)
+     call rdas_u_ua(trim(actions), trim(in_grid), trim(in_file), trim(out_file))
+  end if
+
+  call parallel_finish()
+end program rdas_ua2u

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_grids.f90
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_grids.f90
@@ -1,0 +1,910 @@
+!-----------------------------------------------------------------------+
+! This package of subroutines are used for HAFS grid calculation.
+! authors and history:
+!      -- 202102, created by Yonghui Weng
+!-----------------------------------------------------------------------+
+   subroutine rtll(rot_lon,rot_lat,geo_lon,geo_lat,cen_lon,cen_lat)
+
+!-- from https://github.com/NOAA-EMC/fv3atm/blob/cf0a73180b2d9ac55ebfce4785a7270d205423db/io/module_wrt_grid_comp.F90#L3545
+!-- called in fv3atm
+!   else if ( trim(output_grid) == 'rotated_latlon' ) then
+!           do j=lbound(lonPtr,2),ubound(lonPtr,2)
+!           do i=lbound(lonPtr,1),ubound(lonPtr,1)
+!             rot_lon = lon1 + (lon2-lon1)/(imo-1) * (i-1)
+!             rot_lat = lat1 + (lat2-lat1)/(jmo-1) * (j-1)
+!             call rtll(rot_lon, rot_lat, geo_lon, geo_lat, dble(cen_lon), dble(cen_lat))
+!             if (geo_lon < 0.0) geo_lon = geo_lon + 360.0
+!             lonPtr(i,j) = geo_lon
+!             latPtr(i,j) = geo_lat
+!           enddo
+!           Enddo
+!
+!--------------
+  real, intent(in)  :: rot_lon, rot_lat
+  real, intent(out) :: geo_lon, geo_lat
+  real, intent(in)  :: cen_lat, cen_lon
+!
+  real, parameter :: pi=3.14159265358979323846
+  real, parameter :: dtr=pi/180.0
+!
+  real :: tph0, ctph0, stph0, tlm, tph, stph, ctph, ctlm, stlm, aph, cph
+  real :: xx, yy
+!--------------
+!
+!--- Convert all angles to radians
+  tph0=cen_lat*dtr
+  ctph0=cos(tph0)
+  stph0=sin(tph0)
+  tlm=rot_lon*dtr
+  tph=rot_lat*dtr
+!
+  stph=sin(tph)
+  ctph=cos(tph)
+  ctlm=cos(tlm)
+  stlm=sin(tlm)
+!
+  xx=stph0*ctph*ctlm+ctph0*stph
+  xx=max(xx,-1.0)
+  xx=min(xx, 1.0)
+  aph=asin(xx)
+  cph=cos(aph)
+!
+  xx=(ctph0*ctph*ctlm-stph0*stph)/cph
+  xx=max(xx,-1.0)
+  xx=min(xx, 1.0)
+  xx=acos(xx)/dtr
+  yy=ctph*stlm/cph
+  xx=sign(xx,yy)
+  geo_lon=cen_lon+xx
+
+  geo_lat=aph/dtr
+!
+  if (geo_lon < 0.0)  geo_lon=geo_lon+360.0
+!
+  return
+  end subroutine rtll
+
+!-----------------------------------------------------------------------+
+!--- from hwrf_wps.fd/geogrid/src/module_map_utils.f90
+!--- modified
+  subroutine ijll_rotlatlon(i, j, phi, lambda, ixdim, jydim, lat1, lon1, stagger, lat,lon)
+
+  implicit none
+
+  ! Arguments
+  real, intent(in)    :: i, j
+  real, intent(in)    :: phi      ! For Rotated Lat/Lon -- domain half-extent in degrees latitude
+  real, intent(in)    :: lambda   ! For Rotated Lat/Lon -- domain half-extend in degrees longitude
+  integer, intent(in) :: ixdim    ! For Rotated Lat/Lon -- number of mass points in an odd row
+  integer, intent(in) :: jydim    ! For Rotated Lat/Lon -- number of rows
+  real, intent(in)    :: lat1     ! SW latitude (1,1) in degrees (-90->90N)
+  real, intent(in)    :: lon1     ! SW longitude (1,1) in degrees (-180->180E)
+  character (len=*), intent(in) :: stagger  ! For Rotated Lat/Lon -- mass or velocity grid 'VV'/'T'
+  real, intent(out)   :: lat, lon
+
+  ! Local variables
+  integer :: ih,jh
+  real :: jj
+  integer :: midcol,midrow,ncol,iadd1,iadd2,imt,jh2,knrow,krem,kv,nrow
+  real :: dphd,dlmd !Grid increments, degrees
+  real :: arg1,arg2,d2r,fctr,glatr,glatd,glond,pi, &
+          r2d,tlatd,tlond,tlatr,tlonr,tlm0,tph0
+  real :: col
+
+  jj = j
+  if ( (j - int(j)) .gt. 0.999) then
+     jj = j + 0.0002
+  endif
+
+  jh = int(jj)
+
+  dphd = phi/real((jydim-1)/2)
+  dlmd = lambda/real(ixdim-1)
+
+  pi = acos(-1.0)
+  d2r = pi/180.
+  r2d = 1./d2r
+  tph0 = lat1*d2r
+  tlm0 = -lon1*d2r
+
+  midrow = int((jydim+1)/2)
+  midcol = ixdim
+
+  col = 2*i-1+abs(mod(jh+1,2))
+  tlatd = (jj-midrow)*dphd
+  tlond = (col-midcol)*dlmd
+
+  if (trim(stagger) == 'VV') then
+     if (mod(jh,2) .eq. 0) then
+        tlond = tlond - dlmd
+     else
+        tlond = tlond + dlmd
+     end if
+  end if
+
+  tlatr = tlatd*d2r
+  tlonr = tlond*d2r
+  arg1 = sin(tlatr)*cos(tph0)+cos(tlatr)*sin(tph0)*cos(tlonr)
+  glatr = asin(arg1)
+
+  glatd = glatr*r2d
+
+  arg2 = cos(tlatr)*cos(tlonr)/(cos(glatr)*cos(tph0))-tan(glatr)*tan(tph0)
+  if (abs(arg2) > 1.) arg2 = abs(arg2)/arg2
+  fctr = 1.
+  if (tlond > 0.) fctr = -1.
+
+  glond = tlm0*r2d+fctr*acos(arg2)*r2d
+
+  lat = glatd
+  lon = -glond
+  if (lon < 0.) lon = lon + 360.
+
+  return
+  end subroutine ijll_rotlatlon
+
+!-----------------------------------------------------------------------+
+!--- from vortex_init/hwrf_set_ijstart/swcorner_dynamic.F
+!--- modified
+  subroutine EARTH_LATLON ( HLAT,HLON,VLAT,VLON,     & !Earth lat,lon at H and V points
+                          DLMD1,DPHD1,WBD1,SBD1,   & !input res,west & south boundaries,
+                          CENTRAL_LAT,CENTRAL_LON, & ! central lat,lon, all in degrees
+                          IDS,IDE,JDS,JDE,KDS,KDE, &
+                          IMS,IME,JMS,JME,KMS,KME, &
+                          ITS,ITE,JTS,JTE,KTS,KTE  )
+!
+ IMPLICIT NONE
+ INTEGER,    INTENT(IN   )                            :: IDS,IDE,JDS,JDE,KDS,KDE
+ INTEGER,    INTENT(IN   )                            :: IMS,IME,JMS,JME,KMS,KME
+ INTEGER,    INTENT(IN   )                            :: ITS,ITE,JTS,JTE,KTS,KTE
+ REAL,       INTENT(IN   )                            :: DLMD1,DPHD1,WBD1,SBD1
+ REAL,       INTENT(IN   )                            :: CENTRAL_LAT,CENTRAL_LON
+ REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(OUT)        :: HLAT,HLON,VLAT,VLON
+
+! local
+
+
+ INTEGER,PARAMETER                           :: KNUM=SELECTED_REAL_KIND(13)
+ INTEGER                                     :: I,J
+ REAL(KIND=KNUM)                             :: WB,SB,DLM,DPH,TPH0,STPH0,CTPH0
+ REAL(KIND=KNUM)                             :: TDLM,TDPH,TLMH,TLMV,TLMH0,TLMV0,TPHH,TPHV,DTR
+ REAL(KIND=KNUM)                             :: STPH,CTPH,STPV,CTPV,PI_2
+ REAL(KIND=KNUM)                             :: SPHH,CLMH,FACTH,SPHV,CLMV,FACTV
+ REAL(KIND=KNUM), DIMENSION(IMS:IME,JMS:JME) :: GLATH,GLONH,GLATV,GLONV
+ REAL(KIND=KNUM) :: DLMD8,DPHD8,WBD8,SBD8,CLAT8,CLON8
+ REAL(KIND=KNUM) :: CPHH, CPHV
+!-------------------------------------------------------------------------
+ DLMD8=DLMD1
+ DPHD8=DPHD1
+ WBD8=WBD1
+ SBD8=SBD1
+ CLAT8=CENTRAL_LAT
+ CLON8=CENTRAL_LON
+!
+      PI_2 = ACOS(0.)
+      DTR  = PI_2/90.
+      WB   = WBD8 * DTR                 ! WB:   western boundary in radians
+      SB   = SBD8 * DTR                 ! SB:   southern boundary in radians
+      DLM  = DLMD8 * DTR                ! DLM:  dlamda in radians
+      DPH  = DPHD8 * DTR                ! DPH:  dphi   in radians
+      TDLM = DLM + DLM                  ! TDLM: 2.0*dlamda
+      TDPH = DPH + DPH                  ! TDPH: 2.0*DPH
+
+!     For earth lat lon only
+
+      TPH0  = CLAT8*DTR                ! TPH0: central lat in radians
+      STPH0 = SIN(TPH0)
+      CTPH0 = COS(TPH0)
+
+                                                !    .H
+      DO J = JTS,MIN(JTE,JDE-1)                 ! H./    This loop takes care of zig-zag
+!                                               !   \.H  starting points along j
+         TLMH0 = WB - TDLM + MOD(J+1,2) * DLM   !  ./    TLMH (rotated lats at H points)
+         TLMV0 = WB - TDLM + MOD(J,2) * DLM     !  H     (//ly for V points)
+         TPHH = SB + (J-1)*DPH                  !   TPHH (rotated lons at H points) are simple trans.
+         TPHV = TPHH                            !   TPHV (rotated lons at V points) are simple trans.
+         STPH = SIN(TPHH)
+         CTPH = COS(TPHH)
+         STPV = SIN(TPHV)
+         CTPV = COS(TPHV)
+                                                              !   .H
+         DO I = ITS,MIN(ITE,IDE-1)                            !  /
+           TLMH = TLMH0 + I*TDLM                              !  \.H   .U   .H
+!                                                             !H./ ----><----
+           SPHH = CTPH0 * STPH + STPH0 * CTPH * COS(TLMH)     !     DLM + DLM
+           CPHH = sqrt(1-SPHH**2)
+           GLATH(I,J)=ASIN(SPHH)                              ! GLATH: Earth Lat in radians
+           !CLMH = CTPH*COS(TLMH)/(COS(GLATH(I,J))*CTPH0) &
+           !     - TAN(GLATH(I,J))*TAN(TPH0)
+           CLMH = (CTPH*COS(TLMH)-SPHH*STPH0) / (CPHH*CTPH0)
+           IF(CLMH .GT. 1.) CLMH = 1.0
+           IF(CLMH .LT. -1.) CLMH = -1.0
+           FACTH = 1.
+           IF(TLMH .GT. 0.) FACTH = -1.
+           GLONH(I,J) = -CLON8*DTR + FACTH*ACOS(CLMH)
+
+         ENDDO
+
+         DO I = ITS,MIN(ITE,IDE-1)
+           TLMV = TLMV0 + I*TDLM
+           SPHV = CTPH0 * STPV + STPH0 * CTPV * COS(TLMV)
+           CPHV = sqrt(1-SPHV**2)
+           GLATV(I,J) = ASIN(SPHV)
+           !CLMV = CTPV*COS(TLMV)/(COS(GLATV(I,J))*CTPH0) &
+           !     - TAN(GLATV(I,J))*TAN(TPH0)
+           CLMV = (CTPV*COS(TLMV)-SPHV*STPH0) / (CPHV*CTPH0)
+           IF(CLMV .GT. 1.) CLMV = 1.
+           IF(CLMV .LT. -1.) CLMV = -1.
+           FACTV = 1.
+           IF(TLMV .GT. 0.) FACTV = -1.
+           GLONV(I,J) = -CLON8*DTR + FACTV*ACOS(CLMV)
+
+         ENDDO
+
+      ENDDO
+
+!     Conversion to degrees (may not be required, eventually)
+
+      DO J = JTS, MIN(JTE,JDE-1)
+       DO I = ITS, MIN(ITE,IDE-1)
+          HLAT(I,J) = GLATH(I,J) / DTR
+          HLON(I,J)= -GLONH(I,J)/DTR
+          IF(HLON(I,J) .LT. 0.) HLON(I,J) = HLON(I,J) + 360.
+!
+          VLAT(I,J) = GLATV(I,J) / DTR
+          VLON(I,J) = -GLONV(I,J) / DTR
+          IF(VLON(I,J) .LT. 0.) VLON(I,J) = VLON(I,J) + 360.
+
+       ENDDO
+      ENDDO
+
+END SUBROUTINE EARTH_LATLON
+
+!-----------------------------------------------------------------------+
+ subroutine general_create_llxy_transform(region_lat,region_lon,nlat,nlon,gt)
+!
+! adopted from hafs sorc/hafs_gsi.fd/src/gsi/general_tll2xy_mod.f90
+!
+! abstract:  copy routines from gridmod.f90 to make a general purpose module which allows
+!     conversion of earth lat lons to grid coordinates for any non-staggered rectangular
+!     orthogonal grid with known earth lat and lon of each grid point.
+!     set up constants to allow conversion between earth lat lon and analysis grid units.
+!     There is no need to specify details of the analysis grid projection.  All that is required
+!     is the earth latitude and longitude in radians of each analysis grid point.
+!
+  use constants
+  use var_type
+
+  implicit none
+
+  integer,intent(in   ) :: nlat,nlon
+  real   ,intent(in   ) :: region_lat(nlat,nlon),region_lon(nlat,nlon)
+  type(llxy_cons),intent(inout) :: gt
+
+  real,parameter:: rbig =1.0e30
+  real    :: xbar_min,xbar_max,ybar_min,ybar_max
+  real    :: clon,slon,r_of_lat,xbar,ybar
+  integer :: i,j,istart0,iend,iinc,itemp,ilast,jlast
+  real    :: glats(nlon,nlat),glons(nlon,nlat)
+  real,allocatable:: clata(:,:),slata(:,:),clona(:,:),slona(:,:)
+  real    :: clat0,slat0,clon0,slon0
+  real    :: clat_m1,slat_m1,clon_m1,slon_m1
+  real    :: clat_p1,slat_p1,clon_p1,slon_p1
+  real    :: x,y,z,xt,yt,zt,xb,yb,zb
+  real    :: rlonb_m1,clonb_m1,slonb_m1
+  real    :: rlonb_p1,clonb_p1,slonb_p1
+  real    :: crot,srot
+
+  do j=1,nlon
+     do i=1,nlat
+        glats(j,i)=region_lat(i,j)
+        glons(j,i)=region_lon(i,j)
+     end do
+  end do
+  gt%pihalf=0.5*pi
+  gt%nlon=nlon
+  gt%nlat=nlat
+  gt%rlon_min_dd=1.0
+  gt%rlat_min_dd=1.0
+  gt%rlon_max_dd=nlon
+  gt%rlat_max_dd=nlat
+
+!  define xtilde, ytilde grid, transform
+
+!  glons,glats are lons, lats of input grid points of dimension nlon,nlat
+  call general_get_xytilde_domain(gt,gt%nlon,gt%nlat,glons,glats,gt%nxtilde,gt%nytilde, &
+                   xbar_min,xbar_max,ybar_min,ybar_max)
+  if(gt%lallocated) then
+     deallocate(gt%i0_tilde,gt%j0_tilde,gt%ip_tilde,gt%jp_tilde,gt%xtilde0,gt%ytilde0)
+     deallocate(gt%cos_beta_ref,gt%sin_beta_ref,gt%region_lat,gt%region_lon)
+     gt%lallocated=.false.
+  end if
+  allocate(gt%i0_tilde(gt%nxtilde,gt%nytilde),gt%j0_tilde(gt%nxtilde,gt%nytilde))
+  allocate(gt%ip_tilde(gt%nxtilde,gt%nytilde),gt%jp_tilde(gt%nxtilde,gt%nytilde))
+  allocate(gt%xtilde0(gt%nlon,gt%nlat),gt%ytilde0(gt%nlon,gt%nlat))
+  allocate(gt%cos_beta_ref(gt%nlon,gt%nlat),gt%sin_beta_ref(gt%nlon,gt%nlat))
+  allocate(gt%region_lat(gt%nlat,gt%nlon),gt%region_lon(gt%nlat,gt%nlon))
+
+  gt%lallocated=.true.
+
+  do j=1,nlon
+     do i=1,nlat
+        gt%region_lat(i,j)=region_lat(i,j)
+        gt%region_lon(i,j)=region_lon(i,j)
+     end do
+  end do
+
+! define atilde_x, btilde_x, atilde_y, btilde_y
+
+  gt%btilde_x   =(gt%nxtilde -1.0     )/(xbar_max-xbar_min)
+  gt%btilde_xinv=(xbar_max-xbar_min)/(gt%nxtilde -1.0     )
+  gt%atilde_x   =1.0-gt%btilde_x*xbar_min
+  gt%btilde_y   =(gt%nytilde -1.0     )/(ybar_max-ybar_min)
+  gt%btilde_yinv=(ybar_max-ybar_min)/(gt%nytilde -1.0     )
+  gt%atilde_y   =1.0-gt%btilde_y*ybar_min
+
+! define xtilde0,ytilde0
+  do j=1,gt%nlat
+     do i=1,gt%nlon
+        r_of_lat=gt%pihalf+gt%sign_pole*glats(i,j)
+        clon=cos(glons(i,j)+gt%rlambda0)
+        slon=sin(glons(i,j)+gt%rlambda0)
+        xbar=r_of_lat*clon
+        ybar=r_of_lat*slon
+        gt%xtilde0(i,j)=gt%atilde_x+gt%btilde_x*xbar
+        gt%ytilde0(i,j)=gt%atilde_y+gt%btilde_y*ybar
+     end do
+  end do
+
+!  now get i0_tilde, j0_tilde, ip_tilde,jp_tilde
+  ilast=1 ; jlast=1
+  istart0=gt%nxtilde
+  iend=1
+  iinc=-1
+  do j=1,gt%nytilde
+     itemp=istart0
+     istart0=iend
+     iend=itemp
+     iinc=-iinc
+     ybar=j
+     do i=istart0,iend,iinc
+        xbar=i
+        call general_nearest_3(ilast,jlast,gt%i0_tilde(i,j),gt%j0_tilde(i,j), &
+                       gt%ip_tilde(i,j),gt%jp_tilde(i,j),xbar,ybar,gt%nlon,gt%nlat,gt%xtilde0,gt%ytilde0)
+     end do
+  end do
+
+!   new, more accurate and robust computation of cos_beta_ref and sin_beta_ref which is independent
+!     of sign_pole and works for any orientation of grid on sphere (only restriction for now is that
+!     x-y coordinate of analysis grid is right handed).
+  allocate(clata(gt%nlon,gt%nlat),slata(gt%nlon,gt%nlat),clona(gt%nlon,gt%nlat),slona(gt%nlon,gt%nlat))
+  do j=1,gt%nlat
+     do i=1,gt%nlon
+        clata(i,j)=cos(glats(i,j))
+        slata(i,j)=sin(glats(i,j))
+        clona(i,j)=cos(glons(i,j))
+        slona(i,j)=sin(glons(i,j))
+     end do
+  end do
+  do j=1,gt%nlat
+     do i=2,gt%nlon-1
+
+!     do all interior lon points to 2nd order accuracy
+
+!   transform so pole is at rlat0,rlon0 and 0 meridian is tangent to earth latitude at rlat0,rlon0.
+
+        clat0=clata(i,j) ; slat0=slata(i,j) ; clon0=clona(i,j) ; slon0=slona(i,j)
+
+!    now obtain new coordinates for m1 and p1 points.
+
+        clat_m1=clata(i-1,j) ; slat_m1=slata(i-1,j) ; clon_m1=clona(i-1,j) ; slon_m1=slona(i-1,j)
+        clat_p1=clata(i+1,j) ; slat_p1=slata(i+1,j) ; clon_p1=clona(i+1,j) ; slon_p1=slona(i+1,j)
+
+        x=clat_m1*clon_m1 ; y=clat_m1*slon_m1 ; z=slat_m1
+        xt=x*clon0+y*slon0 ; yt=-x*slon0+y*clon0 ; zt=z
+        yb=zt*clat0-xt*slat0
+        xb=yt
+        zb=xt*clat0+zt*slat0
+
+        rlonb_m1=atan2(-yb,-xb)   !  the minus signs here are so line for m1 is directed same
+        clonb_m1=cos(rlonb_m1)
+        slonb_m1=sin(rlonb_m1)
+
+        x=clat_p1*clon_p1 ; y=clat_p1*slon_p1 ; z=slat_p1
+        xt=x*clon0+y*slon0 ; yt=-x*slon0+y*clon0 ; zt=z
+        yb=zt*clat0-xt*slat0
+        xb=yt
+        zb=xt*clat0+zt*slat0
+        rlonb_p1=atan2(yb,xb)
+        clonb_p1=cos(rlonb_p1)
+        slonb_p1=sin(rlonb_p1)
+        crot=0.5*(clonb_m1+clonb_p1)
+        srot=0.5*(slonb_m1+slonb_p1)
+        gt%cos_beta_ref(i,j)=crot*clon0-srot*slon0
+        gt%sin_beta_ref(i,j)=srot*clon0+crot*slon0
+     end do
+!               now do i=1 and i=gt%nlon at 1st order accuracy
+     i=1
+
+!   transform so pole is at rlat0,rlon0 and 0 meridian is tangent to earth latitude at rlat0,rlon0.
+
+        clat0=clata(i,j) ; slat0=slata(i,j) ; clon0=clona(i,j) ; slon0=slona(i,j)
+!    now obtain new coordinates for m1 and p1 points.
+
+        clat_p1=clata(i+1,j) ; slat_p1=slata(i+1,j) ; clon_p1=clona(i+1,j) ; slon_p1=slona(i+1,j)
+
+        x=clat_p1*clon_p1 ; y=clat_p1*slon_p1 ; z=slat_p1
+        xt=x*clon0+y*slon0 ; yt=-x*slon0+y*clon0 ; zt=z
+        yb=zt*clat0-xt*slat0
+        xb=yt
+        zb=xt*clat0+zt*slat0
+        rlonb_p1=atan2(yb,xb)
+        clonb_p1=cos(rlonb_p1)
+        slonb_p1=sin(rlonb_p1)
+        crot=clonb_p1
+        srot=slonb_p1
+        gt%cos_beta_ref(i,j)=crot*clon0-srot*slon0
+        gt%sin_beta_ref(i,j)=srot*clon0+crot*slon0
+
+     i=gt%nlon
+
+!   transform so pole is at rlat0,rlon0 and 0 meridian is tangent to earth latitude at rlat0,rlon0.
+
+        clat0=clata(i,j) ; slat0=slata(i,j) ; clon0=clona(i,j) ; slon0=slona(i,j)
+
+!    now obtain new coordinates for m1 and p1 points.
+
+        clat_m1=clata(i-1,j) ; slat_m1=slata(i-1,j) ; clon_m1=clona(i-1,j) ; slon_m1=slona(i-1,j)
+
+        x=clat_m1*clon_m1 ; y=clat_m1*slon_m1 ; z=slat_m1
+        xt=x*clon0+y*slon0 ; yt=-x*slon0+y*clon0 ; zt=z
+        yb=zt*clat0-xt*slat0
+        xb=yt
+        zb=xt*clat0+zt*slat0
+
+        rlonb_m1=atan2(-yb,-xb)   !  the minus signs here are so line for m1 is directed same
+        clonb_m1=cos(rlonb_m1)
+        slonb_m1=sin(rlonb_m1)
+
+        crot=clonb_m1
+        srot=slonb_m1
+        gt%cos_beta_ref(i,j)=crot*clon0-srot*slon0
+        gt%sin_beta_ref(i,j)=srot*clon0+crot*slon0
+  end do
+  deallocate(clata,slata,clona,slona)
+
+end subroutine general_create_llxy_transform
+
+!-----------------------------------------------------------------------+
+subroutine general_tll2xy(gt,rlon,rlat,x,y,outside)
+!
+! adopted from hafs sorc/hafs_gsi.fd/src/gsi/general_tll2xy_mod.f90
+!
+! abstract:  copy routines from gridmod.f90 to make a general purpose module which allows
+!     conversion of earth lat lons to grid coordinates for any non-staggered rectangular
+!     orthogonal grid with known earth lat and lon of each grid point.
+!     general_tll2xy converts earth lon-lat to x-y grid units of a
+!           general regional rectangular domain.  Also, decides if
+!           point is inside this domain.  As a result, there is
+!           no restriction on type of horizontal coordinate for
+!           a regional run, other than that it not have periodicity
+!           or polar singularities.
+!           This is done by first converting rlon, rlat to an
+!           intermediate coordinate xtilde,ytilde, which has
+!           precomputed pointers and constants for final conversion
+!           to the desired x,y via 3 point inverse interpolation.
+!           All of the information needed is derived from arrays
+!           specifying earth latitude and longitude of every point
+!           on the input grid.  Currently, the input x-y grid that
+!           this is based on must be non-staggered.  This restriction
+!           will eventually be lifted so we can run directly from
+!           model grids that are staggered without first resorting
+!           to interpolation of the guess to a non-staggered grid.
+!
+  use var_type
+
+  implicit none
+
+    type(llxy_cons),intent(in) :: gt
+    real,intent(in   ) :: rlon
+    real,intent(in   ) :: rlat
+    real,intent(  out) :: x
+    real,intent(  out) :: y
+    logical,intent(out):: outside
+
+    real    :: clon,slon,r_of_lat,xtilde,ytilde
+    real    :: dtilde,etilde
+    real    :: d1tilde,d2tilde,e1tilde,e2tilde,detinv
+    integer :: itilde,jtilde
+    integer :: i0,j0,ip,jp
+
+!   first compute xtilde, ytilde
+
+    clon=cos(rlon+gt%rlambda0)
+    slon=sin(rlon+gt%rlambda0)
+    r_of_lat=gt%pihalf+gt%sign_pole*rlat
+
+    xtilde=gt%atilde_x+gt%btilde_x*r_of_lat*clon
+    ytilde=gt%atilde_y+gt%btilde_y*r_of_lat*slon
+
+!  next get interpolation information
+
+    itilde=max(1,min(nint(xtilde),gt%nxtilde))
+    jtilde=max(1,min(nint(ytilde),gt%nytilde))
+
+    i0     =   gt%i0_tilde(itilde,jtilde)
+    j0     =   gt%j0_tilde(itilde,jtilde)
+    ip     =i0+gt%ip_tilde(itilde,jtilde)
+    jp     =j0+gt%jp_tilde(itilde,jtilde)
+    dtilde =xtilde-gt%xtilde0(i0,j0)
+    etilde =ytilde-gt%ytilde0(i0,j0)
+    d1tilde=(gt%xtilde0(ip,j0)-gt%xtilde0(i0,j0))*(ip-i0)
+    d2tilde=(gt%xtilde0(i0,jp)-gt%xtilde0(i0,j0))*(jp-j0)
+    e1tilde=(gt%ytilde0(ip,j0)-gt%ytilde0(i0,j0))*(ip-i0)
+    e2tilde=(gt%ytilde0(i0,jp)-gt%ytilde0(i0,j0))*(jp-j0)
+    detinv =1.0/(d1tilde*e2tilde-d2tilde*e1tilde)
+    x = i0+detinv*(e2tilde*dtilde-d2tilde*etilde)
+    y = j0+detinv*(d1tilde*etilde-e1tilde*dtilde)
+
+    outside=x < gt%rlon_min_dd .or. x > gt%rlon_max_dd .or. &
+            y < gt%rlat_min_dd .or. y > gt%rlat_max_dd
+
+    return
+
+end subroutine general_tll2xy
+
+!-----------------------------------------------------------------------+
+subroutine general_txy2ll(gt,x,y,rlon,rlat)
+!
+! adopted from hafs sorc/hafs_gsi.fd/src/gsi/general_tll2xy_mod.f90
+!
+! abstract: convert x-y grid units to earth lat-lon coordinates
+!
+  use var_type
+
+  implicit none
+
+    type(llxy_cons),intent(in) :: gt
+    real, intent(in   ) :: x
+    real, intent(in   ) :: y
+    real, intent(  out) :: rlon
+    real, intent(  out) :: rlat
+
+    real   :: r_of_lat,xtilde,ytilde
+    real   :: dtilde,etilde,xbar,ybar
+    real   :: d1tilde,d2tilde,e1tilde,e2tilde
+    integer:: i0,j0,ip,jp
+
+    i0=nint(x)
+    j0=nint(y)
+    i0=max(1,min(i0,gt%nlon))
+    j0=max(1,min(j0,gt%nlat))
+    ip=i0+nint(sign(1.0,x-i0))
+    jp=j0+nint(sign(1.0,y-j0))
+    if(ip<1) then
+       i0=2
+       ip=1
+    end if
+    if(jp<1) then
+       j0=2
+       jp=1
+    end if
+    if(ip>gt%nlon) then
+       i0=gt%nlon-1
+       ip=gt%nlon
+    end if
+    if(jp>gt%nlat) then
+       j0=gt%nlat-1
+       jp=gt%nlat
+    end if
+    d1tilde=(gt%xtilde0(ip,j0)-gt%xtilde0(i0,j0))*(ip-i0)
+    d2tilde=(gt%xtilde0(i0,jp)-gt%xtilde0(i0,j0))*(jp-j0)
+    e1tilde=(gt%ytilde0(ip,j0)-gt%ytilde0(i0,j0))*(ip-i0)
+    e2tilde=(gt%ytilde0(i0,jp)-gt%ytilde0(i0,j0))*(jp-j0)
+    dtilde =d1tilde*(x-i0) +d2tilde*(y-j0)
+    etilde =e1tilde*(x-i0) +e2tilde*(y-j0)
+    xtilde =dtilde         +gt%xtilde0(i0,j0)
+    ytilde =etilde         +gt%ytilde0(i0,j0)
+
+    xbar=(xtilde-gt%atilde_x)*gt%btilde_xinv
+    ybar=(ytilde-gt%atilde_y)*gt%btilde_yinv
+    r_of_lat=sqrt(xbar**2+ybar**2)
+    rlat=(r_of_lat-gt%pihalf)*gt%sign_pole
+    rlon=atan2(ybar,xbar)-gt%rlambda0
+
+end subroutine general_txy2ll
+
+!-----------------------------------------------------------------------+
+subroutine general_nearest_3(ilast,jlast,i0,j0,ip,jp,x,y,nx0,ny0,x0,y0)
+!
+! adopted from hafs sorc/hafs_gsi.fd/src/gsi/general_tll2xy_mod.f90
+!
+! abstract: find closest 3 points to (x,y) on grid defined by x0,y0
+!
+
+  use var_type
+
+  implicit none
+
+  integer, intent(inout) :: ilast,jlast
+  integer, intent(  out) :: i0,j0
+  integer, intent(  out) :: ip,jp
+  integer, intent(in   ) :: nx0,ny0
+  real    ,intent(in   ) :: x,y
+  real    ,intent(in   ) :: x0(nx0,ny0),y0(nx0,ny0)
+
+  real    :: dista,distb,dist2,dist2min
+  integer :: i,inext,j,jnext
+
+  do
+     i0=ilast
+     j0=jlast
+     dist2min=huge(dist2min)
+     inext=0
+     jnext=0
+     do j=max(j0-1,1),min(j0+1,ny0)
+        do i=max(i0-1,1),min(i0+1,nx0)
+           dist2=(x-x0(i,j))**2+(y-y0(i,j))**2
+           if(dist2<dist2min) then
+              dist2min=dist2
+              inext=i
+              jnext=j
+           end if
+        end do
+     end do
+     if(inext==i0.and.jnext==j0) exit
+     ilast=inext
+     jlast=jnext
+  end do
+
+!  now find which way to go in x for second point
+
+  ip=0
+  if(i0==nx0)  ip=-1
+  if(i0==1) ip=1
+  if(ip==0) then
+     dista=(x-x0(i0-1,j0))**2+(y-y0(i0-1,j0))**2
+     distb=(x-x0(i0+1,j0))**2+(y-y0(i0+1,j0))**2
+     if(distb<dista) then
+        ip=1
+     else
+        ip=-1
+     end if
+  end if
+
+!  repeat for y for 3rd point
+
+  jp=0
+  if(j0==ny0  ) jp=-1
+  if(j0==1 ) jp=1
+  if(jp==0) then
+     dista=(x-x0(i0,j0-1))**2+(y-y0(i0,j0-1))**2
+     distb=(x-x0(i0,j0+1))**2+(y-y0(i0,j0+1))**2
+     if(distb<dista) then
+        jp=1
+     else
+        jp=-1
+     end if
+  end if
+
+  ilast=i0
+  jlast=j0
+
+end subroutine general_nearest_3
+
+!-----------------------------------------------------------------------+
+subroutine general_get_xytilde_domain(gt,nx0,ny0,rlons0,rlats0, &
+                                  nx,ny,xminout,xmaxout,yminout,ymaxout)
+!
+! adopted from hafs sorc/hafs_gsi.fd/src/gsi/general_tll2xy_mod.f90
+
+  use constants
+  use var_type
+
+  implicit none
+
+  type(llxy_cons),intent(inout) :: gt
+  integer, intent(in   ) :: nx0,ny0
+  real, intent(in   )    :: rlons0(nx0,ny0),rlats0(nx0,ny0)
+
+  integer,intent(  out) :: nx,ny
+  real   ,intent(  out) :: xminout,xmaxout,yminout,ymaxout
+
+  real,parameter:: r37=37.0
+
+  real    :: area,areamax,areamin,extra,rlats0max,rlats0min,testlambda
+  real    :: xthis,ythis
+  integer :: i,ip1,j,jp1,m
+
+  real    :: coslon0(nx0,ny0),sinlon0(nx0,ny0)
+  real    :: coslat0(nx0,ny0),sinlat0(nx0,ny0)
+  real    :: count,delbar
+  real    :: dx,dy,disti,distj,distmin,distmax
+  real    :: xmin,xmax,ymin,ymax
+
+!  get range of lats for input grid
+
+  rlats0max=maxval(rlats0) ; rlats0min=minval(rlats0)
+
+!   assign hemisphere ( parameter sign_pole )
+
+  if(rlats0min>-r37*deg2rad) gt%sign_pole=-1.0   !  northern hemisphere xy domain
+  if(rlats0max< r37*deg2rad) gt%sign_pole= 1.0   !  southern hemisphere xy domain
+
+
+!   get optimum rotation angle rlambda0
+
+  areamin= huge(areamin)
+  areamax=-huge(areamax)
+  do m=0,359
+     testlambda=m*deg2rad
+     xmax=-huge(xmax)
+     xmin= huge(xmin)
+     ymax=-huge(ymax)
+     ymin= huge(ymin)
+     do j=1,ny0,ny0-1
+        do i=1,nx0
+           xthis=(gt%pihalf+gt%sign_pole*rlats0(i,j))*cos(rlons0(i,j)+testlambda)
+           ythis=(gt%pihalf+gt%sign_pole*rlats0(i,j))*sin(rlons0(i,j)+testlambda)
+           xmax=max(xmax,xthis)
+           ymax=max(ymax,ythis)
+           xmin=min(xmin,xthis)
+           ymin=min(ymin,ythis)
+        end do
+     end do
+     do j=1,ny0
+        do i=1,nx0,nx0-1
+           xthis=(gt%pihalf+gt%sign_pole*rlats0(i,j))*cos(rlons0(i,j)+testlambda)
+           ythis=(gt%pihalf+gt%sign_pole*rlats0(i,j))*sin(rlons0(i,j)+testlambda)
+           xmax=max(xmax,xthis)
+           ymax=max(ymax,ythis)
+           xmin=min(xmin,xthis)
+           ymin=min(ymin,ythis)
+        end do
+     end do
+     area=(xmax-xmin)*(ymax-ymin)
+     areamax=max(area,areamax)
+     if(area<areamin) then
+        areamin =area
+        gt%rlambda0=testlambda
+        xmaxout =xmax
+        xminout =xmin
+        ymaxout =ymax
+        yminout =ymin
+     end if
+  end do
+
+
+!   now determine resolution of input grid and choose nx,ny of xy grid accordingly
+!                 (currently hard-wired at 1/2 the average input grid increment)
+
+  do j=1,ny0
+     do i=1,nx0
+        coslon0(i,j)=cos(1.0*rlons0(i,j)) ; sinlon0(i,j)=sin(1.0*rlons0(i,j))
+        coslat0(i,j)=cos(1.0*rlats0(i,j)) ; sinlat0(i,j)=sin(1.0*rlats0(i,j))
+     end do
+  end do
+
+  delbar=0.0
+  count =0.0
+  do j=1,ny0-1
+     jp1=j+1
+     do i=1,nx0-1
+        ip1=i+1
+        disti=acos(sinlat0(i,j)*sinlat0(ip1,j)+coslat0(i,j)*coslat0(ip1,j)* &
+                  (sinlon0(i,j)*sinlon0(ip1,j)+coslon0(i,j)*coslon0(ip1,j)))
+        distj=acos(sinlat0(i,j)*sinlat0(i,jp1)+coslat0(i,j)*coslat0(i,jp1)* &
+                  (sinlon0(i,j)*sinlon0(i,jp1)+coslon0(i,j)*coslon0(i,jp1)))
+        distmax=max(disti,distj)
+        distmin=min(disti,distj)
+        delbar=delbar+distmax
+        count=count+1.0
+     end do
+  end do
+  delbar=delbar/count
+  dx=0.5*delbar
+  dy=dx
+
+!   add extra space to computational grid to push any boundary problems away from
+!     area of interest
+
+  extra=10.0*dx
+  xmaxout=xmaxout+extra
+  xminout=xminout-extra
+  ymaxout=ymaxout+extra
+  yminout=yminout-extra
+  nx=1+(xmaxout-xminout)/dx
+  ny=1+(ymaxout-yminout)/dy
+
+end subroutine general_get_xytilde_domain
+
+!-----------------------------------------------------------------------+
+subroutine general_rotate_wind_ll2xy(gt,u0,v0,u,v,rlon0,x,y)
+!
+! adopted from hafs sorc/hafs_gsi.fd/src/gsi/general_tll2xy_mod.f90
+!
+! DESCRIPTION: to convert earth vector wind components to corresponding local x,y coordinate
+
+  use var_type
+
+  implicit none
+
+    type(llxy_cons),intent(in) :: gt
+    real, intent(in   ) :: u0,v0        ! earth wind component
+    real, intent(in   ) :: rlon0        ! earth   lon (radians)
+    real, intent(in   ) :: x,y          ! local x,y coordinate (grid units)
+    real, intent(  out) :: u,v          ! rotated coordinate of winds
+
+  real    :: beta,delx,delxp,dely,delyp
+  real    :: sin_beta,cos_beta
+  integer :: ix,iy
+
+!  interpolate departure from longitude part of angle between earth positive east and local positive x
+
+  ix=x
+  iy=y
+  ix=max(1,min(ix,gt%nlon-1))
+  iy=max(1,min(iy,gt%nlat-1))
+  delx=x-ix
+  dely=y-iy
+  delxp=1.0-delx
+  delyp=1.0-dely
+  cos_beta=gt%cos_beta_ref(ix  ,iy  )*delxp*delyp+gt%cos_beta_ref(ix+1,iy  )*delx *delyp+ &
+           gt%cos_beta_ref(ix  ,iy+1)*delxp*dely +gt%cos_beta_ref(ix+1,iy+1)*delx *dely
+  sin_beta=gt%sin_beta_ref(ix  ,iy  )*delxp*delyp+gt%sin_beta_ref(ix+1,iy  )*delx *delyp+ &
+           gt%sin_beta_ref(ix  ,iy+1)*delxp*dely +gt%sin_beta_ref(ix+1,iy+1)*delx *dely
+  beta=atan2(sin_beta,cos_beta)
+
+!  now rotate;
+
+  u= u0*cos(beta-rlon0)+v0*sin(beta-rlon0)
+  v=-u0*sin(beta-rlon0)+v0*cos(beta-rlon0)
+
+end subroutine general_rotate_wind_ll2xy
+
+!-----------------------------------------------------------------------+
+subroutine general_rotate_wind_xy2ll(gt,u,v,u0,v0,rlon0,x,y)
+!
+! adopted from hafs sorc/hafs_gsi.fd/src/gsi/general_tll2xy_mod.f90
+!
+! DESCRIPTION: rotate u,v in local x,y coordinate to u0,v0 in earth lat, lon coordinate
+
+  use var_type
+
+  implicit none
+
+    type(llxy_cons),intent(in) :: gt
+    real, intent(in   ) :: u,v         ! rotated coordinate winds
+    real, intent(in   ) :: rlon0       ! earth   lon     (radians)
+    real, intent(in   ) :: x,y         ! rotated lon/lat (radians)
+    real, intent(  out) :: u0,v0       ! earth winds
+
+  real    :: beta,delx,delxp,dely,delyp
+  real    :: sin_beta,cos_beta
+  integer :: ix,iy
+
+!  interpolate departure from longitude part of angle between earth
+!  positive east and local positive x
+
+  ix=x
+  iy=y
+  ix=max(1,min(ix,gt%nlon-1))
+  iy=max(1,min(iy,gt%nlat-1))
+  delx=x-ix
+  dely=y-iy
+  delxp=1.0-delx
+  delyp=1.0-dely
+  cos_beta=gt%cos_beta_ref(ix  ,iy  )*delxp*delyp+gt%cos_beta_ref(ix+1,iy  )*delx *delyp+ &
+           gt%cos_beta_ref(ix  ,iy+1)*delxp*dely +gt%cos_beta_ref(ix+1,iy+1)*delx *dely
+  sin_beta=gt%sin_beta_ref(ix  ,iy  )*delxp*delyp+gt%sin_beta_ref(ix+1,iy  )*delx *delyp+ &
+           gt%sin_beta_ref(ix  ,iy+1)*delxp*dely +gt%sin_beta_ref(ix+1,iy+1)*delx *dely
+  beta=atan2(sin_beta,cos_beta)
+
+!  now rotate;
+
+  u0= u*cos(beta-rlon0)-v*sin(beta-rlon0)
+  v0= u*sin(beta-rlon0)+v*cos(beta-rlon0)
+
+end subroutine general_rotate_wind_xy2ll
+
+!-----------------------------------------------------------------------+

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_netcdf.f90
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_netcdf.f90
@@ -1,0 +1,723 @@
+!-----------------------------------------------------------------------+
+! This package of subroutines are used for HAFS grid calculation.
+! authors and history:
+!      -- 202102, created by Yonghui Weng
+!      -- 202411, Yonghui Weng modified subroutine write_nc_real to output float/double/int type data
+!
+!========================================================================================
+  subroutine rd_grid_spec_data(ncfile, grid)
+
+  use netcdf
+  use module_mpi
+  use var_type
+  implicit none
+
+  character(len=*), intent(in)    :: ncfile
+  type(grid2d_info) :: grid
+
+  integer :: i, j, n
+  integer :: ncid, varid, ndims, nvars, xtype, dimids(5), vdim(5)
+  character(len=50) :: varname, dimname
+  real    :: lon_c, lon_min
+
+  call nccheck(nf90_open(trim(ncfile), nf90_nowrite, ncid), 'wrong in open: '//trim(ncfile), .true.)
+  call nccheck(nf90_inquire(ncid, ndims, nvars), 'wrong in inquire ncid', .true.)
+  do n = 1, ndims
+     call nccheck(nf90_inquire_dimension(ncid,n,name=dimname, len=i), 'wrong in inquire_dimension', .true.)
+     select case (trim(dimname))
+            case ('grid_x', 'west_east_stag'); grid%grid_x = i
+            case ('grid_y') ; grid%grid_y = i
+            case ('time') ;   grid%ntime  = i
+            case ('grid_xt') ; grid%grid_xt = i
+            case ('grid_yt') ; grid%grid_yt = i
+     end select
+  enddo
+
+  if (allocated(grid%grid_lon)) deallocate(grid%grid_lon)
+  allocate(grid%grid_lon(grid%grid_x,grid%grid_y))
+  call nccheck(nf90_inq_varid(ncid, 'grid_lon', varid), 'wrong in nf90_inq_varid grid_lon', .false.)
+  call nccheck(nf90_get_var(ncid, varid, grid%grid_lon), 'wrong in get data of grid_lon', .false.)
+  !where ( grid%grid_lon > 180. ) grid%grid_lon=grid%grid_lon-360.
+  call longitude_expand_360to540(grid%grid_x,grid%grid_y,grid%grid_lon)
+
+  if (allocated(grid%grid_lat)) deallocate(grid%grid_lat)
+  allocate(grid%grid_lat(grid%grid_x,grid%grid_y))
+  call nccheck(nf90_inq_varid(ncid, 'grid_lat', varid), 'wrong in nf90_inq_varid grid_lat', .false.)
+  call nccheck(nf90_get_var(ncid, varid, grid%grid_lat), 'wrong in get data of grid_lat', .false.)
+
+  if (allocated(grid%times)) deallocate(grid%times)
+  allocate(grid%times(grid%ntime))
+  call nccheck(nf90_inq_varid(ncid, 'time', varid), 'wrong in nf90_inq_varid time', .false.)
+  call nccheck(nf90_get_var(ncid, varid, grid%times), 'wrong in get data of time', .false.)
+  call nccheck(nf90_get_att(ncid, varid, 'units', grid%times_unit), 'wrong in get times_unit', .false.)
+
+  if (allocated(grid%grid_lont)) deallocate(grid%grid_lont)
+  allocate(grid%grid_lont(grid%grid_xt,grid%grid_yt))
+  call nccheck(nf90_inq_varid(ncid, 'grid_lont', varid), 'wrong in nf90_inq_varid grid_lont', .false.)
+  call nccheck(nf90_get_var(ncid, varid, grid%grid_lont), 'wrong in get data of grid_lont', .false.)
+  !where ( grid%grid_lont > 180. ) grid%grid_lont=grid%grid_lont-360.
+  call longitude_expand_360to540(grid%grid_xt,grid%grid_yt,grid%grid_lont)
+
+  if (allocated(grid%grid_latt)) deallocate(grid%grid_latt)
+  allocate(grid%grid_latt(grid%grid_xt,grid%grid_yt))
+  call nccheck(nf90_inq_varid(ncid, 'grid_latt', varid), 'wrong in nf90_inq_varid grid_latt', .false.)
+  call nccheck(nf90_get_var(ncid, varid, grid%grid_latt), 'wrong in get data of grid_latt', .false.)
+
+  !if (allocated(grid%grid_area)) deallocate(grid%grid_area)
+  !allocate(grid%grid_area(grid%grid_xt,grid%grid_yt))
+  !call nccheck(nf90_inq_varid(ncid, 'grid_area', varid), 'wrong in nf90_inq_varid grid_area', .false.)
+  !call nccheck(nf90_get_var(ncid, varid, grid%grid_area), 'wrong in get data of grid_area', .false.)
+
+  if ( my_proc_id == 0 ) then
+     write(*,'(a,i0,a,i0,a,i0,a,i0,a)')'  domain dims:     (1:1) --> (',grid%grid_xt,':1) --> (',&
+                                       grid%grid_xt,':',grid%grid_yt,') --> (1:',grid%grid_yt,')'
+     write(*,'(a, 2f7.2,a,2f7.2,a,2f7.2,a,2f7.2)')'       T-cell:', grid%grid_lont(1,1),grid%grid_latt(1,1), '--->', &
+                                grid%grid_lont(grid%grid_xt,1),grid%grid_latt(grid%grid_xt,1), '--->', &
+                             grid%grid_lont(grid%grid_xt,grid%grid_yt),grid%grid_latt(grid%grid_xt,grid%grid_yt), '--->', &
+                                grid%grid_lont(1,grid%grid_yt),grid%grid_latt(1,grid%grid_yt)
+     write(*,'(a,f7.2,a,f7.2,a,f7.2,a,f7.2)')'   grid_lont :',minval(grid%grid_lont),':',maxval(grid%grid_lont),&
+                                             ' grid_latt :',minval(grid%grid_latt),':',maxval(grid%grid_latt)
+     write(*,'(a,i0,a,i0,a,i0,a,i0,a)')'  domain dims:     (1:1) --> (',grid%grid_x ,':1) --> (',&
+                                       grid%grid_x ,':',grid%grid_y ,') --> (1:',grid%grid_y ,')'
+     write(*,'(a, 2f7.2,a,2f7.2,a,2f7.2,a,2f7.2)')'             :', grid%grid_lon (1,1),grid%grid_lat (1,1), '--->', &
+                                grid%grid_lon (grid%grid_x ,1),grid%grid_lat (grid%grid_x ,1), '--->', &
+                             grid%grid_lon (grid%grid_x ,grid%grid_y ),grid%grid_lat (grid%grid_x ,grid%grid_y ), '--->', &
+                                grid%grid_lon (1,grid%grid_y ),grid%grid_lat (1,grid%grid_y )
+     write(*,'(a,f7.2,a,f7.2,a,f7.2,a,f7.2)')'   grid_lon  :',minval(grid%grid_lon ),':',maxval(grid%grid_lon ),&
+                                             ' grid_lat  :',minval(grid%grid_lat ),':',maxval(grid%grid_lat)
+  endif
+
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .true.)
+
+  return
+  end subroutine rd_grid_spec_data
+
+!========================================================================================
+  subroutine get_var_data (ncfile, var, ix, jx, kx, tx, data)
+
+  use netcdf
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: var
+  integer, intent(in)             :: ix, jx, kx, tx
+  real, dimension(ix, jx, kx, tx) :: data
+
+  integer                         :: ncid, varid, dimid,xtype
+  real*8, allocatable, dimension(:,:,:,:)  :: ddata
+  integer, allocatable, dimension(:,:,:,:) :: idata
+
+  write(*,'(a,4i5)')'---getting '//trim(var)//' :', ix, jx, kx, tx
+  call nccheck(nf90_open(trim(ncfile), nf90_nowrite, ncid), 'wrong in open '//trim(ncfile), .false.)
+  call nccheck(nf90_inq_varid(ncid, trim(var), varid), 'wrong in nf90_inq_varid '//trim(var), .false.)
+  call nccheck(nf90_inquire_variable(ncid, varid, xtype=xtype), 'wrong in nf90_inquire_variable'//trim(var), .false.)
+
+  if ( xtype == nf90_float .or. xtype == nf90_real .or. xtype == nf90_real4 ) then
+     call nccheck(nf90_get_var(ncid, varid, data), 'wrong in get data of '//trim(var), .false.)
+  else if ( xtype == nf90_double .or. xtype == nf90_real8 ) then
+     allocate(ddata(ix, jx, kx, tx))
+     call nccheck(nf90_get_var(ncid, varid, ddata), 'wrong in get data of '//trim(var), .false.)
+     data=real(ddata)
+     deallocate(ddata)
+  else if ( xtype == nf90_int ) then
+     allocate(idata(ix, jx, kx, tx))
+     call nccheck(nf90_get_var(ncid, varid, idata), 'wrong in get data of '//trim(var), .false.)
+     data=real(idata)
+     deallocate(idata)
+  else
+     !---NF90_BYTE, NF90_CHAR, NF90_SHORT
+     write(*,*)' !!!! please add ',xtype,' xtype data here '
+     stop
+  endif
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .false.)
+
+  return
+  end subroutine get_var_data
+
+!========================================================================================
+  subroutine get_var_data_par (ncfile, var, ix, jx, kx, tx, data, ixs, jxs, kxs, txs)
+
+  use netcdf
+  use module_mpi
+
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: var
+  integer, intent(in)             :: ix, jx, kx, tx, ixs, jxs, kxs, txs
+  real, dimension(ix, jx, kx, tx) :: data
+
+  integer                         :: ncid, varid, dimid,xtype
+  real*8, allocatable, dimension(:,:,:,:)  :: ddata
+  integer, allocatable, dimension(:,:,:,:) :: idata
+
+  write(*,'(a,3(i0,1x),i0,a,3(i0,1x),i0,a)')'---getting '//trim(var)//' : (', ixs, jxs, kxs, txs, ') --> (', ix, jx, kx, tx,')'
+  !call nccheck(nf90_open(trim(ncfile), nf90_nowrite, ncid), &
+  call nccheck(nf90_open(trim(ncfile), nf90_nowrite, ncid), 'wrong in open '//trim(ncfile), .false.)
+  call nccheck(nf90_inq_varid(ncid, trim(var), varid), 'wrong in nf90_inq_varid '//trim(var), .false.)
+  !call nccheck(nf90_var_par_access(ncid, varid, nf90_collective), 'wrong in  nf90_var_par_access '//trim(var), .false.)
+  call nccheck(nf90_inquire_variable(ncid, varid, xtype=xtype), 'wrong in nf90_inquire_variable'//trim(var), .false.)
+  !call nccheck(nf90_var_par_access(ncid, varid, nf90_collective), 'wrong in nf90_var_par_access '//trim(var), .false.)
+
+  if ( xtype == nf90_float .or. xtype == nf90_real .or. xtype == nf90_real4 ) then
+     call nccheck(nf90_get_var(ncid, varid, data, start = (/ixs, jxs, kxs, txs/), count = (/ix, jx, kx, tx/)), 'wrong in get data of '//trim(var), .false.)
+  else if ( xtype == nf90_double .or. xtype == nf90_real8 ) then
+     allocate(ddata(ix, jx, kx, tx))
+     call nccheck(nf90_get_var(ncid, varid, ddata, start = (/ixs, jxs, kxs, txs/), count = (/ix, jx, kx, tx/)), 'wrong in get data of '//trim(var), .false.)
+     data=real(ddata)
+     deallocate(ddata)
+  else if ( xtype == nf90_int ) then
+     allocate(idata(ix, jx, kx, tx))
+     call nccheck(nf90_get_var(ncid, varid, idata, start = (/ixs, jxs, kxs, txs/), count = (/ix, jx, kx, tx/)), 'wrong in get data of '//trim(var), .false.)
+     data=real(idata)
+     deallocate(idata)
+  else
+     !---NF90_BYTE, NF90_CHAR, NF90_SHORT
+     write(*,*)' !!!! please add ',xtype,' xtype data here '
+     stop
+  endif
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .false.)
+
+  return
+  end subroutine get_var_data_par
+!========================================================================================
+  subroutine get_character_var(ncid, varname, dim_len, dimsize, values)
+
+  use netcdf
+  implicit none
+
+  integer, intent(in) :: ncid, dim_len, dimsize
+  character (len = *), intent(in) :: varname
+  character (len = 1), dimension(dim_len, dimsize), intent(out) :: values
+  character (len = nf90_max_name) :: vname
+  integer :: ivarid, vartype, nvardims, nvarAtts, dimlen
+  integer,dimension(nf90_max_var_dims) :: start, count, vdims, vardimids
+  character(len=nf90_max_name)  :: dimname
+  integer :: lenstr, j
+
+  call nccheck( nf90_inq_varid(ncid, varname, ivarid), 'wrong in inq_varid '//trim(varname), .false.)
+  call nccheck( nf90_inquire_variable(ncid, ivarid, &
+                                    name = vname, &
+                                    xtype = vartype, &
+                                    ndims = nvardims, &
+                                    dimids = vardimids, &
+                                    natts = nvarAtts), 'wrong in inquire_variable '//trim(varname), .false.)
+
+  lenstr = 1
+
+  do j = 1, nvardims
+    call nccheck(nf90_inquire_dimension(ncid, vardimids(j), name = dimname, len = dimlen), 'wrong in inquire_dimension '//trim(varname), .false.)
+    lenstr = lenstr * dimlen
+    start(j) = 1
+    count(j) = dimlen
+  enddo
+
+  call nccheck( nf90_get_var(ncid, ivarid, values, start = start, count = count), 'wrong in get '//trim(varname), .false. )
+  !write(*, fmt = '(a, " filled")') varname
+
+  end subroutine get_character_var
+
+!========================================================================================
+  subroutine get_var_dim(ncfile, var, ndims, dims)
+
+  use netcdf
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: var
+  integer, intent(out)            :: ndims
+  integer, dimension(nf90_max_var_dims), intent(out) :: dims
+
+  integer                               :: ncid, varid, i
+  integer, dimension(nf90_max_var_dims) :: dimids
+
+  call nccheck(nf90_open(trim(ncfile), nf90_nowrite, ncid), 'wrong in open '//trim(ncfile), .false.)
+  call nccheck(nf90_inq_varid(ncid, trim(var), varid), 'wrong in nf90_inq_varid '//trim(var), .false.)
+  call nccheck(nf90_inquire_variable(ncid, varid, ndims=ndims, dimids=dimids), 'wrong in inquire_variable '//trim(var), .false.)
+  dims=-999
+  do i = 1, ndims
+     call nccheck(nf90_inquire_dimension(ncid,dimids(i), len=dims(i)), 'wrong in inquire '//trim(var)//' dim', .false.)
+  enddo
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .false.)
+
+  return
+  end subroutine get_var_dim
+
+!========================================================================================
+  subroutine update_rdas_restart(ncfile, varname, ix, jx, kx, tx, dat4)
+
+  use netcdf
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: varname
+  integer, intent ( in)           :: ix, jx, kx, tx  ! -1=no-this-dim
+  real, dimension(abs(ix), abs(jx), abs(kx), abs(tx)), intent(in) :: dat4
+
+  integer :: ncid, varid, ndims, xtype, rcode
+
+  call nccheck(nf90_open(trim(ncfile), nf90_write, ncid), 'wrong in open '//trim(ncfile), .true.)
+  !---check variable's type: nf90_real, nf90_double
+  call nccheck(nf90_inq_varid(ncid, trim(varname), varid), 'wrong in inq_varid '//trim(varname), .true.)
+  call nccheck(nf90_inquire_variable(ncid, varid, xtype=xtype, ndims=ndims), 'wrong in inquire '//trim(varname)//' xtype', .false.)
+  if ( xtype == nf90_float .or. xtype == nf90_real .or. xtype == nf90_real4 ) then
+     call nccheck(nf90_put_var(ncid, varid, dat4), 'wrong in write '//trim(varname), .false.)
+  else if ( xtype == nf90_double .or. xtype == nf90_real8 ) then
+     call nccheck(nf90_put_var(ncid, varid, dble(dat4)), 'wrong in write '//trim(varname), .false.)
+  endif
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .true.)
+
+  return
+  end subroutine update_rdas_restart
+!========================================================================================
+  subroutine update_rdas_restart_par(ncfile, varname, ix, jx, kx, tx, dat4, ixs, jxs, kxs, txs)
+
+  use netcdf
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: varname
+  integer, intent ( in)           :: ix, jx, kx, tx, ixs, jxs, kxs, txs  ! -1=no-this-dim
+  real, dimension(abs(ix), abs(jx), abs(kx), abs(tx)), intent(in) :: dat4
+
+  integer :: ncid, varid, ndims, xtype, rcode
+
+  call nccheck(nf90_open(trim(ncfile), nf90_write, ncid), 'wrong in open '//trim(ncfile), .true.)
+  !---check variable's type: nf90_real, nf90_double
+  call nccheck(nf90_inq_varid(ncid, trim(varname), varid), 'wrong in inq_varid '//trim(varname), .true.)
+  call nccheck(nf90_inquire_variable(ncid, varid, xtype=xtype, ndims=ndims), 'wrong in inquire '//trim(varname)//' xtype', .false.)
+  if ( xtype == nf90_float .or. xtype == nf90_real .or. xtype == nf90_real4 ) then
+     call nccheck(nf90_put_var(ncid, varid, dat4, start = (/ixs, jxs, kxs, txs/), count = (/ix, jx, kx, tx/)), 'wrong in write '//trim(varname), .false.)
+  else if ( xtype == nf90_double .or. xtype == nf90_real8 ) then
+     call nccheck(nf90_put_var(ncid, varid, dble(dat4), start = (/ixs, jxs, kxs, txs/), count = (/ix, jx, kx, tx/)), 'wrong in write '//trim(varname), .false.)
+  endif
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .true.)
+
+  return
+  end subroutine update_rdas_restart_par
+
+!========================================================================================
+  subroutine write_nc_dim(ncfile, dimname, nx)
+
+  use netcdf
+  use module_mpi
+
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: dimname
+  integer, intent ( in)           :: nx
+
+  logical                         :: file_exists
+  integer                         :: ncid, nxid, rcode
+
+  !----1.0 open or creat file
+  inquire(file=trim(ncfile), exist=file_exists)
+  if ( file_exists ) then
+     call nccheck(nf90_open(trim(ncfile), nf90_write, ncid), 'wrong in open '//trim(ncfile), .true.)
+  else
+     call nccheck(nf90_create(trim(ncfile), nf90_hdf5, ncid), 'wrong in creat '//trim(ncfile), .true.)
+  endif
+
+  !----2.0 define dimension
+  rcode=nf90_inq_dimid(ncid, trim(dimname), nxid)
+  if ( rcode /= nf90_noerr ) then   !need to create the dimension
+     call nccheck(nf90_def_dim(ncid, trim(dimname), nx, nxid), 'wrong in def '//trim(dimname), .true.)
+  endif
+
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .true.)
+
+  return
+  end subroutine write_nc_dim
+
+!========================================================================================
+  subroutine write_nc_real0d(ncfile, varname, data, units, long_name)
+
+  use netcdf
+  use module_mpi
+
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: varname
+  character(len=*), intent(in)    :: units
+  character(len=*), intent(in)    :: long_name
+  real                            :: data
+
+  logical                         :: file_exists
+  integer                         :: ncid, varid, rcode
+
+  !----1.0 open or creat file
+  inquire(file=trim(ncfile), exist=file_exists)
+  if ( file_exists ) then
+     call nccheck(nf90_open(trim(ncfile), nf90_write, ncid), 'wrong in open '//trim(ncfile), .true.)
+  else
+     call nccheck(nf90_create(trim(ncfile), nf90_hdf5, ncid), 'wrong in creat '//trim(ncfile), .true.)
+  endif
+
+  !----2.0 define variables
+  rcode=nf90_inq_varid(ncid, varname, varid)
+  if ( rcode /= nf90_noerr ) then  ! need to create the var
+     call nccheck(nf90_def_var(ncid, varname, nf90_real, varid), 'wrong in def '//trim(varname), .true.)
+     !call nccheck(nf90_var_par_access(ncid, varid, nf90_collective), 'wrong in  nf90_var_par_access '//trim(varname), .false.)
+     if ( len_trim(units) > 0 ) call nccheck(nf90_put_att(ncid, varid, "units", units), 'wrong in put units', .false.)
+     if ( len_trim(long_name) > 0 ) call nccheck(nf90_put_att(ncid, varid, "long_name",long_name), 'wrong in put long_name', .false.)
+  endif
+
+  !----3.0
+  call nccheck(nf90_put_var(ncid, varid, data), 'wrong in write '//trim(varname), .true.)
+
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .true.)
+
+  return
+  end subroutine write_nc_real0d
+
+!========================================================================================
+  subroutine write_nc_real(ncfile, varname, ix, jx, kx, tx, cx, cy, ck, ct, data, units, long_name)
+
+  use netcdf
+  use module_mpi
+
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: varname
+  integer, intent(in)             :: ix, jx, kx, tx   !dimensions for this varname
+  character(len=*), intent(in)    :: cx, cy, ck, ct   !dimension name
+  real, dimension(abs(ix), abs(jx), abs(kx), abs(tx)), intent(inout)  :: data
+  character(len=*), intent(in)    :: units
+  character(len=*), intent(in)    :: long_name
+
+  logical                         :: file_exists
+  integer                         :: ncid, varid, xtype, rcode, ixid, jxid, kxid, txid
+  integer                         :: date_time(8)
+  character*10                    :: date(3)
+
+  real                            :: FillValue
+
+  xtype=-999  !hint: the default data type is nf90_float
+  FillValue=9.999e+20
+  !----1.0 process data _FillValue
+  where( data > 9.0e+8 .or. data < -300000. ) data=FillValue
+
+  !----2.0 check file
+  inquire(file=trim(ncfile), exist=file_exists)
+  if ( file_exists ) then
+     call nccheck(nf90_open(trim(ncfile), nf90_write, ncid), 'wrong in open '//trim(ncfile)//' for '//trim(varname), .true.)
+  else
+     write(*,*)' !!!! please call write_nc_dim to generate the nc file of '//trim(ncfile)
+     stop
+  endif
+
+  !----3.0 check dimensions
+  if ( len_trim(cx) > 0 .and. cx(1:1) /= '-' .and. cx(1:1) /= '=' .and. ix > 0 ) then  !ix<0 will not generate this dimension
+     rcode=nf90_inq_dimid(ncid, trim(cx), ixid)
+     if ( rcode /= nf90_noerr ) then
+        call nccheck(nf90_def_dim(ncid, cx, ix, ixid), 'wrong in def_dim '//trim(cx), .true.)
+     else
+        if ( xtype < 0 .or. xtype > 99 ) then !get dimension type
+           rcode=nf90_inq_varid(ncid, trim(cx), varid)
+           if ( rcode == nf90_noerr ) rcode=nf90_inquire_variable(ncid, varid, xtype=xtype)
+        endif
+     endif
+  endif
+  if ( len_trim(cy) > 0 .and. cy(1:1) /= '-' .and. cy(1:1) /= '=' .and. jx > 0 ) then
+     rcode=nf90_inq_dimid(ncid, trim(cy), jxid)
+     if ( rcode /= nf90_noerr )  then
+        call nccheck(nf90_def_dim(ncid, cy, jx, jxid), 'wrong in def_dim '//trim(cy), .true.)
+     else
+        if ( xtype < 0 .or. xtype > 99 ) then !get dimension type
+           rcode=nf90_inq_varid(ncid, trim(cy), varid)
+           if ( rcode == nf90_noerr ) rcode=nf90_inquire_variable(ncid, varid, xtype=xtype)
+        endif
+     endif
+  endif
+  if ( len_trim(ck) > 0 .and. ck(1:1) /= '-' .and. ck(1:1) /= '=' .and. kx > 0 ) then
+     rcode=nf90_inq_dimid(ncid, trim(ck), kxid)
+     if ( rcode /= nf90_noerr ) then
+        call nccheck(nf90_def_dim(ncid, ck, kx, kxid), 'wrong in def_dim '//trim(ck), .true.)
+     else
+        if ( xtype < 0 .or. xtype > 99 ) then !get dimension type
+           rcode=nf90_inq_varid(ncid, trim(ck), varid)
+           if ( rcode == nf90_noerr ) rcode=nf90_inquire_variable(ncid, varid, xtype=xtype)
+        endif
+     endif
+  endif
+  if ( len_trim(ct) > 0 .and. ct(1:1) /= '-' .and. ct(1:1) /= '=' .and. tx > 0 ) then
+     rcode=nf90_inq_dimid(ncid, trim(ct), txid)
+     if ( rcode /= nf90_noerr ) then
+        call nccheck(nf90_def_dim(ncid, ct, tx, txid), 'wrong in def_dim '//trim(ct), .true.)
+     else
+        if ( xtype < 0 .or. xtype > 99 ) then !get dimension type
+           rcode=nf90_inq_varid(ncid, trim(ct), varid)
+           if ( rcode == nf90_noerr ) rcode=nf90_inquire_variable(ncid, varid, xtype=xtype)
+        endif
+     endif
+  endif
+  if ( xtype < 0 .or. xtype > 99 ) xtype=nf90_real
+
+  !----4.0 check var
+  rcode=nf90_inq_varid(ncid, varname, varid)
+  if ( rcode /= nf90_noerr ) then  ! need to define the var
+     if ( tx>0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/ixid,jxid,kxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/ixid,kxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/jxid,kxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/kxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/ixid,jxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/ixid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/jxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+        endif
+     else if ( tx<=0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/ixid,jxid,kxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/ixid,kxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/jxid,kxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/kxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/ixid,jxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/ixid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, (/jxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), xtype, varid), 'wrong in def_var '//trim(varname), .true.)
+        endif
+     endif
+     !---
+     !if ( ix>0 .and. jx>0 ) then
+     !   call nccheck(nf90_def_var_chunking(ncid, varid, 1, [jx, ix]), 'wrong in nf90_def_var_chunking', .false.)
+     !   call nccheck(nf90_def_var_deflate(ncid, varid, 1, 1, 4), 'wrong in nf90_def_var_deflate 4', .false.)
+     !endif
+     call nccheck(nf90_enddef(ncid), 'wrong in nf90_enddef', .false.)
+  endif
+
+  !----5.0 write data
+  !call nccheck(nf90_var_par_access(ncid, varid, nf90_collective), 'wrong in  nf90_var_par_access '//trim(varname), .false.)
+  if ( xtype == nf90_float .or. xtype == nf90_real .or. xtype == nf90_real4 ) then
+     if ( tx>0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ix,jx,kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ix,   kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/   jx,kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/      kx,tx/))), 'wrong in write '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ix,jx,   tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ix,      tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/   jx,   tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/         tx/))), 'wrong in write '//trim(varname), .true.)
+        endif
+     else if ( tx<=0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ix,jx,kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ix,   kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/   jx,kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/      kx   /))), 'wrong in write '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ix,jx      /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ix         /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/   jx      /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, data), 'wrong in write '//trim(varname), .true.)
+        endif
+     endif
+  else if ( xtype == nf90_double .or. xtype == nf90_real8 ) then
+     if ( tx>0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/ix,jx,kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/ix,   kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/   jx,kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/      kx,tx/))), 'wrong in write '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/ix,jx,   tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/ix,      tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/   jx,   tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/         tx/))), 'wrong in write '//trim(varname), .true.)
+        endif
+     else if ( tx<=0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/ix,jx,kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/ix,   kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/   jx,kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/      kx   /))), 'wrong in write '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/ix,jx      /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/ix         /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(dble(data), (/   jx      /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, dble(data)), 'wrong in write '//trim(varname), .true.)
+        endif
+     endif
+  else if ( xtype == nf90_int ) then
+     if ( tx>0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/ix,jx,kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/ix,   kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/   jx,kx,tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/      kx,tx/))), 'wrong in write '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/ix,jx,   tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/ix,      tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/   jx,   tx/))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/         tx/))), 'wrong in write '//trim(varname), .true.)
+        endif
+     else if ( tx<=0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/ix,jx,kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/ix,   kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/   jx,kx   /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/      kx   /))), 'wrong in write '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/ix,jx      /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/ix         /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(int(data), (/   jx      /))), 'wrong in write '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, int(data)), 'wrong in write '//trim(varname), .true.)
+        endif
+     endif
+  endif
+
+  !----6.0 put att
+  if ( len_trim(units) > 0 .and. units(1:1) /= '=') call nccheck(nf90_put_att(ncid, varid, "units", units), 'wrong in put units', .false.)
+  if ( len_trim(long_name) > 0 .and. long_name(1:1) /= '=') call nccheck(nf90_put_att(ncid, varid, "long_name",long_name), 'wrong in put long_name', .false.)
+  call nccheck(nf90_put_att(ncid, nf90_global, "File-type", "HAFS_datool file"), 'wrong in put_att', .false.)
+  call date_and_time(date(1), date(2), date(3), date_time)
+  call nccheck(nf90_put_att(ncid, nf90_global, "Created_date",date(1)), 'wrong input Created_date', .false.)
+
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .true.)
+
+  return
+  end subroutine write_nc_real
+
+!========================================================================================
+  subroutine write_nc_real_par(ncfile, varname, ix, jx, kx, tx, cx, cy, ck, ct,      &
+                               is, js, ks, ts, ni, nj, nk, nt, data, units, long_name)
+
+  use netcdf
+  use module_mpi
+
+  implicit none
+  character(len=*), intent(in)    :: ncfile
+  character(len=*), intent(in)    :: varname
+  integer, intent(in)             :: ix, jx, kx, tx   !dimensions for this varname
+  character(len=*), intent(in)    :: cx, cy, ck, ct   !dimension name
+  integer, intent(in)             :: is, js, ks, ts   !data block starts
+  integer, intent(in)             :: ni, nj, nk, nt   !data size
+  real, dimension(ni, nj, nk, nt), intent(inout)  :: data
+  character(len=*), intent(in)    :: units
+  character(len=*), intent(in)    :: long_name
+
+  logical                         :: file_exists
+  integer                         :: ncid, varid, rcode, ixid, jxid, kxid, txid
+  integer                         :: date_time(8)
+  character*10                    :: date(3)
+
+  real                            :: FillValue
+
+  FillValue=9.999e+20
+  !----1.0 process data _FillValue
+  where( data > 9.0e+8 .or. data < -300000. ) data=FillValue
+
+  !----2.0 check file
+  inquire(file=trim(ncfile), exist=file_exists)
+  if ( file_exists ) then
+     call nccheck(nf90_open(trim(ncfile), nf90_write, ncid), 'wrong in open '//trim(ncfile)//' for '//trim(varname), .true.)
+  else
+     write(*,*)' !!!! please call write_nc_dim to generate the nc file of '//trim(ncfile)
+     stop
+  endif
+
+  !----3.0 check dimensions
+  if ( len_trim(cx) > 0 .and. cx(1:1) /= '-' .and. cx(1:1) /= '=' .and. ix > 0 ) then  !ix<0 will not generate this dimension
+     rcode=nf90_inq_dimid(ncid, trim(cx), ixid)
+     if ( rcode /= nf90_noerr ) call nccheck(nf90_def_dim(ncid, cx, ix, ixid), 'wrong in def_dim '//trim(cx), .true.)
+  endif
+  if ( len_trim(cy) > 0 .and. cy(1:1) /= '-' .and. cy(1:1) /= '=' .and. jx > 0 ) then
+     rcode=nf90_inq_dimid(ncid, trim(cy), jxid)
+     if ( rcode /= nf90_noerr ) call nccheck(nf90_def_dim(ncid, cy, jx, jxid), 'wrong in def_dim '//trim(cy), .true.)
+  endif
+  if ( len_trim(ck) > 0 .and. ck(1:1) /= '-' .and. ck(1:1) /= '=' .and. kx > 0 ) then
+     rcode=nf90_inq_dimid(ncid, trim(ck), kxid)
+     if ( rcode /= nf90_noerr ) call nccheck(nf90_def_dim(ncid, ck, kx, kxid), 'wrong in def_dim '//trim(ck), .true.)
+  endif
+  if ( len_trim(ct) > 0 .and. ct(1:1) /= '-' .and. ct(1:1) /= '=' .and. tx > 0 ) then
+     rcode=nf90_inq_dimid(ncid, trim(ct), txid)
+     if ( rcode /= nf90_noerr ) call nccheck(nf90_def_dim(ncid, ct, tx, txid), 'wrong in def_dim '//trim(ct), .true.)
+  endif
+
+  !----4.0 check var
+  rcode=nf90_inq_varid(ncid, varname, varid)
+  if ( rcode /= nf90_noerr ) then  ! need to define the var
+     if ( tx>0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/ixid,jxid,kxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/ixid,kxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/jxid,kxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/kxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/ixid,jxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/ixid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/jxid,txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/txid/), varid), 'wrong in def_var '//trim(varname), .true.)
+        endif
+     else if ( tx<=0 ) then
+        if ( kx >0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/ixid,jxid,kxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/ixid,kxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/jxid,kxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/kxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+        else if ( kx <= 0 ) then
+           if ( ix>0 .and. jx>0  ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/ixid,jxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix>0 .and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/ixid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0 .and. jx>0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,(/jxid/), varid), 'wrong in def_var '//trim(varname), .true.)
+           if ( ix<=0.and. jx<=0 ) call nccheck(nf90_def_var(ncid, trim(varname), nf90_real,varid), 'wrong in def_var '//trim(varname), .true.)
+        endif
+     endif
+     !call nccheck(nf90_def_var_deflate(ncid, varid, 1, 1, 4), 'wrong in nf90_def_var_deflate 4', .false.)
+     call nccheck(nf90_enddef(ncid), 'wrong in nf90_enddef', .false.)
+  endif
+
+  !----5.0 write data
+  !call nccheck(nf90_var_par_access(ncid, varid, nf90_collective), 'wrong in  nf90_var_par_access '//trim(varname), .false.)
+  if ( tx>0 ) then
+     if ( kx >0 ) then
+        if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ni,nj,nk,nt/)), start=(/is,js,ks,ts/), count=(/ni,nj,nk,nt/)), 'wrong in write '//trim(varname), .true.)
+        if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ni,   nk,nt/)), start=(/is,   ks,ts/), count=(/ni,   nk,nt/)), 'wrong in write '//trim(varname), .true.)
+        if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/   nj,nk,nt/)), start=(/   js,ks,ts/), count=(/   nj,nk,nt/)), 'wrong in write '//trim(varname), .true.)
+        if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/      nk,nt/)), start=(/      ks,ts/), count=(/      nk,nt/)), 'wrong in write '//trim(varname), .true.)
+     else if ( kx <= 0 ) then
+        if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ni,nj,   nt/)), start=(/is,js,   ts/), count=(/ni,nj,   nt/)), 'wrong in write '//trim(varname), .true.)
+        if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ni,      nt/)), start=(/is,      ts/), count=(/ni,      nt/)), 'wrong in write '//trim(varname), .true.)
+        if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/   nj,   nt/)), start=(/   js,   ts/), count=(/   nj,   nt/)), 'wrong in write '//trim(varname), .true.)
+        if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/         nt/)), start=(/         ts/), count=(/         nt/)), 'wrong in write '//trim(varname), .true.)
+     endif
+  else if ( tx<=0 ) then
+     if ( kx >0 ) then
+        if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ni,nj,nk   /)), start=(/is,js,ks   /), count=(/ni,nj,nk   /)), 'wrong in write '//trim(varname), .true.)
+        if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ni,   nk   /)), start=(/is,   ks   /), count=(/ni,   nk   /)), 'wrong in write '//trim(varname), .true.)
+        if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/   nj,nk   /)), start=(/   js,ks   /), count=(/   nj,nk   /)), 'wrong in write '//trim(varname), .true.)
+        if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/      nk   /)), start=(/      ks   /), count=(/      nk   /)), 'wrong in write '//trim(varname), .true.)
+     else if ( kx <= 0 ) then
+        if ( ix>0 .and. jx>0  ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ni,nj      /)), start=(/is,js      /), count=(/ni,nj      /)), 'wrong in write '//trim(varname), .true.)
+        if ( ix>0 .and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/ni         /)), start=(/is         /), count=(/ni         /)), 'wrong in write '//trim(varname), .true.)
+        if ( ix<=0 .and. jx>0 ) call nccheck(nf90_put_var(ncid, varid, reshape(data, (/   nj      /)), start=(/   js      /), count=(/   nj      /)), 'wrong in write '//trim(varname), .true.)
+        if ( ix<=0.and. jx<=0 ) call nccheck(nf90_put_var(ncid, varid, data), 'wrong in write '//trim(varname), .true.)
+     endif
+  endif
+
+  !----6.0 put att
+  if ( len_trim(units) > 0 .and. units(1:1) /= '=') call nccheck(nf90_put_att(ncid, varid, "units", units), 'wrong in put units', .false.)
+  if ( len_trim(long_name) > 0 .and. long_name(1:1) /= '=') call nccheck(nf90_put_att(ncid, varid, "long_name",long_name), 'wrong in put long_name', .false.)
+  call nccheck(nf90_put_att(ncid, nf90_global, "File-type", "HAFS_datool file"), 'wrong in put_att', .false.)
+  call date_and_time(date(1), date(2), date(3), date_time)
+  call nccheck(nf90_put_att(ncid, nf90_global, "Created_date",date(1)), 'wrong input Created_date', .false.)
+
+  call nccheck(nf90_close(ncid), 'wrong in close '//trim(ncfile), .true.)
+
+  return
+  end subroutine write_nc_real_par
+
+!========================================================================================
+  subroutine nccheck(status, states, ifstop)
+
+  use netcdf
+  implicit none
+  integer, intent ( in) :: status
+  character(len=*), intent(in)    :: states
+  logical, intent ( in) :: ifstop
+
+  if (status /= nf90_noerr) then
+     write(*,'(a,a)')trim(nf90_strerror(status)), '   '//trim(states)
+     if ( ifstop ) stop
+  end if
+  end subroutine nccheck
+!=======================================================================================

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_rdas_u_ua.f90
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_rdas_u_ua.f90
@@ -1,0 +1,257 @@
+!========================================================================================
+  subroutine rdas_u_ua(u_ua, in_grid, in_file, out_file)
+
+!-----------------------------------------------------------------------------
+! HAFS DA tool - u_ua
+! authors and history:
+!      -- 202411, Yonghui Weng added this subroutine to update ua/va(u/v) with u/v(ua/va) values.
+!
+!-----------------------------------------------------------------------------
+! This subroutine updates ua/va(u/v) with u/v(ua/va) values.
+! u_ua:    string, "u_update_ua" or "ua_update_u"
+!          u_update_ua -- update ua/va with u/v values
+!          ua_update_u -- update u/v with ua/va values
+! in_grid: domain grid file, grid_spec.nc or grid_mspec.nest02_2024_06_30_18.tile2.nc
+! in_file: hafs restart file, usually is 20240630.180000.fv_core.res.tile1.nc or 20240630.180000.fv_core.res.nest02.tile2.nc
+!-----------------------------------------------------------------------------
+
+  use constants
+  use netcdf
+  use module_mpi
+  use var_type
+
+  implicit none
+  character (len=*), intent(in)         :: u_ua, in_grid, in_file, out_file
+
+  type(grid2d_info)                     :: grid
+  real, allocatable, dimension(:,:)     :: cangu, sangu, cangv, sangv
+  integer  :: ix, iy, iz, ndims, k, ncid, varid, i, j, rcode, xtype, nvars, nv, dimids(5), vdim(5)
+  integer  :: yaxis_1, yaxis_2, xaxis_1, xaxis_2, zaxis_1
+  integer  :: yaxis_1id, yaxis_2id, xaxis_1id, xaxis_2id, uid, vid, zaxis_1id, timeid
+  integer  :: yaxis_1iv, yaxis_2iv, xaxis_1iv, xaxis_2iv, zaxis_1iv, timeiv
+  integer, dimension(nf90_max_var_dims) :: dims
+  real, allocatable, dimension(:,:,:,:) :: dat41, dat42, ua, va, u, v
+  real, allocatable, dimension(:,:)     :: dat21, dat22
+  real, allocatable, dimension(:)       :: dat11
+  real*8, allocatable, dimension(:,:,:,:) :: ddat4
+
+  character (len=2500)                  :: nc_file
+  character(len=nf90_max_name)          :: varname, dimname(4)
+
+!------------------------------------------------------------------------------
+! 1 --- arg process and parameters
+
+!------------------------------------------------------------------------------
+! 2 --- input grid info: read from grid file grid_spec.nc
+  call rd_grid_spec_data(trim(in_grid), grid)
+  ix=grid%grid_xt
+  iy=grid%grid_yt
+  allocate( cangu(ix,iy+1),sangu(ix,iy+1),cangv(ix+1,iy),sangv(ix+1,iy) )
+  call cal_uv_coeff_fv3(ix, iy, grid%grid_lat, grid%grid_lon, cangu, sangu, cangv, sangv)
+
+!------------------------------------------------------------------------------
+! 3 --- updates
+  if ( trim(u_ua) == 'u_update_ua' ) then
+     !---get u dimensions
+     call get_var_dim(trim(in_file), 'u', ndims, dims)
+     if ( ndims /= 4 ) then
+        write(*,'(a)')' !!!!! warning: please check u dimensions in '//trim(in_file)
+        write(*,*)ndims, dims
+        stop
+     endif
+     iz=dims(3)
+     write(*,*),'dims: ',dims(1:4)
+     write(*,'(a,i,a,i,a,i,a,i,a,i)')'u dimensions: ',ix,'=',dims(1),':',iy+1,'=',dims(2),':',iz
+
+     !---get u/v
+     allocate(dat41(ix, iy+1, iz,1), dat42(ix+1, iy, iz,1))
+     call get_var_data(trim(in_file), 'u', ix, iy+1, iz, 1, dat41)
+     call get_var_data(trim(in_file), 'v', ix+1, iy, iz, 1, dat42)
+
+     !---convert u,v from fv3grid to earth
+     allocate(dat21(ix, iy+1), dat22(ix+1, iy))
+     allocate(ua(ix,iy,iz,1), va(ix,iy,iz,1))
+     do k = 1, iz
+        call fv3uv2earth(ix, iy, dat41(:,:,k,1), dat42(:,:,k,1), cangu, sangu, cangv, sangv, dat21, dat22)
+        !---destage: C-/D- grid to A-grid
+        ua(:,:,k,1) = (dat21(:,1:iy)+dat21(:,2:iy+1))/2.0
+        va(:,:,k,1) = (dat22(1:ix,:)+dat22(2:ix+1,:))/2.0
+     enddo
+     deallocate(dat41, dat42, dat21, dat22, cangu, sangu, cangv, sangv)
+
+     !---update in_file
+     call update_rdas_restart(trim(in_file), 'ua', ix, iy, iz, 1, ua)
+     call update_rdas_restart(trim(in_file), 'va', ix, iy, iz, 1, va)
+     deallocate(ua, va)
+
+  else if ( trim(u_ua) == 'ua_update_u' ) then
+     !---get ua dimensions
+     call get_var_dim(trim(in_file), 'ua', ndims, dims)
+     if ( ndims /= 4 ) then
+        write(*,'(a)')' !!!!! warning: please check ua dimensions in '//trim(in_file)
+        write(*,*)ndims, dims
+        stop
+     endif
+     iz=dims(3)
+     write(*,'(a,i,a,i,a,i,a,i,a,i)')'u dimensions: ',ix,'=',dims(1),':',iy,'=',dims(2),':',iz
+
+     !---get ua/va
+     allocate(dat41(ix, iy, iz, 1), dat42(ix, iy, iz, 1))
+     call get_var_data(trim(in_file), 'ua', ix, iy, iz, 1, dat41)
+     call get_var_data(trim(in_file), 'va', ix, iy, iz, 1, dat42)
+
+     !---stage ua/va grid
+     allocate(ua(ix, iy+1, iz, 1), va(ix+1, iy, iz, 1))
+     ua(:,1   ,:,1)=dat41(:,1,:,1)
+     ua(:,2:iy,:,1)=0.5*(dat41(:,1:iy-1,:,1)+dat41(:,2:iy,:,1))
+     ua(:,iy+1,:,1)=dat41(:,iy,:,1)
+     va(1   ,:,:,1)=dat42(1,:,:,1)
+     va(2:ix,:,:,1)=0.5*(dat42(1:ix-1,:,:,1)+dat42(2:ix,:,:,1))
+     va(ix+1,:,:,1)=dat42(ix,:,:,1)
+     deallocate(dat41, dat42)
+
+     !---convert earth wind to fv3grid wind
+     allocate(u(ix, iy+1, iz,1), v(ix+1, iy, iz,1))
+     do k = 1, iz
+        call earthuv2fv3(ix, iy, ua(:,:,k,1), va(:,:,k,1), cangu, sangu, cangv, sangv, u(:,:,k,1), v(:,:,k,1))
+     enddo
+     deallocate(ua, va, cangu, sangu, cangv, sangv)
+
+     call nccheck(nf90_open(trim(in_file), nf90_nowrite, ncid), 'wrong in open '//trim(in_file), .true.)
+     !---get ua xtype from input_file
+     xtype=nf90_real
+     call nccheck(nf90_inq_varid(ncid, "ua", varid), 'wrong in nf90_inq_varid ua id', .false.)
+     call nccheck(nf90_inquire_variable(ncid, varid, xtype=xtype), 'wrong in nf90_inquire_variable xtype', .false.)
+
+     !---update or generate a new file
+     rcode=nf90_inq_varid(ncid, 'u', varid)
+     call nccheck(nf90_close(ncid), 'wrong in close '//trim(in_file), .false.)
+     if ( rcode == nf90_noerr ) then
+        !---if u/v exist, update u/v
+        call update_rdas_restart(trim(in_file), 'u', ix, iy+1, iz, 1, u)
+        call update_rdas_restart(trim(in_file), 'v', ix+1, iy, iz, 1, v)
+        deallocate(u, v)
+
+     else  !---generate a new file
+        !---create file
+        if ( trim(out_file) == 'w' .or. len_trim(out_file) < 1 ) then
+           i=index(in_file,'.nc')-1
+           if ( i<2 ) i=len_trim(in_file)
+           nc_file=in_file(1:i)//'.ua2u.nc'
+        else
+           nc_file=trim(out_file)
+        endif
+        !--- delete nc_file if it exist
+        open(unit=1234, iostat=rcode, file=trim(nc_file), status='old')
+        if (rcode == 0) close(1234, status='delete')
+        !call nccheck(nf90_create(trim(nc_file), nf90_hdf5, ncid), 'wrong in creat '//trim(nc_file), .true.)
+        call nccheck(nf90_create(trim(nc_file), nf90_netcdf4, ncid), 'wrong in creat '//trim(nc_file), .true.)
+
+        !---define dimension
+        call nccheck(nf90_def_dim(ncid, 'xaxis_1', ix  , xaxis_1id), 'wrong in def_dim xaxis_1', .true.)
+        call nccheck(nf90_def_dim(ncid, 'xaxis_2', ix+1, xaxis_2id), 'wrong in def_dim xaxis_2', .true.)
+        call nccheck(nf90_def_dim(ncid, 'yaxis_1', iy+1, yaxis_1id), 'wrong in def_dim yaxis_1', .true.)
+        call nccheck(nf90_def_dim(ncid, 'yaxis_2', iy  , yaxis_2id), 'wrong in def_dim yaxis_2', .true.)
+        call nccheck(nf90_def_dim(ncid, 'zaxis_1', iz  , zaxis_1id), 'wrong in def_dim zaxis_1', .true.)
+        call nccheck(nf90_def_dim(ncid, 'Time',    1   , timeid   ), 'wrong in def_dim Time   ', .true.)
+
+
+        !---define variables dimensions and u/v
+        call nccheck(nf90_def_var(ncid, 'xaxis_1',  xtype, (/xaxis_1id/), xaxis_1iv), 'wrong in def_var xaxis_1', .true.)
+        !rcode=nf90_def_var(ncid, 'xaxis_1',  xtype, (/xaxis_1id/), xaxis_1iv)
+        call nccheck(nf90_def_var(ncid, 'xaxis_2',  xtype, (/xaxis_2id/), xaxis_2iv), 'wrong in def_var xaxis_2', .true.)
+        call nccheck(nf90_def_var(ncid, 'yaxis_1',  xtype, (/yaxis_1id/), yaxis_1iv), 'wrong in def_var yaxis_1', .true.)
+        call nccheck(nf90_def_var(ncid, 'yaxis_2',  xtype, (/yaxis_2id/), yaxis_2iv), 'wrong in def_var yaxis_2', .true.)
+        call nccheck(nf90_def_var(ncid, 'zaxis_1',  xtype, (/zaxis_1id/), zaxis_1iv), 'wrong in def_var zaxis_1', .true.)
+        call nccheck(nf90_def_var(ncid, 'Time',     xtype, (/timeid/),    timeiv),    'wrong in def_var Time'   , .true.)
+        call nccheck(nf90_def_var(ncid, 'u',        xtype, (/xaxis_1id,yaxis_1id,zaxis_1id,timeid/), uid), 'wrong in def_var u', .true.)
+        call nccheck(nf90_def_var(ncid, 'v',        xtype, (/xaxis_2id,yaxis_2id,zaxis_1id,timeid/), vid), 'wrong in def_var v', .true.)
+        call nccheck(nf90_enddef(ncid), 'wrong in nf90_enddef', .false.)
+
+        !---write variables dimensions and u/v
+        allocate(dat11(ix))
+        do i = 1, ix; dat11(i)=i*1.0; enddo
+        call nccheck(nf90_put_var(ncid, xaxis_1iv, dat11), 'wrong in write xaxis_1', .true.)
+        deallocate(dat11)
+
+        allocate(dat11(ix+1))
+        do i = 1, ix+1; dat11(i)=i*1.0; enddo
+        call nccheck(nf90_put_var(ncid, xaxis_2iv, dat11), 'wrong in write xaxis_2', .true.)
+        deallocate(dat11)
+
+        allocate(dat11(iy+1))
+        do i = 1, iy+1; dat11(i)=i*1.0; enddo
+        call nccheck(nf90_put_var(ncid, yaxis_1iv, dat11), 'wrong in write yaxis_1', .true.)
+        deallocate(dat11)
+
+        allocate(dat11(iy))
+        do i = 1, iy; dat11(i)=i*1.0; enddo
+        call nccheck(nf90_put_var(ncid, yaxis_2iv, dat11), 'wrong in write yaxis_2', .true.)
+        deallocate(dat11)
+
+        allocate(dat11(iz))
+        do i = 1, iz; dat11(i)=i*1.0; enddo
+        call nccheck(nf90_put_var(ncid, zaxis_1iv, dat11), 'wrong in write zaxis_1', .true.)
+        deallocate(dat11)
+
+        call nccheck(nf90_put_var(ncid, timeiv, 1.0), 'wrong in write Time', .true.)
+
+        call nccheck(nf90_put_var(ncid, uid, u), 'wrong in write u', .true.)
+        call nccheck(nf90_put_var(ncid, vid, v), 'wrong in write v', .true.)
+        deallocate(u,v)
+
+        !---copy other variables
+        call nccheck(nf90_open(trim(in_file), nf90_nowrite, ncid), 'wrong in open '//trim(in_file), .true.)
+        call nccheck(nf90_inquire(ncid, ndims, nvars), 'wrong in inquire ncid', .true.)
+        do_input_var_loop: do nv=1, nvars
+           dimids=1; vdim=1
+           call nccheck(nf90_inquire_variable(ncid,nv,varname,xtype,ndims,dimids), 'wrong in inquire_variable '//trim(varname), .false.)
+           do i = 1, ndims
+              call nccheck(nf90_inquire_dimension(ncid,dimids(i), len=vdim(i)), 'wrong in inquire '//trim(varname)//' dim', .false.)
+           enddo
+
+           !---skip xaxis_1(xaxis_1), yaxis_1(yaxis_1), zaxis_1(zaxis_1)
+           if ( ndims < 3 ) cycle do_input_var_loop
+
+           call nccheck(nf90_inq_varid(ncid, trim(varname), varid), 'wrong in inquire '//trim(varname)//' varid', .false.)
+           allocate(dat41(vdim(1),vdim(2),vdim(3),vdim(4)))
+           if ( xtype == nf90_float .or. xtype == nf90_real .or. xtype == nf90_real4 ) then
+              call nccheck(nf90_get_var(ncid, varid, dat41), 'wrong in get '//trim(varname), .true.)
+           else if ( xtype == nf90_double .or. xtype == nf90_real8 ) then
+              allocate(ddat4(vdim(1),vdim(2),vdim(3),vdim(4)))
+              call nccheck(nf90_get_var(ncid, varid, ddat4), 'wrong in get '//trim(varname), .true.)
+              dat41=real(ddat4)
+              deallocate(ddat4)
+           else
+              write(*,*)' !!!! please add ',xtype,' xtype data here '
+              stop
+           endif
+
+           !---write out
+           dimname(1)='xaxis_1'
+           dimname(2)='yaxis_2'
+           if ( vdim(1) == ix+1 ) dimname(1)='xaxis_2'
+           if ( vdim(2) == iy+1 ) dimname(2)='yaxis_1'
+           if ( ndims == 3 ) then   !
+              dimname(3)='Time'
+              dimname(4)='-'
+              write(*,'(a)')' --- writing '//trim(varname)//'('//trim(dimname(1))//','//trim(dimname(2))//','//trim(dimname(3))//')'
+              call write_nc_real(trim(nc_file), trim(varname), vdim(1),vdim(2),vdim(3), -1, trim(dimname(1)), trim(dimname(2)), trim(dimname(3)), trim(dimname(4)), dat41, '-', '-')
+           else if ( ndims == 4 ) then   !
+              dimname(3)='zaxis_1'
+              dimname(4)='Time'
+              write(*,'(a)')' --- writing '//trim(varname)//'('//trim(dimname(1))//','//trim(dimname(2))//','//trim(dimname(3))//','//trim(dimname(4))//')'
+              call write_nc_real(trim(nc_file), trim(varname), vdim(1),vdim(2),vdim(3),vdim(4),trim(dimname(1)), trim(dimname(2)), trim(dimname(3)), trim(dimname(4)), dat41, '-', '-')
+           endif
+           deallocate(dat41)
+
+        enddo do_input_var_loop
+
+     endif
+
+  endif
+
+  return
+  end subroutine rdas_u_ua
+
+!========================================================================================

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_tools.f90
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_tools.f90
@@ -1,0 +1,1098 @@
+!-----------------------------------------------------------------------+
+! This package holds the utility of functions and subroutines for HAFS_DAtool
+! authors and history:
+!      -- 202102, created by Yonghui Weng
+!-----------------------------------------------------------------------+
+  function date2second1970 (yyyy, mm, dd, hh, minute, second) !result(second1970)
+  implicit none
+
+  integer,intent(in) :: yyyy, mm, dd, hh, minute, second
+  real*8             :: date2second1970
+
+  integer :: julian, julian_1970_01_01
+  julian_1970_01_01 = 2440588
+
+  julian = dd -32075 + 1461*(yyyy + 4800 + (mm - 14)/12)/4 + &
+               367*(mm - 2 - ((mm - 14)/12)*12)/12 - &
+               3*((yyyy + 4900 + (mm - 14)/12)/100)/4
+  !write(*,*)'julian =',julian
+
+  date2second1970 = (julian-julian_1970_01_01)*3600*24 + hh*3600 + minute*60 + second
+  return
+  end function date2second1970
+
+!-----------------------------------------------------------------------+
+  function date2second1970_str(cdate)
+  implicit none
+
+  character (len=*),intent(in) :: cdate
+  real*8                       :: date2second1970_str
+
+  integer            :: julian, julian_1970_01_01
+  integer            :: yyyy, mm, dd, hh, minute, second
+  julian_1970_01_01 = 2440588
+
+  read(cdate,'(i4,5i2)')yyyy, mm, dd, hh, minute, second
+
+  julian = dd -32075 + 1461*(yyyy + 4800 + (mm - 14)/12)/4 + &
+               367*(mm - 2 - ((mm - 14)/12)*12)/12 - &
+               3*((yyyy + 4900 + (mm - 14)/12)/100)/4
+  !write(*,*)'julian =',julian
+
+  date2second1970_str = (julian-julian_1970_01_01)*3600*24 + hh*3600 + minute*60 + second
+  return
+  end function date2second1970_str
+
+!-----------------------------------------------------------------------+
+  subroutine second19702date(second1970, hdate, formatstr)
+
+  !---from http://fortranwiki.org/fortran/show/m_time
+
+  implicit none
+  real*8,intent(in) :: second1970
+  character(len=*),intent(in)  :: formatstr
+  character(len=*),intent(out) :: hdate  !YYYYMMDDHHmmss
+
+  integer :: year, month, day, hour, minute, second
+
+  real*8   :: julian
+  real    :: secday
+  integer :: ijul, julian_1970_01_01, jalpha,ja,jb,jc,jd,je
+
+  secday = 24.0*3600.
+  julian_1970_01_01 = 2440588
+
+  julian = dble(second1970/secday)+dble(julian_1970_01_01)
+  ijul = int(julian)
+
+  second = int((julian-ijul)*secday+0.5)
+  minute=int(second/60.0)                      ! Integral minutes from beginning of day
+  second=second-minute*60                      ! Seconds from beginning of minute
+  hour=minute/60                               ! Integral hours from beginning of day
+  minute=minute-hour*60                        ! Integral minutes from beginning of hour
+
+  !---------------------------------------------
+  jalpha=idint((dble(ijul-1867216)-0.25d0)/36524.25d0) ! Correction for Gregorian Calendar
+  ja=ijul+1+jalpha-idint(0.25d0*dble(jalpha))
+  !---------------------------------------------
+
+  jb=ja+1524
+  jc=idint(6680.d0+(dble(jb-2439870)-122.1d0)/365.25d0)
+  jd=365*jc+idint(0.25d0*dble(jc))
+  je=idint(dble(jb-jd)/30.6001d0)
+  day=jb-jd-idint(30.6001d0*dble(je))
+  month=je-1
+
+  if(month.gt.12)then
+     month=month-12
+  endif
+
+  year=jc-4715
+  if(month.gt.2)then
+     year=year-1
+  endif
+
+  if(year.le.0)then
+     year=year-1
+  endif
+
+  if ( trim(formatstr) == "YYYYMMDDHHmmss" ) then
+     write(hdate,'(i4.4,5i2.2)')year, month, day, hour, minute, second
+  else if ( trim(formatstr) == "YYYY-MM-DD hh:mm:ss" ) then
+     write(hdate,'(i4.4,5(a1,i2.2))')year, '-', month, '-', day, ' ', hour, ':', minute, ':', second
+  else if ( trim(formatstr) == "mm/dd/yyyy hh:mm") then
+     write(hdate,'(i,a1,i,a1,i,a1,i,a3)')month,'/',day,'/',year,' ',hour,':',minute
+  endif
+
+  return
+  end subroutine second19702date
+
+!-----------------------------------------------------------------------+
+  real function earth_dist(lon1, lat1, lon2, lat2)
+!   earth_dist - function that calculates the earth distance between
+!                two points.
+!    lon1 - longitude of point 1
+!    lat1 - latitude of point 1
+!    lon2 - longitude of point 2
+!    lat2 - latitude of point 2
+
+  real,intent(in) :: lon1, lat1, lon2, lat2
+  real :: pro
+  real, parameter :: R_earth = 6374.*1e3, pid=3.14159/180.
+
+  pro = sin(lat1*pid) * sin(lat2*pid) +           &
+        cos(lat1*pid) * cos(lat2*pid) *            &
+        cos((lon2-lon1)*pid)
+
+  if ( abs(pro) .gt. 1.001 ) then
+     print*,'In earth_dist, pro > 1, returning',pro
+     earth_dist = -9999999.
+  elseif ( abs(pro) .gt. 1 ) then
+     earth_dist = 0.
+  else
+     earth_dist = R_earth * acos(pro)
+  endif
+
+  return
+  end function
+
+
+!-----------------------------------------------------------------------+
+  integer function binarysearch(length, array, value, delta)
+  ! Given an array and a value, returns the index of the element that
+  ! is closest to, but less than, the given value.
+  ! Uses a binary search algorithm.
+  ! "delta" is the tolerance used to determine if two values are equal
+  ! if ( abs(x1 - x2) <= delta) then
+  !    assume x1 = x2
+  ! endif
+
+  implicit none
+  integer, intent(in) :: length
+  real, dimension(length), intent(in) :: array
+  !f2py depend(length) array
+  real, intent(in) :: value
+  real, intent(in), optional :: delta
+
+  integer :: left, middle, right
+  real :: d
+
+  if (present(delta) .eqv. .true.) then
+      d = delta
+  else
+      d = 1e-9
+  endif
+
+  if ( array(1) < array(length) ) then
+     left = 1
+     right = length
+     do
+         if (left > right) then
+             exit
+         endif
+         middle = nint((left+right) / 2.0)
+         if ( abs(array(middle) - value) <= d) then
+             binarySearch = middle
+             return
+         else if (array(middle) > value) then
+             right = middle - 1
+         else
+             left = middle + 1
+         end if
+     end do
+     binarysearch = right
+  else
+     right = 1
+     left = length
+     do
+       if (right > left) then
+           exit
+       endif
+       middle = nint((left+right) / 2.0)
+       if ( abs(array(middle) - value) <= d) then
+           binarySearch = middle
+           return
+       else if (array(middle) > value) then
+            right = middle + 1
+         else
+             left = middle -1
+         end if
+     end do
+     binarysearch = left
+  endif
+
+  end function binarysearch
+
+!-----------------------------------------------------------------------+
+  integer function beaufortscale(windspeed)
+
+  real, intent(in) :: windspeed   !m/s
+  ! ref to: https://www.wikiwand.com/zh-cn/%E8%92%B2%E7%A6%8F%E6%B0%8F%E9%A2%A8%E7%B4%9A
+  !         https://www.skybrary.aero/index.php/Beaufort_wind_force_scale
+
+  beaufortscale = -99
+  if ( windspeed <= 0.2 ) then
+     beaufortscale = 0
+  else if ( windspeed > 0.3 .and. windspeed <= 1.5 ) then
+     beaufortscale = 1
+  else if ( windspeed > 1.6 .and. windspeed <= 3.3 ) then
+     beaufortscale = 2
+  else if ( windspeed > 3.4 .and. windspeed <= 5.4 ) then
+     beaufortscale = 3
+  else if ( windspeed > 5.4 .and. windspeed <= 7.9 ) then
+     beaufortscale = 4
+  else if ( windspeed > 7.9 .and. windspeed <= 10.7 ) then
+     beaufortscale = 5
+  else if ( windspeed > 10.7 .and. windspeed <= 13.8 ) then
+     beaufortscale = 6
+  else if ( windspeed > 13.8 .and. windspeed <= 17.1 ) then
+     beaufortscale = 7
+  else if ( windspeed > 17.1 .and. windspeed <= 20.7 ) then
+     beaufortscale = 8
+  else if ( windspeed > 20.7 .and. windspeed <= 24.4 ) then
+     beaufortscale = 9
+  else if ( windspeed > 24.4 .and. windspeed <= 28.4 ) then
+     beaufortscale = 10
+  else if ( windspeed > 28.4 .and. windspeed <= 32.6 ) then
+     beaufortscale = 11
+  else if ( windspeed > 32.6 .and. windspeed <= 36.9 ) then
+     beaufortscale = 12
+  else if ( windspeed > 36.9 .and. windspeed <= 41.4 ) then
+     beaufortscale = 13
+  else if ( windspeed > 41.4 .and. windspeed <= 46.1 ) then
+     beaufortscale = 14
+  else if ( windspeed > 46.1 .and. windspeed <= 50.9 ) then
+     beaufortscale = 15
+  else if ( windspeed > 50.9 .and. windspeed <= 56.0 ) then
+     beaufortscale = 16
+  else if ( windspeed > 56.0 .and. windspeed <= 61.2 ) then
+     beaufortscale = 17
+  else if ( windspeed > 61.2 ) then
+     beaufortscale = 18
+  endif
+
+  return
+  end function
+
+!-----------------------------------------------------------------------+
+  subroutine interp_fill_nan_1d(nlen, dat, radius, value_min, value_max)
+
+  integer, intent(in)                  :: nlen, radius
+  real, dimension(nlen), intent(inout) :: dat
+  real, intent(in)                     :: value_min, value_max
+
+  integer :: i, j, i1, i2, nbefore, nafter
+
+  do i = 1, nlen
+     if ( dat(i) < value_min .or. dat(i) > value_max ) then
+        !----search avialable points before/after i
+        i1=0
+        do_search_before: do j = 1, radius
+           if ( i-j < 1 ) exit do_search_before
+           if ( dat(i-j) >= value_min .and. dat(i-j) <= value_max ) then
+              i1 = i - j
+              exit do_search_before
+           endif
+        enddo do_search_before
+        i2=0
+        do_search_after: do j = 1, radius
+           if ( i+j > nlen ) exit do_search_after
+           if ( dat(i+j) >= value_min .and. dat(i+j) <= value_max ) then
+              i2 = i + j
+              exit do_search_after
+           endif
+        enddo do_search_after
+
+        !---interp
+        if ( i1 >= 1 .and. i1 < nlen .and. i2 > 1 .and. i2 <= nlen ) then
+           dat(i) = ((i2-i)*dat(i1) + (i-i1)*dat(i2))/(i2-i1)
+        endif
+     endif
+  enddo
+
+  return
+  end subroutine interp_fill_nan_1d
+
+!========================================================================================
+  subroutine cal_src_dst_grid_weight(grid_src, grid_dst)
+
+  use module_mpi
+  use var_type
+
+  implicit none
+
+  type(grid2d_info), intent(in) :: grid_src, grid_dst
+  integer, allocatable, dimension(:,:) :: x_oini, y_oini
+  real, allocatable, dimension(:,:)     :: lat_src, lon_src, lat_dst, lon_dst
+  integer   :: i, j
+
+!------------------------------------------------------------------------------
+! 1 --- T-grid position in nearest source grid
+  i=int(grid_dst%grid_xt/2);j=int(grid_dst%grid_yt/2)
+  if ( debug_level > 10 ) then
+     write(*,'(a,i0,a,i0)')'---- processing t-cell: ', grid_dst%grid_xt,':',grid_dst%grid_yt
+     write(*,'(a)')' ---    i     j        lon        lat'
+     write(*,'(a3,2i6, 2f11.2,2i11, 2f11.2)')' t:', i, j, grid_dst%grid_lont(i,j), grid_dst%grid_latt(i,j)
+  endif
+
+  allocate(x_oini(grid_dst%grid_xt, grid_dst%grid_yt), y_oini(grid_dst%grid_xt, grid_dst%grid_yt))
+  call search_nearst_grid(grid_src%grid_xt, grid_src%grid_yt, grid_src%grid_latt, grid_src%grid_lont, &
+                          grid_dst%grid_xt, grid_dst%grid_yt, grid_dst%grid_latt, grid_dst%grid_lont, &
+                          x_oini, y_oini)
+  if ( debug_level > 10 ) then
+     write(*,'(a)')' ---    i     j        lon        lat          x          y m(i,j)_lon m(i,j)_lat '
+     write(*,'(a3,2i6)')' t:', i, j
+     write(*,'(a3,2i6, 2f11.2,2i11, 2f11.2)')' t:', i, j, grid_dst%grid_lont(i,j), grid_dst%grid_latt(i,j), x_oini(i,j), y_oini(i,j), &
+        grid_src%grid_lont(x_oini(i,j),y_oini(i,j)), grid_src%grid_latt(x_oini(i,j),y_oini(i,j))
+  endif
+  !do j1=1,grid_dst%grid_yt; do i1=1,grid_dst%grid_xt
+  !   write(98,'(4i6)')i1,j1,x_oini(i1,j1),y_oini(i1,j1)
+  !enddo;enddo
+
+  !---find (x_oini(i,j), y_oini(i,j)) and its neighboring 8 points, and calculate distance and then weights
+  allocate(gwt%gwt_t(grid_dst%grid_xt, grid_dst%grid_yt))  !grid_weight_info
+  call cal_grid_weight(grid_src%grid_xt, grid_src%grid_yt, grid_src%grid_latt, grid_src%grid_lont, &
+                       grid_dst%grid_xt, grid_dst%grid_yt, grid_dst%grid_latt, grid_dst%grid_lont, &
+                       x_oini, y_oini, gwt%max_points, gwt%gwt_t)
+  deallocate(x_oini, y_oini)
+  write(*,'(a,30i6)')'    gwt%gwt_t @ ', i, j, gwt%gwt_t(i,j)%src_points, gwt%gwt_t(i,j)%src_x(1:gwt%gwt_t(i,j)%src_points), &
+                     gwt%gwt_t(i,j)%src_y(1:gwt%gwt_t(i,j)%src_points)
+
+  !---so for T-grid variables:
+  ! merged-grid = (1.0-dst_weight)*sum(gwt%gwt_t(i,j)%src_weight(:)*SRCVAR(gwt%gwt_t(i,j)%src_x(:), gwt%gwt_t(i,j)%src_y(:))) +
+  !               dst_weight*sum(gwt%gwt_t(i,j)%dst_weight(:)*DSTVAR(gwt%gwt_t(i,j)%dst_x(:),gwt%gwt_t(i,j)%dst_y(:)))
+
+  !---4.2, U-grid (grid_dst%grid_xt, grid_dst%grid_y)
+  write(*,'(a)')'---- processing u-cell ----'
+  allocate(x_oini(grid_dst%grid_xt, grid_dst%grid_y), y_oini(grid_dst%grid_xt, grid_dst%grid_y))
+  allocate(lon_src(grid_src%grid_xt, grid_src%grid_y), lat_src(grid_src%grid_xt, grid_src%grid_y))
+  if ( grid_src%grid_x-grid_src%grid_xt >= 1 ) then
+     lon_src(1:grid_src%grid_xt,1:grid_src%grid_y) = (grid_src%grid_lon(1:grid_src%grid_xt,1:grid_src%grid_y) + &
+                                                      grid_src%grid_lon(2:grid_src%grid_x ,1:grid_src%grid_y))/2.0
+     lat_src(1:grid_src%grid_xt,1:grid_src%grid_y) = (grid_src%grid_lat(1:grid_src%grid_xt,1:grid_src%grid_y) + &
+                                                      grid_src%grid_lat(2:grid_src%grid_x ,1:grid_src%grid_y))/2.0
+  else
+     lon_src(1:grid_src%grid_xt,1:grid_src%grid_y) = grid_src%grid_lon(1:grid_src%grid_xt,1:grid_src%grid_y)
+     lat_src(1:grid_src%grid_xt,1:grid_src%grid_y) = grid_src%grid_lat(1:grid_src%grid_xt,1:grid_src%grid_y)
+  endif
+  !write(*,'(a)')'last row src lat before: ------------------'
+  !write(*,'(15f8.2)')grid_src%grid_lat(488:grid_src%grid_xt,grid_src%grid_y-1)
+
+  allocate(lon_dst(grid_dst%grid_xt, grid_dst%grid_y), lat_dst(grid_dst%grid_xt, grid_dst%grid_y))
+  if ( grid_dst%grid_x-grid_dst%grid_xt >= 1 ) then
+     lon_dst(1:grid_dst%grid_xt,1:grid_dst%grid_y) = (grid_dst%grid_lon(1:grid_dst%grid_xt,1:grid_dst%grid_y) + &
+                                                      grid_dst%grid_lon(2:grid_dst%grid_x ,1:grid_dst%grid_y))/2.0
+     lat_dst(1:grid_dst%grid_xt,1:grid_dst%grid_y) = (grid_dst%grid_lat(1:grid_dst%grid_xt,1:grid_dst%grid_y) + &
+                                                      grid_dst%grid_lat(2:grid_dst%grid_x ,1:grid_dst%grid_y))/2.0
+  else
+     lon_dst(1:grid_dst%grid_xt,1:grid_dst%grid_y) = grid_dst%grid_lon(1:grid_dst%grid_xt,1:grid_dst%grid_y)
+     lat_dst(1:grid_dst%grid_xt,1:grid_dst%grid_y) = grid_dst%grid_lat(1:grid_dst%grid_xt,1:grid_dst%grid_y)
+  endif
+
+  !if (debug) then
+  write(*,'(a,2i8,4f10.3)')'src grid_lat: ', grid_src%grid_x , grid_src%grid_y, grid_src%grid_lat(1,1), &
+                           grid_src%grid_lat(grid_src%grid_x,1), grid_src%grid_lat(grid_src%grid_x,grid_src%grid_y), &
+                           grid_src%grid_lat(1,grid_src%grid_y)
+  write(*,'(a,2i8,4f10.3)')'src    u lat: ', grid_src%grid_xt, grid_src%grid_y, lat_src(1,1),lat_src(grid_src%grid_xt,1), &
+                           lat_src(grid_src%grid_xt,grid_src%grid_y), lat_src(1,grid_src%grid_y)
+  write(*,'(a,f7.2,a,f7.2,a,f7.2,a,f7.2)')'src  grid range:',minval(grid_src%grid_lon),':',maxval(grid_src%grid_lon), &
+                           '; ',minval(grid_src%grid_lat),':',maxval(grid_src%grid_lat)
+  write(*,'(a,f7.2,a,f7.2,a,f7.2,a,f7.2)')'src u-grid range:',minval(lon_src),':',maxval(lon_src),'; ',minval(lat_src),':',maxval(lat_src)
+  write(*,'(a,2i8,4f10.3)')'dst grid_lat: ', grid_dst%grid_x , grid_dst%grid_y, grid_dst%grid_lat(1,1), &
+                           grid_dst%grid_lat(grid_dst%grid_x,1), grid_dst%grid_lat(grid_dst%grid_x,grid_dst%grid_y), &
+                           grid_dst%grid_lat(1,grid_dst%grid_y)
+  write(*,'(a,2i8,4f10.3)')'dst    u lat: ', grid_dst%grid_xt, grid_dst%grid_y, lat_dst(1,1),lat_dst(grid_dst%grid_xt,1),&
+                           lat_dst(grid_dst%grid_xt,grid_dst%grid_y), lat_dst(1,grid_dst%grid_y)
+  write(*,'(a,f7.2,a,f7.2,a,f7.2,a,f7.2)')'dst  grid range:',minval(grid_dst%grid_lon),':',maxval(grid_dst%grid_lon), &
+                           '; ',minval(grid_dst%grid_lat),':',maxval(grid_dst%grid_lat)
+  write(*,'(a,f7.2,a,f7.2,a,f7.2,a,f7.2)')'dst u-grid range:',minval(lon_dst),':',maxval(lon_dst),'; ',minval(lat_dst),':',maxval(lat_dst)
+  !endif !if (debug) then
+
+  call search_nearst_grid(grid_src%grid_xt, grid_src%grid_y, lat_src, lon_src, &
+                          grid_dst%grid_xt, grid_dst%grid_y, lat_dst, lon_dst, x_oini, y_oini)
+
+  write(*,'(a3, 2i6, 2f11.2,2i11)')' u:', i, j, lon_dst(i,j), lat_dst(i,j), x_oini(i,j), y_oini(i,j)
+
+  allocate(gwt%gwt_u(grid_dst%grid_xt, grid_dst%grid_y))  !grid_weight_info
+  call cal_grid_weight(grid_src%grid_xt, grid_src%grid_y, lat_src, lon_src, &
+                       grid_dst%grid_xt, grid_dst%grid_y, lat_dst, lon_dst, x_oini, y_oini, gwt%max_points, gwt%gwt_u)
+  deallocate(x_oini, y_oini, lon_src, lat_src, lon_dst, lat_dst)
+
+  !---4.3, V-grid
+  write(*,'(a)')'---- processing v-cell ----'
+  allocate(x_oini(grid_dst%grid_x, grid_dst%grid_yt), y_oini(grid_dst%grid_x, grid_dst%grid_yt))
+  allocate(lon_src(grid_src%grid_x, grid_src%grid_yt), lat_src(grid_src%grid_x , grid_src%grid_yt))
+  if ( grid_src%grid_y-grid_src%grid_yt >= 1 ) then
+     lon_src(1:grid_src%grid_x,1:grid_src%grid_yt) = (grid_src%grid_lon(1:grid_src%grid_x,1:grid_src%grid_yt) + &
+                                                      grid_src%grid_lon(1:grid_src%grid_x,2:grid_src%grid_y))/2.0
+     lat_src(1:grid_src%grid_x,1:grid_src%grid_yt) = (grid_src%grid_lat(1:grid_src%grid_x,1:grid_src%grid_yt) + &
+                                                      grid_src%grid_lat(1:grid_src%grid_x,2:grid_src%grid_y))/2.0
+  else
+     lon_src(1:grid_src%grid_x,1:grid_src%grid_yt) = grid_src%grid_lon(1:grid_src%grid_x,1:grid_src%grid_yt)
+     lat_src(1:grid_src%grid_x,1:grid_src%grid_yt) = grid_src%grid_lat(1:grid_src%grid_x,1:grid_src%grid_yt)
+  endif
+
+  allocate(lon_dst(grid_dst%grid_x, grid_dst%grid_yt), lat_dst(grid_dst%grid_x , grid_dst%grid_yt))
+  if ( grid_dst%grid_y-grid_dst%grid_yt >= 1 ) then
+     lon_dst(1:grid_dst%grid_x,1:grid_dst%grid_yt) = (grid_dst%grid_lon(1:grid_dst%grid_x,1:grid_dst%grid_yt) + &
+                                                      grid_dst%grid_lon(1:grid_dst%grid_x,2:grid_dst%grid_y))/2.0
+     lat_dst(1:grid_dst%grid_x,1:grid_dst%grid_yt) = (grid_dst%grid_lat(1:grid_dst%grid_x,1:grid_dst%grid_yt) + &
+                                                      grid_dst%grid_lat(1:grid_dst%grid_x,2:grid_dst%grid_y))/2.0
+  else
+     lon_dst(1:grid_dst%grid_x,1:grid_dst%grid_yt) = grid_dst%grid_lon(1:grid_dst%grid_x,1:grid_dst%grid_yt)
+     lat_dst(1:grid_dst%grid_x,1:grid_dst%grid_yt) = grid_dst%grid_lat(1:grid_dst%grid_x,1:grid_dst%grid_yt)
+  endif
+  call search_nearst_grid(grid_src%grid_x, grid_src%grid_yt, lat_src, lon_src, &
+                          grid_dst%grid_x, grid_dst%grid_yt, lat_dst, lon_dst, x_oini, y_oini)
+
+  write(*,'(a3,2i6, 2f11.2,2i11)')' v:', i, j, lon_dst(i,j), lat_dst(i,j), x_oini(i,j), y_oini(i,j)
+
+  allocate(gwt%gwt_v(grid_dst%grid_x, grid_dst%grid_yt))  !grid_weight_info
+  call cal_grid_weight(grid_src%grid_x, grid_src%grid_yt, lat_src, lon_src, &
+                       grid_dst%grid_x, grid_dst%grid_yt, lat_dst, lon_dst, x_oini, y_oini, gwt%max_points, gwt%gwt_v)
+  deallocate(x_oini, y_oini, lon_src, lat_src, lon_dst, lat_dst)
+
+  return
+  end subroutine cal_src_dst_grid_weight
+!========================================================================================
+!-----------------------------------------------------------------------+
+  subroutine search_nearst_grid0(src_ix, src_jx, src_lat, src_lon, dst_ix, dst_jx, &
+             dst_lat, dst_lon, dst_in_src_x, dst_in_src_y)
+
+  implicit none
+
+  integer, intent(in)                  :: src_ix, src_jx, dst_ix, dst_jx
+  real, dimension(src_ix, src_jx), intent(in) :: src_lat, src_lon
+  real, dimension(dst_ix, dst_jx), intent(in) :: dst_lat, dst_lon
+  integer, dimension(dst_ix, dst_jx), intent(out) :: dst_in_src_x, dst_in_src_y
+
+  real, allocatable, dimension(:)  :: max_dx, max_dy
+  real    :: dis, dis0
+  integer :: i, j, i1, j1
+
+  allocate(max_dy(src_jx))
+  do j = 1, src_jx
+     max_dy(j) = maxval(src_lat(:,j))-minval(src_lat(:,j))
+  enddo
+  allocate(max_dx(src_ix))
+  do i = 1, src_ix
+     max_dx(i) = maxval(src_lon(i,:))-minval(src_lon(i,:))
+  enddo
+
+  !out_ave_dx=abs( (dst_lon(1,int(dst_jx/2))-dst_lon(dst_ix,dst_jx))/real(dst_ix))
+  !out_ave_dy=abs( (dst_lat(int(dst_jx/2),1)-dst_lat(dst_ix,dst_jx))/real(dst_jx))
+  dst_in_src_x=-99; dst_in_src_y=-99
+  write(*,'(a,2f12.6)')'max dst grid dx/dy in deg:', maxval(max_dx), maxval(max_dy)
+
+  do j = 1,dst_jx; do i = 1,dst_ix
+     dis0=99999.0
+     do_search_src_grid_y: do j1 = 1, src_jx
+         !if( abs(dst_lat(i,j)-src_lat(int(src_ix/2),j1)) > 2.0*out_ave_dy ) cycle do_search_src_grid_y
+         !if( abs(dst_lat(i,j)-src_lat(int(src_ix/2),j1)) > 20.0*out_ave_dy .and.  &
+         !    abs(dst_lat(i,j)-src_lat(1,j1)) > 20.0*out_ave_dy .and. &
+         !    abs(dst_lat(i,j)-src_lat(src_ix,j1)) > 20.0*out_ave_dy ) cycle do_search_src_grid_y
+         if ( abs(dst_lat(i,j)-src_lat(int(src_ix/2),j1)) > 2.0*max_dy(j1) ) cycle do_search_src_grid_y
+         do_search_src_grid_x: do i1 = 1, src_ix
+            !if ( abs(dst_lon(i,j)-src_lon(i1,j1)) > 1.0*out_ave_dx ) cycle do_search_src_grid_x
+            if ( abs(dst_lon(i,j)-src_lon(i1,j1)) > max_dx(i1) ) cycle do_search_src_grid_x
+            dis=(dst_lon(i,j)-src_lon(i1,j1))**2.0+(dst_lat(i,j)-src_lat(i1,j1))**2.0
+            if ( dis <= dis0 ) then
+               dis0 = dis
+               dst_in_src_x(i,j)=i1
+               dst_in_src_y(i,j)=j1
+            endif
+         enddo do_search_src_grid_x
+     enddo do_search_src_grid_y
+
+  enddo; enddo
+
+  deallocate(max_dy, max_dx)
+
+  return
+  end subroutine search_nearst_grid0
+
+!-----------------------------------------------------------------------+
+  subroutine search_nearst_grid(src_ix, src_jx, src_lat, src_lon, dst_ix, dst_jx, &
+             dst_lat, dst_lon, dst_in_src_x, dst_in_src_y)
+
+  implicit none
+
+  integer, intent(in)                  :: src_ix, src_jx, dst_ix, dst_jx
+  real, dimension(src_ix, src_jx), intent(in) :: src_lat, src_lon
+  real, dimension(dst_ix, dst_jx), intent(in) :: dst_lat, dst_lon
+  integer, dimension(dst_ix, dst_jx), intent(out) :: dst_in_src_x, dst_in_src_y
+
+  integer, allocatable, dimension(:,:,:)  :: src_points_lon, src_points_lat
+  integer, allocatable, dimension(:,:) :: src_points
+  real, allocatable, dimension(:)      :: ll_lon, ll_lat
+
+  integer :: i, j, ll_ix, ll_jx, i1, j1, max_points, i2, j2, i3, j3, n
+  real    :: min_lon, min_lat, max_lon, max_lat, d_ll, dis, dis0, dis_src, dis_dst
+  logical :: src_in_bin
+  real    :: earth_dist
+
+  !---define serach bins
+  d_ll = 0.1   !default bin size is 0.1 degx0.1 deg
+  i1=int(src_ix/2); j1=int(src_jx/2);
+  dis=sqrt((src_lon(i1,j1)-src_lon(i1+1,j1+1))**2.0+(src_lat(i1,j1)-src_lat(i1+1,j1+1))**2.0)
+  dis_src=int(dis*100.)/100.
+  d_ll=max(dis_src,d_ll)
+  i1=int(dst_ix/2); j1=int(dst_jx/2);
+  dis=sqrt((dst_lon(i1,j1)-dst_lon(i1+1,j1+1))**2.0+(dst_lat(i1,j1)-dst_lat(i1+1,j1+1))**2.0)
+  dis_dst=int(dis*100.)/100.
+  d_ll=max(dis_dst,d_ll)
+  !---determine max_points in each bin
+  max_points=min(max(10, 30*(int(d_ll/min(dis_src,dis_dst))+1)**2), 100000)
+
+  min_lon = min(minval(src_lon), minval(dst_lon)) - 5.*d_ll
+  min_lat = min(minval(src_lat), minval(dst_lat)) - 5.*d_ll
+  max_lon = max(maxval(src_lon), maxval(dst_lon)) + 5.*d_ll
+  max_lat = max(maxval(src_lat), maxval(dst_lat)) + 5.*d_ll
+  min_lon = int(min_lon*10)/10.0
+  max_lon = int((max_lon+0.5)*10)/10.0
+  min_lat = int(min_lat*10)/10.0
+  max_lat = int((max_lat+0.5)*10)/10.0
+
+  ll_ix = int((max_lon - min_lon)/d_ll) + 1
+  ll_jx = int((max_lat - min_lat)/d_ll) + 1
+  write(*,'(a,f,i )')'ll bin size d_ll and max_points:', d_ll, max_points
+  write(*,'(a,3f  )')'min lon for src dst min:', minval(src_lon), minval(dst_lon), min_lon
+  write(*,'(a,3f,i)')'max lon for src dst max:', maxval(src_lon), maxval(dst_lon), max_lon, ll_ix
+  write(*,'(a,3f  )')'min lat for src dst min:', minval(src_lat), minval(dst_lat), min_lat
+  write(*,'(a,3f,i)')'max lat for src dst max:', maxval(src_lat), maxval(dst_lat), max_lat, ll_jx
+  allocate ( ll_lon(ll_ix), ll_lat(ll_jx))
+  do i = 1, ll_ix
+     ll_lon(i) = min_lon + (i-1)*d_ll
+  enddo
+  do j = 1, ll_jx
+     ll_lat(j) = min_lat + (j-1)*d_ll
+  enddo
+  write(*,'(a,f10.3,a,f10.3,a,f10.3,a,f10.3)')'search grids: ', ll_lon(1),'-->',ll_lon(ll_ix),' : ', ll_lat(1), '-->', ll_lat(ll_jx)
+
+  !---sign src grids to search bins
+  allocate ( src_points(ll_ix,ll_jx))
+  allocate ( src_points_lon(ll_ix,ll_jx,max_points), src_points_lat(ll_ix,ll_jx,max_points))
+  src_points=0
+
+  !--- may need halo
+  write(*,'(a)')'---sign src to ll grids'
+  !$omp parallel do &
+  !$omp& private(i,j)
+  do j = 1, src_jx; do i = 1, src_ix
+     i1 = int((src_lon(i,j) - ll_lon(1))/d_ll) + 1
+     j1 = int((src_lat(i,j) - ll_lat(1))/d_ll) + 1
+     do i2 = -1, 1; do j2 = -1, 1;   !add halo
+        i3=i1+i2; j3=j1+j2
+        if ( i3 >= 1 .and. i3 <= ll_ix .and. j3 >= 1 .and. j3 <= ll_jx ) then
+           if ( src_points(i3,j3) < max_points ) then
+              src_in_bin=.false.
+              do n=1,src_points(i3,j3)
+                 if ( i .eq. src_points_lon(i3,j3,n) .and. &
+                      j .eq. src_points_lat(i3,j3,n) ) then
+                    !---src point already included, skip
+                    src_in_bin=.true.
+                    exit
+                 endif
+              enddo
+              !---add the src point into the ll grid bin if it is not yet included
+              if ( .not. src_in_bin ) then
+                 src_points(i3,j3) = src_points(i3,j3) + 1
+                 src_points_lon(i3,j3,src_points(i3,j3)) = i
+                 src_points_lat(i3,j3,src_points(i3,j3)) = j
+              endif
+           else
+              write(*,'(a,6i6,2f10.3)') 'WARNING: src_points(i3,j3) >= max_points at i3, j3, i, j, src_lon(i,j), src_lat(i,j)', &
+                 src_points(i3,j3), max_points, i3, j3, i, j, src_lon(i,j), src_lat(i,j)
+           endif
+           !---may need add halo:
+        endif
+     enddo; enddo
+  enddo; enddo
+
+  !---search nearest src grid for each dst grid
+  write(*,'(a)')'---search nearest src grid for each dst grid'
+  !$omp parallel do &
+  !$omp& private(i,j)
+  do j = 1, dst_jx; do i = 1, dst_ix
+     !---calculate dst grid position in search-bin
+     i1 = int((dst_lon(i,j) - ll_lon(1))/d_ll) + 1
+     j1 = int((dst_lat(i,j) - ll_lat(1))/d_ll) + 1
+     if ( i1 < 1 .or. j1 < 1 ) then
+        write(*,'(a,4i6,4f10.3)')'i1j1---',i,j,i1,j1,ll_lon(1),ll_lat(1),dst_lon(i,j),dst_lat(i,j)
+        stop
+     endif
+     if ( src_points(i1,j1) > 0 .and. src_points(i1,j1) <= max_points ) then
+        !i2=i+1; if ( i2 > dst_ix) i2=i-1
+        !j2=j+1; if ( j2 > dst_jx) j2=j-1
+        dis0=999999.0
+        do n = 1, src_points(i1,j1)
+           if ( src_points_lon(i1,j1,n) < 1 .or. src_points_lon(i1,j1,n) > src_ix .or. src_points_lat(i1,j1,n) < 1 .or. src_points_lat(i1,j1,n) > src_jx ) then
+              write(*,'(7i8)')n, i, j, i1, j1, src_points_lon(i1,j1,n), src_points_lat(i1,j1,n)
+           endif
+           !dis=(dst_lon(i,j)-src_lon(src_points_lon(i1,j1,n),src_points_lat(i1,j1,n)))**2.0 + &
+           !    (dst_lat(i,j)-src_lat(src_points_lon(i1,j1,n),src_points_lat(i1,j1,n)))**2.0
+           !---calculate great circle earth distance in km
+           dis=earth_dist(src_lon(src_points_lon(i1,j1,n),src_points_lat(i1,j1,n)), &
+                          src_lat(src_points_lon(i1,j1,n),src_points_lat(i1,j1,n)), &
+                          dst_lon(i,j),dst_lat(i,j))/1000.
+           if ( dis < dis0 ) then
+              dis0 = dis
+              dst_in_src_x(i,j)=src_points_lon(i1,j1,n)
+              dst_in_src_y(i,j)=src_points_lat(i1,j1,n)
+           endif
+        enddo
+     else
+        dst_in_src_x(i,j)=-99
+        dst_in_src_y(i,j)=-99
+     endif
+  enddo; enddo
+
+  !---clean up
+  deallocate(ll_lon, ll_lat, src_points, src_points_lon, src_points_lat)
+  write(*,'(a)')'---search_nearst_grid finished'
+
+  return
+  end subroutine search_nearst_grid
+
+!-----------------------------------------------------------------------+
+  subroutine cal_grid_weight(src_ix, src_jx, src_lat, src_lon, dst_ix, dst_jx, &
+             dst_lat, dst_lon, dst_in_src_x, dst_in_src_y, max_points, gw )
+
+  use var_type
+  implicit none
+  integer, intent(in)                  :: src_ix, src_jx, dst_ix, dst_jx, max_points
+  real, dimension(src_ix, src_jx), intent(in) :: src_lat, src_lon
+  real, dimension(dst_ix, dst_jx), intent(in) :: dst_lat, dst_lon
+  integer, dimension(dst_ix, dst_jx), intent(in) :: dst_in_src_x, dst_in_src_y
+  type(gridmap_info), dimension(dst_ix, dst_jx), intent(inout) :: gw  !gridweight
+
+  integer :: i, j, k, n, i1, j1, ixs, jxs, ixi, jxi, min_ij_src, min_ij_dst
+  real    :: dst_weight, earth_dist, dis, lon180_1, lon180_2
+
+  !$omp parallel do &
+  !$omp& private(i,j)
+  do j = 1,dst_jx; do i = 1,dst_ix
+     ixs=dst_in_src_x(i,j)  !the position in src grids
+     jxs=dst_in_src_y(i,j)
+
+     gw(i,j)%src_points=0
+     allocate(gw(i,j)%src_x(max_points), gw(i,j)%src_y(max_points), gw(i,j)%src_weight(max_points))
+     if ( ixs >= 1 .and. ixs <= src_ix .and. jxs >= 1 .and. jxs <= src_jx ) then
+        n=0  !gw(i,j)%src_points=0
+        do j1 = -1, 1; do i1 = -1, 1;
+        !do j1 = 0, 0; do i1 = 0, 0
+           if ( i1*j1 == 0 ) then  !5-point
+              ixi=ixs+i1; jxi=jxs+j1
+              !---change left to center
+              if ( ixi < 1 ) ixi=3
+              if ( ixi > src_ix ) ixi=src_ix-2
+              if ( jxi < 1 ) jxi=3
+              if ( jxi > src_jx ) jxi=src_jx-2
+              if ( ixi >= 1 .and. ixi <= src_ix .and. jxi >= 1 .and. jxi <= src_jx .and. n < max_points) then
+                 n=n+1
+                 gw(i,j)%src_x(n)=ixi
+                 gw(i,j)%src_y(n)=jxi
+                 !gw(i,j)%src_weight(n)=earth_dist(src_lon(ixi,jxi),src_lat(ixi,jxi),dst_lon(i,j),dst_lat(i,j))
+                 !nolinear dis weight
+                 !gw(i,j)%src_weight(n)=gw(i,j)%src_weight(n)*gw(i,j)%src_weight(n)
+                 !---use the weighting function based on exp(-r/r_scale); here r_scale is hardcoded as 2km currently
+                 gw(i,j)%src_weight(n)=exp(-earth_dist(src_lon(ixi,jxi),src_lat(ixi,jxi),dst_lon(i,j),dst_lat(i,j))/2000.)
+              endif  !if ( ixi >= 1 .and. ixi <= src_ix .and. jxi >= 1 .and. jxi <= src_jx ) then
+           endif
+        enddo; enddo
+
+        !---convert earth_dist to weightening
+        gw(i,j)%src_points=n
+        if ( n > 0 ) then
+           dis=0.
+           do k = 1, n
+              dis=dis+gw(i,j)%src_weight(k)
+           enddo
+           if ( dis == 0. ) then
+              gw(i,j)%src_weight(1:n)=1.0/real(n)
+           else if (dis > 0. .and. dis < 9000000000. ) then
+              !gw(i,j)%src_weight(1:n)=gw(i,j)%src_weight(1:n)/dis
+              if ( n <= 1 ) then
+                 gw(i,j)%src_weight(1:n)=1.0
+              else
+                 !gw(i,j)%src_weight(1:n)=(dis-gw(i,j)%src_weight(1:n))/((n-1)*dis)
+                 gw(i,j)%src_weight(1:n)=gw(i,j)%src_weight(1:n)/dis
+              endif
+           else
+              write(*,'(a)')'earth_dist calculation is wrong'
+           endif
+        endif
+     endif
+
+     !---select dst grids for smooth if needed
+     gw(i,j)%dst_points=0
+     dst_weight=0.0
+     allocate(gw(i,j)%dst_x(max_points), gw(i,j)%dst_y(max_points), gw(i,j)%dst_weight(max_points))
+
+     !if ( ixs > 1 .and. ixs < src_ix .and. jxs > 1 .and. jxs < src_jx ) then
+     !   !---when the grid is inside of src-domain, no dst grid is needed
+     !   !dst_weight=0.0
+        gw(i,j)%dst_points=1
+        gw(i,j)%dst_x(1)=i
+        gw(i,j)%dst_y(1)=j
+        gw(i,j)%dst_weight(1)=1.0
+     !else if ( (i==1 .and. ixs==1) .or. (i==dst_ix .and. ixs==src_ix) .or. (j==1 .and. jxs==1) .or. (j==dst_jx .and. jxs==src_jx) ) then
+     !   !---when the dst domain is the same as the src domain, no dst grid is needed too
+     !   !--- so just the outest circle
+     !   !dst_weight=0.0
+     !   gw(i,j)%dst_points=1
+     !   gw(i,j)%dst_x(1)=i
+     !   gw(i,j)%dst_y(1)=j
+     !   gw(i,j)%dst_weight(1)=1.0
+     !else
+     !   !if ( ixs <= 2 .or. ixs >= src_ix-1 .or. jxs >= 2 .or. jxs <= src_jx-1 ) then
+     !   !---add self
+     !   n=1
+     !   gw(i,j)%dst_x(n) = i
+     !   gw(i,j)%dst_y(n) = j
+     !   gw(i,j)%dst_weight(n) = 1.0
+     !   !dst_weight=0.3
+
+     !   if ( ixs == 1 .or. ixs == src_ix .or. jxs == 1 .or. jxs == src_jx ) then
+     !      !---if the grid is on the edge of the src domain, then add 9-point smooth.
+     !      do j1 = -1, 1; do i1 = -1, 1
+     !         if ( i1 /= 0 .and. j1 /= 0 ) then
+     !            ixi=i+i1; jxi=j+j1
+     !            if ( ixi >= 1 .and. ixi <= dst_ix .and. jxi >=1 .and. jxi <= dst_jx ) then
+     !               n=n+1; gw(i,j)%dst_x(n)=ixi; gw(i,j)%dst_y(n)=jxi; gw(i,j)%dst_weight(n)=0.5
+     !            endif
+     !         endif
+     !      enddo; enddo
+     !      !dst_weight=0.5
+     !   !elseif ( ixs < 1 .or. ixs > src_ix .or. jxs < 1 .or. jxs > src_jx ) then
+     !      !dst_weight=1.0
+     !   endif
+
+     !   gw(i,j)%dst_points=n
+     !   gw(i,j)%dst_weight(1:n)=gw(i,j)%dst_weight(1:n)/sum(gw(i,j)%dst_weight(1:n))
+     !endif
+
+     if ( ixs>=1 .and. ixs<=src_ix .and. jxs>=1 .and. jxs<=src_jx) then  !inside src-domain
+        dst_weight=0.0
+        if ( gwt%relaxzone < 0 ) gwt%relaxzone = min(30, int(min(src_ix, src_jx, dst_ix, dst_jx)/10))
+        !--- find relaxzone: min (i,j) or max (i,j) grids to src (1,1) and src(ix,jx)
+        !  ixs, jxs
+        min_ij_src = min(ixs, jxs, src_ix-ixs, src_jx-jxs) ! shortest distance (grid not earth-distance) from SRC domain edge
+        min_ij_dst = min(i, j, dst_ix-i, dst_jx-j)
+        if ( min_ij_src <= gwt%relaxzone .and. min_ij_dst > 2 .and. gwt%relaxzone > 0 ) then
+           dst_weight = real(gwt%relaxzone - min_ij_src)/real(gwt%relaxzone)
+           if ( dst_weight < 0.0 .or. dst_weight > 1.0 ) then
+              write(*,'(a,7i6,f10.4)')'---relaxzone dst_weight:', i,j,ixs,jxs,min_ij_src,min_ij_dst,gwt%relaxzone,dst_weight
+              stop
+           endif
+        endif
+     else
+        dst_weight=1.0
+     endif
+
+     !--- find TC vortex relax zone
+     if ( tc%vortexrep==1 .and. tc%lat>-85. .and. tc%lat<85. .and. tc%lon>=-180. .and. tc%lon<=360. ) then
+        if ( tc%lon<0.)tc%lon=tc%lon+360.
+        if ( ixs>=1 .and. ixs<=src_ix .and. jxs>=1 .and. jxs<=src_jx) then
+           lon180_1=src_lon(ixs,jxs)
+           lon180_2=tc%lon
+           dis = earth_dist(lon180_1,src_lat(ixs,jxs),lon180_2,tc%lat)/1000.
+
+           if ( abs(tc%vortexreplace_r(1)-tc%vortexreplace_r(2)) < 1.0 .or. tc%vortexreplace_r(1) < 1.0 .or. tc%vortexreplace_r(2) < 1.0 ) then
+              tc%vortexreplace_r(1)=600.
+              tc%vortexreplace_r(2)=900.
+           endif
+           if ( dis < tc%vortexreplace_r(1) ) then
+              dst_weight=0.0
+           else if ( dis > tc%vortexreplace_r(2) ) then
+              dst_weight=1.0
+           else
+              dst_weight=(dis-tc%vortexreplace_r(1))/(tc%vortexreplace_r(2)-tc%vortexreplace_r(1))
+           endif
+           !write(*,*)'----tc zone', tc%lon, tc%lat, dis, tc%vortexreplace_r(1:2), dst_weight
+           if ( dst_weight < 0.0 .or. dst_weight > 1.0 ) then
+              write(*,'(a,4i6,4f10.2)')'---vortex dst_weight:', i,j,ixs,jxs,tc%vortexreplace_r(1:2), dis, dst_weight
+              stop
+           endif
+        else
+           dst_weight=1.0
+        endif
+     endif
+
+     !---combine src and dst weight
+     if ( gw(i,j)%src_points > 0 ) then
+        gw(i,j)%src_weight(1:gw(i,j)%src_points)=(1.0-dst_weight)*gw(i,j)%src_weight(1:gw(i,j)%src_points)
+        gw(i,j)%dst_weight(1:gw(i,j)%dst_points)=     dst_weight *gw(i,j)%dst_weight(1:gw(i,j)%dst_points)
+     else
+        gw(i,j)%src_weight = 0.
+     endif
+
+  enddo; enddo
+
+  return
+  end subroutine cal_grid_weight
+
+!-----------------------------------------------------------------------+
+  subroutine combine_grids_for_remap(ixi, jxi, kxi, txi, fdat_src, ixo, jxo, kxo, txo, fdat_dst, gw, fdat_out)
+
+! --- remap: (src U dst) --> src
+! --- merge: (src U dst) --> dst
+
+  use constants
+  use var_type
+  implicit none
+  integer, intent(in)                  :: ixi, jxi, kxi, txi, ixo, jxo, kxo, txo
+  real, dimension(ixi, jxi, kxi, txi), intent(in) :: fdat_src
+  real, dimension(ixo, jxo, kxo, txo), intent(in) :: fdat_dst
+  type(gridmap_info), dimension(ixo, jxo), intent(in) :: gw
+  real, dimension(ixo, jxo, kxo, txo), intent(out) :: fdat_out
+
+  integer   :: i, j, k, n, i1, j1, k1, n1, ncount
+
+  !$omp parallel do &
+  !$omp& private(i,j,k,n)
+  do n = 1, txo; do k = 1, kxo; do j = 1, jxo; do i = 1, ixo
+     fdat_out(i,j,k,n)=0.0
+     ncount=0
+     if ( gw(i,j)%src_points > 0 ) then
+        do_src_points_loop: do n1 = 1, gw(i,j)%src_points
+           i1=gw(i,j)%src_x(n1)
+           j1=gw(i,j)%src_y(n1)
+           if ( i1 < 1 .or. i1 > ixi .or. j1 < 1 .or. j1 > jxi ) cycle do_src_points_loop
+           if ( gw(i,j)%src_weight(n1) <= 0. .or. gw(i,j)%src_weight(n1) > 1.0 ) cycle do_src_points_loop
+           if ( fdat_src(i1,j1,k,n) < -99999. .or. fdat_src(i1,j1,k,n) > 90000000. ) cycle do_src_points_loop
+           fdat_out(i,j,k,n)=fdat_out(i,j,k,n)+gw(i,j)%src_weight(n1)*fdat_src(i1,j1,k,n)
+           ncount=ncount+1
+        enddo do_src_points_loop
+     endif
+     if ( gw(i,j)%dst_points > 0 ) then
+        do_dst_points_loop: do n1 = 1, gw(i,j)%dst_points
+           i1=gw(i,j)%dst_x(n1)
+           j1=gw(i,j)%dst_y(n1)
+           if ( i1 < 1 .or. i1 > ixo .or. j1 < 1 .or. j1 > jxo ) cycle do_dst_points_loop
+           if ( gw(i,j)%dst_weight(n1) <= 0. .or. gw(i,j)%dst_weight(n1) > 1.0 ) cycle do_dst_points_loop
+           if ( fdat_dst(i1,j1,k,n) < -99999. .or. fdat_dst(i1,j1,k,n) > 90000000. ) cycle do_dst_points_loop
+           fdat_out(i,j,k,n)=fdat_out(i,j,k,n)+gw(i,j)%dst_weight(n1)*fdat_dst(i1,j1,k,n)
+           ncount=ncount+1
+        enddo do_dst_points_loop
+     endif
+     if (ncount < 1 ) fdat_out(i,j,k,n)=missing
+
+     !---debug
+     !if ( (i == int(ixo/4) .or. i == int(ixo/2) .or. i == ixo-1) .and. &
+     !     (j == int(jxo/4) .or. j == int(jxo/2) .or. j == jxo-1) .and. k==1 .and. n==1 ) then
+     if ( i == int(ixo/2) .and.j == int(jxo/2) .and. k==1 .and. n==1 ) then
+        if (debug_level>20) write(*,'(a,   5i10)')'--combine_grids_for_remap: ',i,j, gw(i,j)%src_points, gw(i,j)%dst_points, ncount
+        if (debug_level>20) write(*,'(a,  90i10)')'--             src_points: ', ((gw(i,j)%src_x(n1), gw(i,j)%src_y(n1)),n1=1,gw(i,j)%src_points)
+        if (debug_level>20) write(*,'(a,90e)')    '--             src_weight: ', ((gw(i,j)%src_weight(n1)),n1=1,gw(i,j)%src_points)
+        write(*,'(a,90e)')    '--             src_values: ', ( fdat_src(gw(i,j)%src_x(n1),gw(i,j)%src_y(n1),k,n),n1=1,gw(i,j)%src_points)
+        if ( gw(i,j)%dst_points > 0 ) then
+           if (debug_level>20) write(*,'(a,  90i13)')'--             dst_points: ', ((gw(i,j)%dst_x(n1), gw(i,j)%dst_y(n1)),n1=1,gw(i,j)%dst_points)
+           if (debug_level>20) write(*,'(a,90e)')'--             dst_weight: ', ((gw(i,j)%dst_weight(n1)),n1=1,gw(i,j)%dst_points)
+           write(*,'(a,90e)')    '--             dst_values: ', ( fdat_dst(gw(i,j)%dst_x(n1),gw(i,j)%dst_y(n1),k,n),n1=1,gw(i,j)%dst_points)
+        else
+           write(*,'(a)')     '--             no dst point'
+        endif
+        write(*,'(a,e)')    '--          remaped value: ', fdat_out(i,j,k,n)
+     endif
+
+  enddo; enddo; enddo; enddo
+
+  return
+  end subroutine combine_grids_for_remap
+
+!-----------------------------------------------------------------------+
+  subroutine combine_grids_for_merge(ixi, jxi, kxi, txi, fdat_src, ixo, jxo, kxo, txo, fdat_dst, gw, fdat_out)
+
+! --- remap: (src U dst) --> src
+! --- merge: (src U dst) --> dst
+
+  use constants
+  use var_type
+  implicit none
+  integer, intent(in)                  :: ixi, jxi, kxi, txi, ixo, jxo, kxo, txo
+  real, dimension(ixi, jxi, kxi, txi), intent(in) :: fdat_src
+  real, dimension(ixo, jxo, kxo, txo), intent(in) :: fdat_dst
+  type(gridmap_info), dimension(ixo, jxo), intent(in) :: gw
+  real, dimension(ixo, jxo, kxo, txo), intent(out) :: fdat_out
+
+  integer   :: i, j, k, n, i1, j1, k1, n1, ncount
+
+  !$omp parallel do &
+  !$omp& private(i,j,k,n)
+  do n = 1, txo; do k = 1, kxo; do j = 1, jxo; do i = 1, ixo
+     fdat_out(i,j,k,n)=0.0
+     ncount=0
+     if ( gw(i,j)%dst_points > 0 ) then
+        do_dst_points_loop: do n1 = 1, gw(i,j)%dst_points
+           i1=gw(i,j)%dst_x(n1)
+           j1=gw(i,j)%dst_y(n1)
+           if ( i1 < 1 .or. i1 > ixo .or. j1 < 1 .or. j1 > jxo ) cycle do_dst_points_loop
+           !if ( gw(i,j)%dst_weight(n1) <= 0. .or. gw(i,j)%dst_weight(n1) > 1.0 ) cycle do_dst_points_loop
+           if ( fdat_dst(i1,j1,k,n) < -99999. .or. fdat_dst(i1,j1,k,n) > 90000000. ) cycle do_dst_points_loop
+           !fdat_out(i,j,k,n)=fdat_out(i,j,k,n)+gw(i,j)%dst_weight(n1)*fdat_dst(i1,j1,k,n)
+           fdat_out(i,j,k,n)=fdat_out(i,j,k,n)+fdat_dst(i1,j1,k,n)
+           ncount=ncount+1
+        enddo do_dst_points_loop
+     endif
+     if ( ncount > 0 ) then
+        fdat_out(i,j,k,n)=fdat_out(i,j,k,n)/real(ncount)
+     else
+        if ( gw(i,j)%src_points > 0 ) then
+           do_src_points_loop: do n1 = 1, gw(i,j)%src_points
+              i1=gw(i,j)%src_x(n1)
+              j1=gw(i,j)%src_y(n1)
+              if ( i1 < 1 .or. i1 > ixi .or. j1 < 1 .or. j1 > jxi ) cycle do_src_points_loop
+              if ( gw(i,j)%src_weight(n1) <= 0. .or. gw(i,j)%src_weight(n1) > 1.0 ) cycle do_src_points_loop
+              if ( fdat_src(i1,j1,k,n) < -99999. .or. fdat_src(i1,j1,k,n) > 90000000. ) cycle do_src_points_loop
+              fdat_out(i,j,k,n)=fdat_out(i,j,k,n)+gw(i,j)%src_weight(n1)*fdat_src(i1,j1,k,n)
+              ncount=ncount+1
+           enddo do_src_points_loop
+        endif
+     endif
+     if (ncount < 1 ) fdat_out(i,j,k,n)=missing
+
+     !---debug
+     !if ( (i == int(ixo/4) .or. i == int(ixo/2) .or. i == ixo-1) .and. &
+     !     (j == int(jxo/4) .or. j == int(jxo/2) .or. j == jxo-1) .and. k==1 .and. n==1 ) then
+     if ( i == int(ixo/2) .and.j == int(jxo/2) .and. k==1 .and. n==1 ) then
+        write(*,'(a,   5i10)')'--combine_grids_for_merge: ',i,j, gw(i,j)%src_points, gw(i,j)%dst_points, ncount
+        write(*,'(a,  90i10)')'--             src_points: ', ((gw(i,j)%src_x(n1), gw(i,j)%src_y(n1)),n1=1,gw(i,j)%src_points)
+        write(*,'(a,90f)')    '--             src_values: ', ( fdat_src(gw(i,j)%src_x(n1),gw(i,j)%src_y(n1),k,n),n1=1,gw(i,j)%src_points)
+        if ( gw(i,j)%dst_points > 0 ) then
+           write(*,'(a,  90i10)')'--             dst_points: ', ((gw(i,j)%dst_x(n1), gw(i,j)%dst_y(n1)),n1=1,gw(i,j)%dst_points)
+           write(*,'(a,  e)')    '--             dst_values: ', ( fdat_dst(gw(i,j)%dst_x(n1),gw(i,j)%dst_y(n1),k,n),n1=1,gw(i,j)%dst_points)
+        else
+           write(*,'(a)')     '--             no dst point'
+        endif
+        write(*,'(a,  f)')    '--          remaped value: ', fdat_out(i,j,k,n)
+     endif
+
+  enddo; enddo; enddo; enddo
+
+  return
+  end subroutine combine_grids_for_merge
+
+!-----------------------------------------------------------------------+
+  function uppercase (cs)
+
+  implicit none
+  character(len=*), intent(in) :: cs
+  character(len=len(cs)),target       :: uppercase
+  integer                      :: k,tlen
+  character, pointer :: ca
+  integer, parameter :: co=iachar('A')-iachar('a') ! case offset
+  !The transfer function truncates the string with xlf90_r
+  tlen = len_trim(cs)
+  if (tlen <= 0) then      ! catch IBM compiler bug
+     uppercase = cs  ! simply return input blank string
+  else
+    uppercase = cs(1:tlen)
+!#if defined _CRAYX1
+!    do k=1, tlen
+!       if(uppercase(k:k) >= "a" .and. uppercase(k:k) <= 'z') uppercase(k:k) = achar(ichar(uppercase(k:k))+co)
+!    end do
+!#else
+    do k=1, tlen
+       ca => uppercase(k:k)
+       if(ca >= "a" .and. ca <= "z") ca = achar(ichar(ca)+co)
+    enddo
+!#endif
+  endif
+  end function uppercase
+
+!-----------------------------------------------------------------------+
+  function lowercase (cs)
+
+  implicit none
+  character(len=*), intent(in) :: cs
+  character(len=len(cs)),target       :: lowercase
+  integer, parameter :: co=iachar('a')-iachar('A') ! case offset
+  integer                        :: k,tlen
+  character, pointer :: ca
+  !  The transfer function truncates the string with xlf90_r
+  tlen = len_trim(cs)
+  if (tlen <= 0) then      ! catch IBM compiler bug
+     lowercase = cs  ! simply return input blank string
+  else
+     lowercase = cs(1:tlen)
+!#if defined _CRAYX1
+!     do k=1, tlen
+!        if(lowercase(k:k) >= "A" .and. lowercase(k:k) <= 'Z') lowercase(k:k) = achar(ichar(lowercase(k:k))+co)
+!     end do
+!#else
+     do k=1, tlen
+        ca => lowercase(k:k)
+        if(ca >= "A" .and. ca <= "Z") ca = achar(ichar(ca)+co)
+     enddo
+!#endif
+  endif
+  end function lowercase
+
+!-----------------------------------------------------------------------+
+  function strrep(string, charset, target_char)
+
+  implicit none
+  character(len=*), intent(in) :: string
+  character(len=1), intent(in) :: charset, target_char
+  character(len(string))       :: strrep
+  integer :: n, ns
+  ns = len(string)
+  strrep(1:ns) = ' '
+  do n = 1, ns
+     if (string(n:n) == charset) then
+        strrep(n:n) = target_char
+     else
+        strrep(n:n) = string(n:n)
+     end if
+  end do
+  end function strrep
+
+!-----------------------------------------------------------------------+
+  subroutine longitude_expand_360to540(nx, ny, lon)
+
+  implicit none
+
+  integer, intent(in) :: nx, ny
+  real, dimension(nx,ny), intent(inout) :: lon
+
+  real    :: lon_c, lon_min, lon_ir, lon_il, lon_jt, lon_jb, lon_west
+  integer :: ic, jc, i0, j0
+
+  !---change grid to [0~360)
+  where ( lon >= 360. ) lon=lon-360.
+  where ( lon <    0. ) lon=lon+360.
+
+  !---if lon within [0 360), return
+  ic = int(nx/2)
+  jc = int(ny/2)
+  if ( ic < 3 .or. jc < 3 ) return
+
+  lon_c = lon(ic,jc)
+  lon_min = minval(lon)
+  if ( abs(lon_c-lon_min) < 180. ) then
+     !---the domain is within [0, 360), no change needed
+     return
+  else
+     !---find out the longitude dimension & west-boundary
+     lon_il = ( lon(ic-1,jc)+lon(ic-1,jc-1)+lon(ic-1,jc+1)+    &
+                lon(ic-2,jc)+lon(ic-2,jc-1)+lon(ic-2,jc+1) )/6.0
+     lon_ir = ( lon(ic+1,jc)+lon(ic+1,jc-1)+lon(ic+1,jc+1)+    &
+                lon(ic+2,jc)+lon(ic+2,jc-1)+lon(ic+2,jc+1) )/6.0
+     lon_jt = ( lon(ic-1,jc+1)+lon(ic,jc+1)+lon(ic+1,jc+1)+    &
+                lon(ic-1,jc+2)+lon(ic,jc+2)+lon(ic+1,jc+2) )/6.0
+     lon_jb = ( lon(ic-1,jc-1)+lon(ic,jc-1)+lon(ic+1,jc-1)+    &
+                lon(ic-1,jc-2)+lon(ic,jc-2)+lon(ic+1,jc-2) )/6.0
+
+     i0=-99
+     j0=-99
+     lon_west=0.0
+     if ( abs(lon_ir-lon_il) >= abs(lon_jt-lon_jb) ) then
+        !---nx is for longitude
+        if ( lon_il <= lon_ir ) then
+           i0=1   !left is the west-boundary
+        else
+           i0=nx  !right is the west-boundary
+        endif
+        !---find out the most west value
+        lon_west=minval(lon(i0,:))
+     else
+        !---ny is for longitude
+        if ( lon_jb <= lon_jt ) then
+           j0=1
+        else
+           j0=ny
+        endif
+        !---find out the most west value
+        lon_west=minval(lon(:,j0))
+     endif
+
+     !---add 360 to the right area
+     where ( lon < lon_west ) lon=lon+360.
+     return
+  endif
+
+  end subroutine longitude_expand_360to540
+
+
+!-----------------------------------------------------------------------+

--- a/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_wind_process.f90
+++ b/sorc/rdas_tools.fd/sorc/rdas_ua2u/sub_wind_process.f90
@@ -1,0 +1,235 @@
+!========================================================================================
+  subroutine cal_uv_coeff_fv3(nx, ny, grid_lat, grid_lon, cangu, sangu, cangv, sangv)
+!-----------------------------------------------------------------------------
+! This subroutine is adopated from gsi/mod_fv3_lola.f90
+! authors and history:
+!      -- 202103, created by Yonghui Weng
+!-----------------------------------------------------------------------------
+  use constants
+  implicit none
+
+  integer, intent(in) :: nx, ny
+  real,dimension(nx+1,ny+1), intent(in) :: grid_lat, grid_lon ! FV3
+!  real, allocatable, dimension(:,:), intent(out) :: cangu, sangu, cangv, sangv
+  real, dimension(nx,ny+1), intent(out) :: cangu, sangu
+  real, dimension(nx+1,ny), intent(out) :: cangv, sangv
+
+  real, allocatable, dimension(:,:)  :: x, y, z
+  integer      :: i, j
+  real         :: sq180, rlat, diff, rlon, xr, yr, zr, xu, yu, zu, uval, ewval, nsval, xv, yv, zv, vval
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! find coefficients for wind conversion btw FV3 & earth
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!  allocate  (   cangu(nx,ny+1),sangu(nx,ny+1),cangv(nx+1,ny),sangv(nx+1,ny) )
+
+!   1.  compute x,y,z at cell cornor from grid_lon, grid_lat
+
+  allocate( x(nx+1,ny+1), y(nx+1,ny+1), z(nx+1,ny+1) )
+  !$omp parallel do &
+  !$omp& private(i,j)
+  do j=1,ny+1
+     do i=1,nx+1
+        x(i,j)=cos(grid_lat(i,j)*deg2rad)*cos(grid_lon(i,j)*deg2rad)
+        y(i,j)=cos(grid_lat(i,j)*deg2rad)*sin(grid_lon(i,j)*deg2rad)
+        z(i,j)=sin(grid_lat(i,j)*deg2rad)
+     enddo
+  enddo
+
+!  2   find angles to E-W and N-S for U edges
+  sq180=180.**2
+  !$omp parallel do &
+  !$omp& private(i,j,rlat,rlon,xr,yr,zr,xu,yu,zu)
+  do j=1,ny+1
+     do i=1,nx
+!      center lat/lon of the edge
+        rlat=0.50*(grid_lat(i,j)+grid_lat(i+1,j))
+        diff=(grid_lon(i,j)-grid_lon(i+1,j))**2
+        if(diff < sq180)then
+           rlon=0.50*(grid_lon(i,j)+grid_lon(i+1,j))
+        else
+           rlon=0.50*(grid_lon(i,j)+grid_lon(i+1,j)-360.)
+        endif
+!    vector to center of the edge
+        xr=cos(rlat*deg2rad)*cos(rlon*deg2rad)
+        yr=cos(rlat*deg2rad)*sin(rlon*deg2rad)
+        zr=sin(rlat*deg2rad)
+!     vector of the edge
+        xu= x(i+1,j)-x(i,j)
+        yu= y(i+1,j)-y(i,j)
+        zu= z(i+1,j)-z(i,j)
+!    find angle with cross product
+        uval=sqrt((xu**2+yu**2+zu**2))
+        ewval=sqrt((xr**2+yr**2))
+        nsval=sqrt((xr*zr)**2+(zr*yr)**2+(xr*xr+yr*yr)**2)
+        cangu(i,j)=(-yr*xu+xr*yu)/ewval/uval
+        sangu(i,j)=(-xr*zr*xu-zr*yr*yu+(xr*xr+yr*yr)*zu) / nsval/uval
+     enddo
+  enddo
+
+!  3   find angles to E-W and N-S for V edges
+  !$omp parallel do &
+  !$omp& private(i,j,rlat,rlon,xr,yr,zr,xu,yu,zu)
+  do j=1,ny
+     do i=1,nx+1
+        rlat=0.50*(grid_lat(i,j)+grid_lat(i,j+1))
+        diff=(grid_lon(i,j)-grid_lon(i,j+1))**2
+        if(diff < sq180)then
+           rlon=0.50*(grid_lon(i,j)+grid_lon(i,j+1))
+        else
+           rlon=0.50*(grid_lon(i,j)+grid_lon(i,j+1)-360.)
+        endif
+        xr=cos(rlat*deg2rad)*cos(rlon*deg2rad)
+        yr=cos(rlat*deg2rad)*sin(rlon*deg2rad)
+        zr=sin(rlat*deg2rad)
+        xv= x(i,j+1)-x(i,j)
+        yv= y(i,j+1)-y(i,j)
+        zv= z(i,j+1)-z(i,j)
+        vval=sqrt((xv**2+yv**2+zv**2))
+        ewval=sqrt((xr**2+yr**2))
+        nsval=sqrt((xr*zr)**2+(zr*yr)**2+(xr*xr+yr*yr)**2)
+        cangv(i,j)=(-yr*xv+xr*yv)/ewval/vval
+        sangv(i,j)=(-xr*zr*xv-zr*yr*yv+(xr*xr+yr*yr)*zv) / nsval/vval
+     enddo
+  enddo
+
+!  4,  clean up
+  deallocate(x, y, z)
+
+  return
+  end subroutine cal_uv_coeff_fv3
+!========================================================================================
+  subroutine earthuv2fv3(nx, ny, u, v, cangu, sangu, cangv, sangv, u_out, v_out)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    earthuv2fv3
+!   prgmmr: wu                      2017-06-15
+!
+! abstract: project earth UV to fv3 UV and interpolate to edge of the cell
+!
+! program history log:
+!
+!
+!   input argument list:
+!    nx,ny - dimensions
+!    u,v -  earth wind components at center of the cell
+!    cangu, sangu, cangv, sangv
+!
+!   output argument list:
+!    u_out,v_out - output fv3 winds on the cell boundaries
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+  implicit none
+
+  integer, intent(in) :: nx,ny                 ! fv3 tile x- and y-dimensions
+  real, intent(in   ) :: u(nx,ny+1),v(nx+1,ny)
+  real, intent(in   ) :: cangu(nx,ny+1),sangu(nx,ny+1)
+  real, intent(in   ) :: cangv(nx+1,ny), sangv(nx+1,ny)
+
+  real, intent(  out) :: u_out(nx,ny+1),v_out(nx+1,ny)
+
+  integer             :: i,j,i1,j1
+!!!!!!! earth u/v to covariant u/v
+!  j=1
+!  do i=1,nx
+!     u_out(i,j)= u(i,j)*cangu(i,j)+v(i,j)*sangu(i,j)
+!  end do
+!
+!  do j=2,ny
+!     do i=1,nx
+!        u_out(i,j)=0.50*( (u(i,j)+u(i,j-1))*cangu(i,j)+(v(i,j)+v(i,j-1))*sangu(i,j) )
+!     end do
+!  end do
+!  j=ny
+!  do i=1,nx
+!     u_out(i,j+1)= u(i,j)*cangu(i,j+1)+v(i,j)*sangu(i,j+1)
+!  end do
+!
+!  do j=1,ny
+!     v_out(1,j)=u(1,j)*cangv(1,j)+v(1,j)*sangv(1,j)
+!     do i=2,nx
+!        v_out(i,j)=0.50*( (u(i,j)+u(i-1,j))*cangv(i,j)+(v(i,j)+v(i-1,j))*sangv(i,j) )
+!     end do
+!     v_out(nx+1,j)=u(nx,j)*cangv(nx+1,j)+v(nx,j)*sangv(nx+1,j)
+!  end do
+
+  do j = 1, ny+1; do i = 1, nx
+     j1=min(j,ny)
+     u_out(i,j)= u(i,j)*cangu(i,j)+v(i,j1)*sangu(i,j)
+  enddo; enddo
+
+  do j = 1, ny; do i = 1, nx+1
+     i1=min(i,nx)
+     v_out(i,j)=u(i1,j)*cangv(i,j)+v(i,j)*sangv(i,j)
+  enddo; enddo
+
+  return
+  end subroutine earthuv2fv3
+!========================================================================================
+  subroutine fv3uv2earth(nx, ny, u, v, cangu, sangu, cangv, sangv, u_out, v_out)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    fv3uv2earth
+!   prgmmr: wu                      2017-06-15
+!
+! abstract: project fv3 UV to earth UV and interpolate to the center of the cells
+!
+! program history log:
+!
+!
+!   input argument list:
+!    nx,ny - dimensions
+!    u,v -  earth wind components at center of the cell
+!    cangu, sangu, cangv, sangv
+!
+!   output argument list:
+!    u_out,v_out - output earth wind components at center of the cell
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+  implicit none
+
+  integer, intent(in) :: nx,ny                 ! fv3 tile x- and y-dimensions
+  real, intent(in   ) :: u(nx,ny+1),v(nx+1,ny)
+  real, intent(in   ) :: cangu(nx,ny+1),sangu(nx,ny+1)
+  real, intent(in   ) :: cangv(nx+1,ny), sangv(nx+1,ny)
+
+  real, intent(  out) :: u_out(nx,ny+1),v_out(nx+1,ny)
+
+  integer             :: i, j, i1, j1
+
+!  do j=1,ny
+!     do i=1,nx
+!        u_out(i,j)=0.50 *( (u(i,j)*sangv(i,j)-v(i,j)*sangu(i,j))/(cangu(i,j)*sangv(i,j)-sangu(i,j)*cangv(i,j)) &
+!                       +(u(i,j+1)*sangv(i+1,j)-v(i+1,j)*sangu(i,j+1))/(cangu(i,j+1)*sangv(i+1,j)-sangu(i,j+1)*cangv(i+1,j)))
+!        v_out(i,j)=0.50 *( (u(i,j)*cangv(i,j)-v(i,j)*cangu(i,j))/(sangu(i,j)*cangv(i,j)-cangu(i,j)*sangv(i,j)) &
+!                       +(u(i,j+1)*cangv(i+1,j)-v(i+1,j)*cangu(i,j+1))/(sangu(i,j+1)*cangv(i+1,j)-cangu(i,j+1)*sangv(i+1,j)))
+!     end do
+!  end do
+
+  do j = 1, ny+1; do i = 1, nx
+     j1=min(j,ny)
+     u_out(i,j)=(u(i,j)*sangv(i,j1)-v(i,j1)*sangu(i,j))/(cangu(i,j)*sangv(i,j1)-sangu(i,j)*cangv(i,j1))
+  enddo; enddo
+
+  do j = 1, ny; do i = 1, nx+1
+     i1=min(i,nx)
+     v_out(i,j)=(u(i1,j)*cangv(i,j)-v(i,j)*cangu(i1,j))/(sangu(i1,j)*cangv(i,j)-cangu(i1,j)*sangv(i,j))
+  enddo; enddo
+
+  return
+  end subroutine fv3uv2earth
+!========================================================================================
+! /work2/noaa/hwrf/noscrub/yweng/hafs_test/hafs_20211112/sorc/hafs_gsi.fd/src/gsi/general_tll2xy_mod.f90
+!========================================================================================


### PR DESCRIPTION
## Description
The PR adds the new rdas_ua2u.x Fortran utility to convert FV3 analysis restarts containing ua/va winds into u/v winds needed for model restarts. This tool was adapted from [hafs_datool](https://github.com/hafs-community/HAFS/blob/85d914a50ab6f7aacfc2bbc0e99c172d55095d00/sorc/hafs_tools.fd/sorc/hafs_datool/sub_hafs_u_ua.f90).

### Incorporation of HAFS DA Tool into RDASApp

This PR introduces the `rdas_ua2u` tool, which was adapted from the HAFS DA Tool (`hafs_datool`) originally developed within the Hurricane Analysis and Forecast System (HAFS) application. The HAFS DA Tool provides a set of analysis-utility functions, including those for preparing or converting model restart fields for use in coupled data assimilation and forecast workflows.

For RDASApp, this initial incorporation focuses on the UA-to-U/V conversion utility (`ua2u`), enabling the FV3-JEDI analysis restarts to be compatible with the forecast model restarts used in RRFS and related systems. The adaptation involved:

- Renaming and re-scoping the code under the RDAS namespace (rdas_ua2u) for consistency.
- Removing HAFS-specific logic (e.g., vortex initialization, tropical cyclone–related preprocessing).
- Refactoring the driver program to fit RDASApp’s execution model.
- Preserving historical and authorship information within source comments to acknowledge the HAFS development lineage.

Future updates may formalize this relationship through a mechanism such as `git subtree` or a shared “upstream component” model, ensuring that ongoing improvements to either HAFS or RDAS DA tools can be merged more seamlessly.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
