### PR TITLE
Hotfix for determining spack-stack version on Jet

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -281,9 +281,10 @@ if [[ $BUILD_WORKAROUND == 'YES' ]]; then
   if (( $(echo "$spack_minor_float >= 9.0" | bc -l) )); then
     cp ../sorc/_workaround_/saber/Geometry_ss1p9.cc            ../sorc/saber/src/saber/interpolation/Geometry.cc
     cp ../sorc/_workaround_/saber/gsi_covariance_mod_ss1p9.f90 ../sorc/saber/src/saber/gsi/covariance/gsi_covariance_mod.f90
+  else
     if [[ $DYCORE == 'FV3' || $DYCORE == 'FV3andMPAS' ]]; then
-      sed -i 's/128.500001/51.499998/' ${dir_root}/rrfs-test/testinput/*yaml
-      sed -i 's/128.500001/51.499998/' ${dir_root}/expr/fv3_2024052700/*yaml
+      sed -i 's/51.499998/128.500001/' ${dir_root}/rrfs-test/testinput/*yaml
+      sed -i 's/51.499998/128.500001/' ${dir_root}/expr/fv3_2024052700/*yaml
     fi
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -275,17 +275,15 @@ if [[ $BUILD_WORKAROUND == 'YES' ]]; then
   # Spack-stack 1.9 uses a different workaround version
   # Remove me once all machines are updated to >1.9
   modfile="$dir_root/modulefiles/RDAS/$BUILD_TARGET.$COMPILER.lua"
-  spack_version=$(grep -oE 'spack-stack(-nco)?-[0-9]+(\.[0-9]+)*' "$modfile" | head -n1 | sed -E 's/^.*spack-stack(-nco)?-//')
+  spack_version=$(grep -oE 'spack-stack(-nco)?[-/][0-9]+(\.[0-9]+)*' "$modfile" | head -n1 | sed -E 's/^spack-stack(-nco)?[-/]//')
   spack_minor=$(echo "$spack_version" | sed -E 's/^1\.([0-9]+).*/\1/')
   spack_minor_float=$(echo "$spack_minor" | awk '{printf "%.1f", $1}')
   if (( $(echo "$spack_minor_float >= 9.0" | bc -l) )); then
     cp ../sorc/_workaround_/saber/Geometry_ss1p9.cc            ../sorc/saber/src/saber/interpolation/Geometry.cc
     cp ../sorc/_workaround_/saber/gsi_covariance_mod_ss1p9.f90 ../sorc/saber/src/saber/gsi/covariance/gsi_covariance_mod.f90
     if [[ $DYCORE == 'FV3' || $DYCORE == 'FV3andMPAS' ]]; then
-      sed -i 's/128.500001/51.499998/' ${dir_root}/rrfs-test/testinput/rrfs_fv3jedi_2024052700_3dvar.yaml
-      sed -i 's/128.500001/51.499998/' ${dir_root}/rrfs-test/testinput/rrfs_fv3jedi_2024052700_hybrid3denvar.yaml
-      sed -i 's/128.500001/51.499998/' ${dir_root}/expr/fv3_2024052700/rrfs_fv3jedi_2024052700_3dvar.yaml
-      sed -i 's/128.500001/51.499998/' ${dir_root}/expr/fv3_2024052700/rrfs_fv3jedi_2024052700_hybrid3denvar.yaml
+      sed -i 's/128.500001/51.499998/' ${dir_root}/rrfs-test/testinput/*yaml
+      sed -i 's/128.500001/51.499998/' ${dir_root}/expr/fv3_2024052700/*yaml
     fi
   fi
 


### PR DESCRIPTION

## Bug Fix Description

This hotfix changes the logic used to determine which spack-stack version is loaded to copy in the relevant gsibec workaround codes. The previous version did not work with spack-stack 1.9 on Jet which was causing issues with #419 and #475. 

A fix is also included to apply the new gsibec parameters to all of the yamls now that we have added more ctests. 

After this fix, I found that all of the ctests in #419 are passing when updating to spack-stack 1.9 on Jet. 

This should not affect anything on Jet prior to updating to spack-stack 1.9. But I will go ahead and run the CI tests to confirm that this does not break anything on other machines. 

**Description of Current Behavior:**
1. When upgrading trying to use spack-stack 1.9 on Jet, the logic in `build.sh` to copy in the gsibec specific code fails. 
2. The incorrect gsibec files are thus used, leading to mismatches between the Atlas and GSI grids. 

**Description of Fixed Behavior:**
1. The logic in `build.sh` is fixed and the correct codes are now copied in. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
