### PR TITLE
[Hotfix] Remove the diagnostic output files from MGBF 

### DIFF
--- a/sorc/_workaround_/saber/mgbf/Interpolation.cc
+++ b/sorc/_workaround_/saber/mgbf/Interpolation.cc
@@ -48,10 +48,10 @@ Interpolation::Interpolation(const oops::GeometryData & outerGeometryData,
       outerGeometryData.functionSpace(), outerGeometryData.comm()));
         int mpirank;
        MPI_Comm_rank(MPI_COMM_WORLD, &mpirank);
-       std::ofstream file("mgbf_filtering_grid_latlon_"+std::to_string(mpirank)+".txt");
-       innerGeomData_->functionSpace().lonlat().dump(file);
-       std::ofstream file2("model_native_grid_latlon_"+std::to_string(mpirank)+".txt");
-       outerGeomData_.functionSpace().lonlat().dump(file2);
+//       std::ofstream file("mgbf_filtering_grid_latlon_"+std::to_string(mpirank)+".txt");
+//       innerGeomData_->functionSpace().lonlat().dump(file);
+//       std::ofstream file2("model_native_grid_latlon_"+std::to_string(mpirank)+".txt");
+//       outerGeomData_.functionSpace().lonlat().dump(file2);
   } else if (params.interpType.value() == "regional") {
     regionalInterp_.reset(new atlas::Interpolation(
 
@@ -59,10 +59,10 @@ Interpolation::Interpolation(const oops::GeometryData & outerGeometryData,
        innerGeomData_->functionSpace(), outerGeomData_.functionSpace()));
         int mpirank;
        MPI_Comm_rank(MPI_COMM_WORLD, &mpirank);
-       std::ofstream file("mgbf_filtering_grid_latlon_"+std::to_string(mpirank)+".txt");
-       innerGeomData_->functionSpace().lonlat().dump(file);
-       std::ofstream file2("model_native_grid_latlon_"+std::to_string(mpirank)+".txt");
-       outerGeomData_.functionSpace().lonlat().dump(file2);
+//       std::ofstream file("mgbf_filtering_grid_latlon_"+std::to_string(mpirank)+".txt");
+//       innerGeomData_->functionSpace().lonlat().dump(file);
+//       std::ofstream file2("model_native_grid_latlon_"+std::to_string(mpirank)+".txt");
+ //      outerGeomData_.functionSpace().lonlat().dump(file2);
 
   } else {
     throw eckit::UserError("wrong interpolator type: " + params.interpType.value(), Here());

--- a/sorc/_workaround_/saber/mgbf/mgbf_src/mgbf_lib/mg_intstate.f90
+++ b/sorc/_workaround_/saber/mgbf/mgbf_src/mgbf_lib/mg_intstate.f90
@@ -1354,8 +1354,8 @@ endif
 !--------------------------------------------------------
 gen_fac=1.
 !cltorg this%a_diff_f(:,:,:)=this%mg_weig1 
-write(tmpfilename, '("mgbf_tmpfile_", I0, ".txt")') this%mype
-open(12,file=trim(tmpfilename),form="formatted")
+!write(tmpfilename, '("mgbf_tmpfile_", I0, ".txt")') this%mype
+!open(12,file=trim(tmpfilename),form="formatted")
 if(this%l_mgbf_inhomogeneous ) then
 this%a_diff_f(:,:,:)=this%weig_var(:,:,:,1) 
 !cltorg this%a_diff_h(:,:,:)=this%mg_weig1 


### PR DESCRIPTION

## Description
The current workaround MGBF code outputs a number of diagnostic files for each PE. While useful for development and debugging, these files can also make it hard to parse through the run directories and are not needed in rrfs-workflow. This PR removes those output files to leave a cleaner run directory. 

I ran the ctests with these changes on Hera and found that everything passes. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
