### PR TITLE
Safe Time-Window Filters + New Obs-Filter Validator

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_181.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/airTemperature
+             is_in: 181
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_183.yaml.j2
@@ -82,15 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
            filter variables:
            - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/airTemperature
+             is_in: 183
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_187.yaml.j2
@@ -82,15 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
            filter variables:
            - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/airTemperature
+             is_in: 187
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_181.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/specificHumidity
+             is_in: 181
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_183.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/specificHumidity
+             is_in: 183
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_187.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/specificHumidity
+             is_in: 187
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_181.yaml.j2
@@ -78,13 +78,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/stationPressure
+             is_in: 181
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_187.yaml.j2
@@ -78,13 +78,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/stationPressure
+             is_in: 187
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_281.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_281.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/windEastward
+             is_in: 281
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_284.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_284.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400 # combined obs spaces -900
-             maxvalue:  5400 #                      900
+           - variable: ObsType/windEastward
+             is_in: 284
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_287.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_287.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/windEastward
+             is_in: 287
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_airTemperature_120.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_airTemperature_120.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 120
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_airTemperature_132.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_airTemperature_132.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 132
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_specificHumidity_120.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_specificHumidity_120.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/specificHumidity
+             is_in: 120
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_specificHumidity_132.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_specificHumidity_132.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/specificHumidity
+             is_in: 132
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_stationPressure_120.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_stationPressure_120.yaml.j2
@@ -78,13 +78,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/stationPressure
+             is_in: 120
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_winds_220.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_winds_220.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 220
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_winds_232.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_winds_232.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 232
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircar_airTemperature_133.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircar_airTemperature_133.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 133
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircar_specificHumidity_133.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircar_specificHumidity_133.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/specificHumidity
+             is_in: 133
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircar_winds_233.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircar_winds_233.yaml.j2
@@ -89,16 +89,16 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
            filter variables:
            - name: windEastward
            - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
            - variable: ObsType/windEastward
              is_in: 233
            action:

--- a/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_130.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_130.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 130
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_131.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_131.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 131
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_134.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_134.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 134
            action:
              name: reduce obs space
 
@@ -175,6 +179,8 @@
            where:
            - variable: QualityMarker/airTemperature
              is_in: 3
+           - variable: ObsType/airTemperature
+             is_in: 134
 
          # Error inflation when observation pressure < 100 hPa (read_prepbufr.f90)
          - filter: Perform Action
@@ -187,6 +193,8 @@
            where:
            - variable: MetaData/pressure
              maxvalue: 10000.0
+           - variable: ObsType/airTemperature
+             is_in: 134
 
          # Bounds Check (ObsError)
          - filter: Bounds Check
@@ -214,6 +222,9 @@
          - filter: Variable Assignment
            udescriptor: "create_temporary_ObsErrorData"
            apply at iterations: 0,1
+           where:
+           - variable: ObsType/airTemperature
+             is_in: 134
            assignments:
            - name: TempObsErrorData/airTemperature
              type: float
@@ -240,6 +251,8 @@
            - variable:
                name: ObsErrorData/airTemperature
              value: is_valid
+           - variable: ObsType/airTemperature
+             is_in: 134
            defer to post: true
 
          # Set ObsError set "error parameter" if > "min value"
@@ -258,6 +271,8 @@
            - variable:
                name: ObsErrorData/airTemperature
              value: is_valid
+           - variable: ObsType/airTemperature
+             is_in: 134
            defer to post: true
 
          # Gross Error Check
@@ -270,9 +285,10 @@
            action:
              name: reject
            where:
-           - variable: ObsType/airTemperature
            - variable: QualityMarker/airTemperature
              is_not_in: 3
+           - variable: ObsType/airTemperature
+             is_in: 134
            defer to post: true
 
          # Gross Error Check: cgross*0.7 if QualityMarker=3
@@ -285,9 +301,10 @@
            action:
              name: reject
            where:
-           - variable: ObsType/airTemperature
            - variable: QualityMarker/airTemperature
              is_in: 3
+           - variable: ObsType/airTemperature
+             is_in: 134
            defer to post: true
 
          # Re-assign err ObsErrorData <--- TempObsErrorData after gross error check.
@@ -303,6 +320,8 @@
            - variable:
                name: TempObsErrorData/airTemperature
              value: is_valid
+           - variable: ObsType/airTemperature
+             is_in: 134
            defer to post: true
 
          #- filter: GOMsaver

--- a/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_135.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_135.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 135
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_specificHumidity_134.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_specificHumidity_134.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/specificHumidity
+             is_in: 134
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_winds_230.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_winds_230.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 230
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_winds_231.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_winds_231.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 231
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_winds_234.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_winds_234.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 234
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_winds_235.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_winds_235.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 235
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/msonet_airTemperature_188.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/msonet_airTemperature_188.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/airTemperature
+             is_in: 188
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/msonet_specificHumidity_188.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/msonet_specificHumidity_188.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/specificHumidity
+             is_in: 188
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/msonet_stationPressure_188.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/msonet_stationPressure_188.yaml.j2
@@ -78,13 +78,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/stationPressure
+             is_in: 188
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/msonet_winds_288.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/msonet_winds_288.yaml.j2
@@ -50,8 +50,12 @@
          # Mesonet winds provider/station use lists
          - filter: RejectList  # initially reject all providers
            udescriptor: "initial_reject_all_providers"
+           where:
+           - variable: ObsType/windEastward
+             is_in: 288
 
          - filter: AcceptList  # accept back selected providers
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -64,6 +68,7 @@
                      "OK-Meso","MesoWest","WT-Meso","WYDOT","NOS-PORTS",
                      "NOS-NWLON","GoMOOS","HADS"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -75,6 +80,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["AFA12","AFA09","AFA01","AFA11","AFA06","AFA03","AFA02","AFA04"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -86,6 +92,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["APG4","APG9","APG1","APG7"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -97,6 +104,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["C5674","AR622","C4709","AR986","C5444","C4827","AR784","C3771","C8843","C2876","C5272","C6207","AR743","AR983","C3518","C4488","AP121","C1470","C4014","C4183","C8715","C8427","C5804","C7467","C7070","C1456","AR701","C4887","AR581","C7966","C8358","AR671","AS402","AS459","AS549","AR104","AS457","C7511","C5590","AP133","AP513","C8607","C8839","C2024","C5210","AP228","C4409","C5817","AP051","AR477","AP750","C6892","C6980","C5286","C1943","C8659","C7902","C2077","C8198","C5092","C6113","C4264","AS307","C6988","C5376","AR778","C2512","C3353","AP837","C2283","C2716","C1780","C3212","AR690","C1112","AP156","AP991","AR808","C3444","C4434","AR652","AP555","AR934","AS677","C8290","AP189","AR697","AR731","C2824","C4564","AP899","C3966","AS386","C7197","C4672","C0646","C4358","AR231","AR834","C7975","C4510","AS291","AS405","C7637","C1403","C2988","C7524","AS659","AP075","C4265","C3456","C7881","C0773","C4411","AR320","AS268","C2049","C6028","C1002","C2659","C0168","C3063","C3603","C5517","C6356","C6840","AS612","C7960","C4925","C7160","C5834","AS106","AR147","C0013","C3628","AR740","C5761","C4197","C7609","AP200","C1521","AR910","C3640","C3822","C4845","C6027","C8235","C8028","AR464","AR850","C6278","AS478","C5129","C7477","AR897","C2112","C4210","C5283","C0198","AS061","AS235","C0310","AS470","AS294","C6413","C6434","C8083","AP430","AP192","C5110","AS311","AR624","C8539","C1130","C2841","C6257","C7400","C3842","C8288","AR313","C0121","C5490","AP059","AS236","AP352","C0562","C3484","C3157","C4237","C5801","C4416","C6995","C7403","C4453","C4541","C1404","C8241","C7286","C8665","C1824","C1792","C0988","C2665","C5467","C5549","AP996","C5485","AP024","AP559","AR692","AS702","C3234","C3607","AS586","AP323","C5928","C3183","C5818","AS303","C7118","AS692","AS239","C2218","C4661","AP386","AP852","C3205","C2140","AS661","C8122","C4605","C1662","C4566","C7275","C8717","C1484","C3109","C6099","C2420","C2670","C2678","C6486","AS509","AR770","C2462","C3702","C4428","C5772","C5262","AP539","C7445","AS583","AP710","C3189","AP979","C6488","C5599","C4954","C6445","C6532","AP587","C5881","C4766","AR992","C0136","C4645","C5896","C6696","C7327","C7785","C7930","C8067","AS654","AP216","C2635","C6410","AR677","C6384","C5165","AS707","C8517","C2553","AS140","C2101","C4420","AS732","AS125","C5920","AR814","C3340","C6277","C3375","AR277","C0527","C7610","C5520","C4821","C2755","AS350","C8608","C8864","AR864","C6247","C2398","C8488","C5768","AR831","AR943","C1500","C1982","AP260","C7381","C5652","C7866","C7794","C8688","AR672","C5738","C4173","AP072","C6284","C8046","AR172","C4719","AP902","C4900","AP044","C3806","C6822","C6873","C8003","C8743","C8635","AP517","C6620","C0803","C4835","AS279","AP330","AS545","AP071","C7761","C2209","C8830","C2789","C1104","AS701","C4329","C6108","AR138","AR750","AS406","AR942","AS226","C1248","C2568","C5176","C5880","AR841","C4349","C6147","AS461","C4855","AS688","AS676","AR684","C1331","C5049","AR666","C6612","C3154","C3931","C3414","AS441","AP682","AR773","AS296","C4880","AR659","C1775","AS257","C1123","C7003","C6944","AR854","AS070","C0288","AS500","C7667","C2006","C8738","AP859","C6622","C7832","C1621","C5488","AS582","C2715","C0677","C4115","AS202","C3407","C3833","C0222","AS716","C8220","C1450","C7633","C5951","C4199","AR598","AR758","C2069","C3712","C7955","C8810","C0160","AS593","C8361","C4554","C6357","C5598","AS436","C3670","C4840","C6917","C1334","C3379","AP894","C0636","C4367","AR525","C6777","C6817","AP061","C1052","C1999","C8190","AR259","AR391","AP165","AP122","C3750","C1732","C1749","C3459","AR727","C5084","C3438","AS440","AS712","C5040","C5595","C5972","C1323","C6884","C7234","AS617","C5632","C3320","C2857","C0162","C6245","C1789","AR918","C2562","AS495","AS044","AS520","C7857","C0572","C5471","AP689","C4184","AR853","AP769","C2787","C7607","C7741","C6633","C5482","C5437","AP291","AS547","C7939","C8592","C7933","C8026","C4669","C5464","AR816","AS041","C4838","C0922","C0181","C3722","C6848","C2258","AP221","AP895","AR914","C2840","C7260","C8782","C3639","C5504","C5616","C2920","C6043","AP201","C6887","C8849","C2434","C7273","C5183","AS313","C8632","C3934","C4262","C5103","C1840","C3200","C4299","C3236","AS539","AS609","C8728","C8842","C2912","C6135","C2534","C5849","AS591","C4614","AR747","C7784","C8343","C1020","C6937","AS292","C7945","C0752","C6311","C7293","C0453","C2995","AS237","C2951","AP244","C3292","AP734","C2627","C2943","C4691","C5029","AR237","C2003","AS329","C1622","C7710","C0757","C0451","C4113","C5970","C6829","C3261","C1259","C0228","C6728","C6725","C0930","C5270","AR786","AS463","C6969","AR718","AP818","C5466","AS614","C5344","C0213","AR663","C1701","C3837","C3926","AS542","C3235","C1795","C7527","C7759","C6720","AP551","C5786","AP601","AR430","C2094","C3742","C3655","C3213","AP126","C8232","AP542","AR516","AR191","C4767","C7921","C4921","AS618","C3250","C3323","C3071","AS054","AS326","C2978","C4185","AS717","AP904","AP912","C7707","C8373","AR801","C6895","C4448","AR284","C4939","AR931","C5719","AR509","C4525","C0900","C6558","AR906","C1837","AS167","AP241","C8256","C8685","C0732","C6267","C7060","C6803","C0508","AS314","AS327","C7718","C7369","C2247","C6304","C4586","C7077","AS045","AS727","C4679","AR585","AR358","C0458","AS064","C2280","C8856"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -108,6 +116,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["TER","LOF","IDA","RIC"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -119,6 +128,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["JKLNH","FRBRG","ATF29","PROUT","SSKTN","BMMNT","CVLTN","DEPEW","LITHS","MRIDN","VNNVA","CLIFT","PLNTT","PMPTN","MDRBC","TAYLR","ONSID","OMAHA","BEAUM","SANTN","CLMKS","KTHVL","LGNNG","GRNTT","LKLML","DALLS","RICMD","RONDV","WOBRG","THRNW","BALTN","FRLWM","TWNCR","HMOU3","SRFLD","TMWTR","NWHIT","SMTHV","SNTNO","HALFX","HCKTT","CPLAY","ONIDA","DUBOH","MLVEN","WCYBT","AIKEN","SHERM","NNSNV","BTHBS","SOMST","FMCNR","FSDRC","SLFDP","MMGRD","FLFRD","BSO03","DLND3","HLDHP","KHEAH","MRTNG","REDWD","NWHLP","MNOKA","COLOR","GDNGS","DNTNP","AXDRA","TFTCN","GALUP","WJRDN","CNTRY","SHEFF","SENSE","DUNCA","BGSND","BUDDY","HNCDL","PRTTS","GRMCG","KNGSM","ORLDO","ASTAG","PHCHS","GLMRG","CARTN","FLMTH","WKVIL","GRNDI","CRVFR","FORFX","TZWLL","DQUOI","GLDMD","DLRYD","PFDRK","DURNE","NTBND","WSHNJ","WHTNY","MARIC","HNDRT","WLSON","CHTNA","WHAVN","FREDC","MTHIN","ELBRN","RHIWY","HALTN","KGGES","VMCSN","BRMPL","RCKTM","SPEED","STVNO","RYRSF","HNVSL","PLNCP","BLMBL","CINNT","PLANV","BTPRM","SCOTT","SAPNG","MNREW","BBLKE","GSLNE","PTINE","BNSRS","DMSCS","BYRM2","PDNCT","DHRLT","RLGH2","CNLMS","CANBY","HFMHE","SYMSJ","LNFR9","ELWOD","AKRNL","MRTRV","HBBRD","HENSN","CHRCH","LVWTH","MEXIA","SANAO","WYLIE","PALSD","AZLTX","KRKBC","PHBOB","WSTJR","MYFLI","PITTN","A0045","RCHMB","PHLDH","MRRRV","JLTNS","HLLFR","STNTV","DBLNS","GSNAV","FMLCM","STFFR","KACHS","CUERO","HWKSH","BNTNH","CISPK","LBLLC","LNF45","KNNTT","ELGTX","TXRKN","RSSLL","VCTR1","BITOL","MORGN","RISTR","CRLLP","XLLMS","OFLLN","KSTFE","AMERY","AMRGS","STHJN","PNCTY","AUBUN","CPEVA","KESHA","LOCUT","BRKLI","LMNST","MMRMS","SLSBR","RDNTH","MZTGM","CRRLL","ASTAK","DLND1","MCCAL","ORTNG","JTMRH","SHNNH","WTRLC","HSSVP","KFDMT","PLSNJ","GRHBL","HRNDN","PDERI","WYNSB","SSSXW","ASHNN","MNNON","CLUBA","PTTSH","FRMYC","SNCPS","HRTWD","KNSMK","MLLCT","SVSPR","WSTNN","KLLES","DNEMR","BKNTZ","KTVKT","HDRSN","SWANS","WLDOR","MNTBR","CRDVG","NWTNC","OKSBA","VNDLC","BLMRB","SNHMB","FRLCC","CORON","SANTP","CHMPL","CLLYV","SBSTP","GWUNI","NEWCS","BNKRH","OCCTE","CHGPS","LNGGR","MSTIC","HNDFC","GAIBG","MMIFL","URBNN","LXNGN","BEUMT","LLMCH","VIDOR","FYTHS","GVECG","MPHS1","KLLMS","MOSSY","VGHN1","LBNNP","BRNTS","WNNVG","BEMA1","ANNEA","NOLSM","HSTKM","TLASS","STANW","PHELN","KDESG","FRTSG","DNDRN","ESTCH","VLNTW","CCHTT","CLYMR","ARPJH","CRSTV","BRDNJ","DNTNC","NWMRT","NVHVN","WLLST","BTHPG","FRDRD","DNVAL","TRNVS","PRSMC","SHLIS","JAYOK","INGLS","GRNBY","BLAIR","HBGIL","MAMIF","MOORE","RVRDG","BRMNG","CONTY","LILLI","SYKEV","WRNSE","SMMRV","EPLST","LVRCC","ATHEN","LUMBR","DETSC","NWTLD","KIIGS","CRSCS","CLDGE","HAVDG","MILVP","PRINC","ROMPA","CHTAN","WRWCK","FRDNA","NMTHB","CRMXL","HCKY1","RCKHL","HRNLK","MNKHN","BWCCD","SANDG","ARLNX","SNNWS","DLTON","RPLEY","MTRSN","WHTSV","HOBBS","MVSTA","WREGT","JEFFR","HYMRK","BELEV","FRDDC","LNCJF","SGRLF","SIMIV","CLEBE","BNSHS","EDONO","EWING","FRSBG","GLFRD","WODBG","WLWMS","MNTST","BCKNL","RIPTN","BUNNB","BURES","DVHCC","JCKSO","OWHMP","MTCHN","ASHBN","CSHRE","CULAL","ELZTN","NWBLM","UPPER","WRRNG","KNNPL","SMMTS","ALGNQ","BTTLB","PLVRN","LNRCU","PWTCS","RBBPH","FXBCV","MDTWN","AEXDR","A0020","NCKLS","STTLC","WNDMH","MASNC","MTBRD","MONEV","ELYNV","FLFRS","SLIDE","ELMSF","HSSLS","CLESP","COPLY","FALWR","LUMBE","GRVLL","PCNSM","WSTCI","LFRST","FRMNT","HMPSH","LONGD","RCESS","RCKTC","MILVL","WALDF","ALPLT","GALIN","PTESN","KNXVN","TMPSH","DLTH1","ASHRB","BEAVF","LALTO","BRSRS","TCMEE","MDINA","GRNLD","MODST","GRMBL","BMNBS","NPVN1","BTHLC","LNGLV","JCKHS","GREEL","MANFD","ESTRC","GRNSD","AVPGS","WSTDN","GLFNC","SEEKO","MCHPC","GGHRB","GTHBG","UNVRS","DPONT","RDFLD","PINEB","WLLWS","WURBR","DGHTN","PHLLL","MRTVL","ANDCS","CLMSD","FBGMC","KCLHS","MRTVM","RMSRM","ESTNP","FRSTG","BINKR","BRMDN","HCKRY","WETVL","CHEEK","TMBS7","RNBRN","JCKJR","RLDMN","CLVLN","WSHVG","PNXST","STBEN","GSCRK","CNGFL","MMMCH","CCCWS","PRTHR","MINNP","SMVWD","PARIS","WSHVL","MNWSH","WHATN","STAFF","DEWYV","ELPRG","WDWRD","ALVRT","MPLRG","KMOMS","LULNG","STTL1","WWBTV","FAYET","BVRTW","ROCKW","HRTSD","FRASR","LNSDL","CRSRV","CSPRG","EPRVD","CRLSC","SLMSP","CLWMM","TRMNF","JPPRN","DVRDH","ALBNY","OLDTP","RVRTN","FRRMF","CRKCT","SHRDN","BLSML","ASIND","CLEGE","STCLR","MANA2","HRTWL","BRPRS","VHSNA","NWEGT","STRTT","OLDFR","SLTNG","THMSC","PITT2","JMS03","SNRSC","WODBR","MNCRN","AVLCS","STLGL","GRVPR","SLSBY","WHRTN","BRWST","LSCRG","WSTPR","GRENR","AIKN1","SCTPL","CLNCL","WLKSB","RSMVA","DTMON","NATCT","HOTFR","SLMSH","SHLLL","WAVYT","JCKGP","RANIR","LCSTR","GVILL","SPGKF","AVNMT","CLPPR","MANHM","REDNG","RCHM2","NRWLK","PRBDN","RSVLL","FDRLW","OPRKN","RYNLD","NWRKS","VLNVH","CHVVS","WSTWN","LRNBG","SCCSN","GSTNA","LORTS","RCHBO","IMMKL","HOMLA","TNKHN","AMNAD","CRPWL","CABRD","MDLWS","CMPEM","WSTPN","CMBRK","ANNDL","WDSTK","BRWCK","ARCHS","LNF20","QNLAN","LNXBC","YLNC2","CHRNC","JECTY","LXTON","SHRWD","SLCUT","JNCTN","WDBJT","KGCBS","FTWTV","ELPRS","BOAZ1","WHTPL","NEWCN","BURNE","BXLDR","STPHN","VSLLS","LNDNN","YNGSJ","BRGPS","BTLCH","GNSCS","HRNVL","BRENH","GRNDO","ISSQH","MCCLE","MSSMC","PNBMC","HSHBY","HANOV","HGHPN","WHTVL","KUHES","RRNCH","SANTE","ONLGO","LARTY","CORFU","MILFL","WYSBO","CSTLW","NWMLF","WILMD","WRRNW","LHGTN","ORGTX","GLENW","NSTHB","WRNBG","SLNSC","HJHSB","APLMD","SDNBL","BULRD","GNIST","HAMLT","BSSMR","CRAIG","MNTCP","BMSPT","AUGDC","URBAN","CHTMG","WATGH","VRGCH","OCNCT","DPKNY","TACOM","SARDN","SNDYC","BRBYS","MMLMC","STLMS","REDPB","CLNLH","KRKLN","BSHPR","PNGCH","CFDPT","DTNTN","HUMHS","WDSWH","WYTHV","MCNCO","RRHMN","NRUHS","MARHU","LNGMD","STRSM","CPCOR","MIDVO","CLRWT","COVIN","TLRSS","SLMNC","ODNVL","RDMND","SPHSC","BRMRT","VERON","MAYVL","PNRGY","HRWNS","WURFR","CETRS","MPLWE","MCKNN","MCNGI","MTVR2","NEWBM","ARNCC","MMMDC","CHMBR","VWCCO","SPJDF","SMTHB","RYSFD","BLKVL","KHDHA","LAFYG","CMARN","CMDAR","FRFPW","CTVIL","MDSON","MNRVL","STORS","OKDL1","HRNLL","GLDSB","RLGH3","TLAHS","OPLCK","PNNNG","BLLVV","ALSVJ","MARRE","SCRON","HAGRS","SHBAB","STTMS","LODIM","ORNGF","ALDNA","CLMSC","CLMNS","BNGMN","LMNGR","SFFRN","CHPSB","BUMNT","LESSC","BRDFD","HAMLN","MANAS","GWNDA","CHSTS","PLMGV","CLNCP","OXFDN","CRLSB","SLDSM","WLLWH","CRTSM","BLMBH","WXYZT","CALFN","DTRED","TMBRK","NALSC","WHLRV","FRNDL","BYCTY","COVGT","MNSAS","WSTGV","CMLLS","BSDGT","CHRLR","MTESO","MNSS2","WTMTR","DCHEC","JCKHP","RMGTN","BATVL","MTQCR","DRSDN","ANSNA","ASHLY","DRRYN","MORTN","PROPL","LNCTN","CHSHS","CNPLS","LKWDW","SMRIA","LSCPA","ABONY","DKLND","SRTHF","ALXXD","SLSWM","DPSAR","NAPBS","OCCAL","LSBBL","WBNST","NRWDQ","WPSMH","DRPKN","NWHPR","ELLEN","WACO4","FTWR2","CHRTT","HKSTN","MYRST","ROMLS","NRTHJ","RSTRT","NESMR","MPTPR","KYHCC","BCYRS","SHNTN","ANTCH","BMNTR","MDWAY","BLMNT","LBNON","BFFLO","WDSTW","CLMBN","NPLSD","LEBNO","ALAP3","FRWSB","ALAP1","HUMBL","PTFSB","LRLJC","WRGHT","MARON","DCTUR","HRMTG","LVNMM","NFAIR","MYFLD","CAYGA","FERFL","FSLKE","SNJNC","JCKNO","MECNC","CHRLG","RLGH5","PHLDD","MNSSN","SLVLN","DRHMC","GNLCM","RNRMS","HAMOK","OSMNN","CPERL","RDNLP","ELKTN","WGGSC","CHRTY","BRSHM","ESTHR","LHSAL","ARRAN","APTS1","CONRO","KBBEJ","PNMES","DECAT","SOUDR","MRTHN","BRTWW","CRNDL","LRAY1","ESTHD","CHRON","SOLHS","GLDSP","STNWM","RSPFP","CHEKT","JMS04","BRTLS","RNTON","WNNMC","FFFMN","BRN01","KSTPT","BRDEN","SCHOL","NGMSS","BNLVL","EPHRA","MDLTV","BDFPV","CHPLH","MMLTN","BWLIG","LRTTC","PNTG5","LNGMP","CLDNY","HLLSB","GRNLN","FRCKP","BLLVU","CMNSL","MDLTN","YARDL","IMPRL","HSTN0","FRTGB","TRTLK","CALIF","FRNKV","OKDLE","LHMNL","BFLCH","CHYNY","WODBY","WNNFL","SETLE","LAGUN","HLLRD","PHILP","VNLND","GSHNJ","GRVSB","HRMNS","NWMDD","KIRBY","LKWLS","LAPTE","HWLND","CRSFL","RRTNN","UPTME","ABNHF","NAVAS","BLLMM","ESHBR","SHAKO","KSHRM","SGRNG","IMSVL","PELIN","PORCH","SCHAU","LKVLL","ELLNV","TRNLL","MIAM6","CYPRS","TCMWA","DRCHS","WLTRB","GLNRC","CRVST","KJOSC","KRMLG","WLSNC","CPRSS","PLMAL","RICHL","WSTMM","CPRVL","MTNWA","GLLWV","PNTGR","MLFHT","RYRFR","MNLSF","FRCST","CPDRL","CHHLS","MNTNC","RSTON","THPLN","HRRDS","HEGNS","JONES","WTFRD","SNDG1","ATTCA","MSSPQ","NLNDN","BRWNS","LHGHC","FT1MT","LRLHL","WTVQT","DLTPC","LKBNV","STHNG","MNRCM","CLRAH","LANGL","BFFLS","BONHM","MARLN","STBRG","GENEA","TOMBL","KNWAT","AUROH","WLMSV","NEWTN","JRMYN","BRDMN","FMYSN","MDSN1","VCHMN","DBNNW","STHNR","CRNX1","RCHWR","SNDI0","BLLVS","MCGVL","EGLRV","CMPBL","JZLTN","LEROY","BNTSL","PRRRY","NPRVD","CHRHU","CLWST","EGLNS","BRNSW","HILMR","LNXHS","CDDML","EURKB","SLNSA","PRTBY","FRSTB","FRDMY","SBS02","MNCNS","ELWRT","FMNTN","STLFC","EDNBR","TRFLG","BGLSB","SPRCT","HRHES","WFORT","DMOND","LIZTN","YKSHR","CHALS","SWFTW","WLLBG","AQLLI","GRNS1","NSTHH","HDLRD","PRVON","BFFLM","KWIES","MRCRS","PLMTT","PGHKA","JSTON","FRTDF","NAPA1","LCKPT","MERDN","POWHA","WNTZV","TOPKA","WTTRV","PLMTS","RSFRD","CAPCL","FTBCM","DISPT","NEWWM","MRAMR","APXNC","MIDBR","SPIGN","LEBON","QUAKT","FPDPT","SLLVN","TRYBU","JMS02","PHNSM","CESSC","HRSHM","CLFCO","POETT","BTHLS","BRNTW","MKSCR","ACMRS","BRUSW","NAMSS","WWLPG","STRLI","HGBRD","RCHST","NPLSL","CHRRS","FRMDD","CHRVL","PCHUT","KLEIN","MTENT","ABGTN","GUILF","MIAM2","RLGH1","TCMMF","WZVNT","MSHWL","BOLVR","OKFLD","GRNDR","LTHM1","BEFFL","PRNCS","BDFDV","WRWRG","WNTRE","FREDT","MKERK","NWTON","RCHDL","RSNGS","WAVRL","NSTSU","CRNNB","PWTCK","ESTFR","NWDST","WLDNP","DNSPS","BRDJW","SLDNR","ASHBR","NRTHU","MLTNL","NVADA","RSNRS","DOLPH","ELCTV","GBSNA","SAVTN","MNTVN","BTHMY","SMTHF","LESSF","MRCIL","CRSPO","SEAWR","SNJSE","NRTHR","A0031","LXNPP","CLRPH","MATLD","GSOCM","ASHSH","HSLND","PCBCH","WHTHL","MINLA","SRCHL","PRRV2","SPRHE","SPGDL","WWLPW","HLMSB","DNSTJ","CRTLS","SVGRD","AHSKE","MNSMF","VCLRV","ABRNS","BLAIN","LNNLN","BRSTW","FRANK","WKFST","WSWEC","BSO02","PRCSD","LSBES","DLVL3","CAPCO","ULYSS","BKFLD","EHAVN","KSSMS","OKLYV","MSCWL","JSPER","STHDY","WLMNE","EVJHA","DLLWY","DCECX","AKRNB","OSCLA","LANDO","DANVL","PTSTW","SYRCS","SLMCC","KNGWL","GRDNC","BRCKP","UNVPL","MARNO","CLMSN","RALGH","MNMNV","CHRDN","FRDBG","HMDEN","MRMAR","LAWNC","FRMNJ","DDLEY","WESSN","TACPE","WHNT2","DOYLT","MCHVL","WTRTN","ESTRR","MDLJR","NWTN1","PKTNN","JKKSN","NWIVN","PRRFR","MNNDR","BFMMA","OCCTY","OLYWB","ANDRW","CMBDC","KETUM","BNNYL","WLLWP","MSHIM","DIMCK","HFFMN","ALFRD","FLMDT","A0082","CRNLS","SEEKK","TKKWL","HGHSV","JSPRH","RSFHM","YANKE","MDGRD","WSTGR","PUALP","KNTWA","TACMA","HIGDN","OLDWS","DTRTV","RTTMN","WALLR","HESPE","WTNHT","HNVRT","ASTRA","FRKNN","MDBJH","BSO07","SARVR","ESTHS","CNTPL","PACSC","OKHRB","CAMAS","BRWLL","CBANY","MNTPL","BTHHA","DACSC","OFLCS","ROCHE","OZRDC","THMLM","ATOWN","GGAPL","EVADL","KUNTZ","MINRL","WNSKT","SLTHL","DNDNN","LGNTN","HLLRT","RLGHD","LXNGT","BRESC","RYREV","RBSNC","FWOTH","TCMAW","ALLNN","ATTLL","BOYER","UNVDE","JIMLW","CHNTL","WLCTT","LKWDA","CRMEL","SNYVL","CUMBR","OLEAN","SPGVL","PIRSN","SPNDR","HUTSV","NEWNJ","CLLMN","SHPBG","ETNVL","OTHLL","MOSCW","LXNGS","NTCHZ","GBFHP","NBUOH","ALTMN","MANSF","MDDON","STHLD","CENSQ","CHTTN","SBURY","MCHNC","VNCMB","NRTBY","DFBS1","PHLFF","DLND4","SMSTX","BBRNC","ALLCS","CHATT","HAMBR","FLKVL","GULF2","ELBAC","GBORO","WSTPA","MRRRJ","SLDAD","LYNJS","WRWNY","NORWH"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -130,6 +140,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["AW314","AW281","AW381","AW233","AW345","AW213"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -141,6 +152,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["CAEGE"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -152,6 +164,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["CO102","CO006","CO001","CO103","CO096","CO104","CO066","CO020","CO071","CO095","CO089","CO008","CO084","CO067","CO097","CO065","CO099","CO073","CO072"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -163,6 +176,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["PATM1","DANM1","RGLM1","ISPV1"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -174,6 +188,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["DC008","DC001","DC010","DC009","DC003","DC006"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -185,6 +200,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["GA109","GA113","GA114","GA104","GA103"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -196,6 +212,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["KCO0","KSYF"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -207,6 +224,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["44037","44029","44034","44024","44030","44035","D0201","44031","44032","44038"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -218,6 +236,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["MRVA1","OBII2","OLCN6","SXHW3","BSBM4","SLVM5","CLSM4","JAKA1","LOKI2","PNGW3","WHRI2","SRDI2","OTNM4","RPRN6"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -229,6 +248,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["RBFI4","RLEI4","RIAI4","RCEI4","RWII4","RDVI4","RDCI4","ROSI4","RSDI4","RDWI4","RDSI4","RCAI4","RFDI4","RMCI4","RTOI4","RTNI4","RONI4","RSYI4","RSBI4","RSLI4","RMVI4","RMQI4","RAVI4"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -240,6 +260,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["SCSI4","SPYI4","SAFI4","SGMM5","SGRI4","KKAS2","PESS2","SSAI4","SFAI4"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -251,6 +272,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["IN001","IN009","IN014","IN008","IN004","IN002","IN016","IN018","IN005","IN013","IN011","IN015"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -262,6 +284,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["NWTC","SRRL","CSUF"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -273,6 +296,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["K1EGN","K5KSM","K5EUR","K5EHT","K5KIO","K5ED7","K5OK7","K5LEA","K5WKY","K5WSU","K5NES","K5SLN","K5PEA","K5BCR","K5FRD"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -284,6 +308,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["LHSCA","CCOCA","BBYCA","CCLCA"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -295,6 +320,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["MD020","MD040","MD054","MD038","MD043","MD018","MD012","MD011","MD037","MD027","MD029","MD004","MD023","MD016"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -306,6 +332,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["MN011","MN035","MN037","MN010","MN095","MN024","MN032","MN091","MN086","MN080","MN015","MN008","MN025","MN014","MN057","MN082","MN029","MN076","MN018","MN044","MN052","MN079","MN045","MN059","MN071","MN021","MN026","MN038","MN043","MN036","MN030","MN075","MN042","MN096","MN022","MN065","MN007","MN084","MN063","MN028","MN033"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -317,6 +344,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["MOA14","MOA05","MOA06","MOA04","MOA01","MOA03","MOA08"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -328,6 +356,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["DBLN6","46012","45012","44044","MBLA1","45132","42003","LJPC1","41048","46027","44041","46091","LKWF1","42040","42019","PILM4","46026","45001","44017","45007","44007","44029","TPLM2","41025","CBIM2","46050","46147","PLSF1","41008","46047","45137","41046","46088","NPDW3","45135","THLO1","46005","KS063","42020","41013","42055","44053","CLKN7","44011","44030","46145","46059","41009","46092","SRST2","44150","CDRF1","42001","SBIO1","41010","LKPL1","44043","GDIV2","46025","44009","46093","SAUF1","42039","46131","42036","41012","FBIS1","44018","42035","SGNW3","45140","45004","45008","45006","41035","46233","46014","42002","45143","SYWW3","46029","45147","46022","SGOF1","42364","46013","46053","DPIA1","45139","46207","42056","44031","LONF1","TIBC1","KNSW3","41036","MHPA1","AGMW3","44004","KS057","CARO3","GSLM4","44038","44013","ABAN6","45005","44014","ACMN4"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -339,6 +368,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["CQ082","QSF","DSTU1","CQ089","ITD22","E5POR","QHW","TVANT","CQ148","JHR","TBLEW","KFCT","TIM60","CQ071","PYRLK","TSHER","CMP12","IMBO","TSUMA","A28","TSUMT","TCAND","MNDN8","GERW","MSCM8","CQ062","WRUN","TCHEL","QB4","HFRNK","CQ160","TLAUR","FOGO","TEAST","LMS","AAWC1","LFPBO","TSELL","ODT06","DPG20","ITD33","TBAIN","K4S1","TWHIT","CLR18","UWASH","MLAM","TOYST","ODT54","E1BEN","E9GRA","TKNAP","COVM","AWSC1","ENUMU","HHAMR","MKAR","SIGM","CMP23","CQ112","WGHA3","LIDW","CQ084","MARC","SEEU1","CQ098","DPG23","CTFPE","GFRI","RICH","MSWN","CQ063","DYER","TANAC","UP104","RXGI","CTHLT","SDMGR","WHALE","UT26","UP439","CQ035","ITD27","QWJ","A30","UTGRS","POR","UP353","UP459","UT23","MRSO","MESX","ITD41","ACOC1","STG48","ITD42","HRHW","CTANT","GUNN","CQ133","SEABE","OPH","ODT36","CLR17","MLPS","LYN21","T130T","CQ136","CQ060","DRLM","PICI","DENI","UP143","UP417","MWQHR","CTFYP","TI182","HRSPG","PTRCA","SDPOY","ODT20","ODT62","HRING","DPG05","DPG18","UP222","SDAPN","DEABT","HWYEB","CQ158","ODT33","TWALK","KCWU1","ODT01","ONTO","TACLS","HARMY","UP007","LDDW1","FALN","UT12","PCS","CMP04","CMP16","H200W","LDSM8","LVHF","RRWO3","SDPMS","RPTI","MNNM","CQ106","MYRI1","UP073","TSAMI","CCD","QRMO3","DPG04","PEN","SDHTB","KBDN","SUNUT","RDN","DPG12","HEDNA","TMARY","KQML","QHV","CQ178","MALI","TBLAI","CTVOL","CTOMS","SNI","MYEP","DPG15","MHYH","LAK","PUYSO","DPG10","DSKMT","CQ067","TSOAP","CQ144","CLR10","UP028","DPG02","CQ103","WPSPT","TRJO","UP164","CLR15","K92S","QHG","CQ070","ODT18","CPC01","CQ097","ITD29","A44","KQPW","TMUKI","CMP24","GDNSP","CPC02","CTDUN","CQ068","TEN","CLR05","ODT42","SDTEC","QBV","HRICH","CMP19","DPG09","UP156","AGKO","GVLI1","PEM","LAYUT","LORO","LANL2","TSPA1","RTB","HSURF","CQ032","MYRB","E8KLA","SDTSR","MPND","DPG21","QWV","SEADU","UTSTV","TIMN2","KQWT","TUNIN","ODT08","UP138","HP002","CQ147","RDHMT","MWQAR","QBR","DPG11","MLEW","ITD09","UT7","CTBOG","FTHI","UP289","CQ087","HBVLY","GOLW","WRDO","ITD45","KQCI","RVF","CQ102","CLR14","TSILI","TDRYD","CQ042","CQ074","LGVI1","MRED","MSCO","LOFUT","COAM8","DPG14","MRVJH","ITD03","MLOS","CQ099","CQ164","MTH04","MDEN","DPG25","UT3","SPOFE","TBULL","FMP","E3POR","ODSW","UP385","SDMEA","UTR20","STCA3","DPG13","FLU","MWQMN","CRVO","HERO","E3HAL","H100A","GNI","UP053","NUNC2","WEHN2","CLR02","MWQKT","CQ096","SBE","MBRM","FAU","GRS","UP225","NIPM8","TRGW4","JPHN2","CFO","MHCA3","ODT41","CQ104","FAFI","UTPSH","SJS","QMG","THFM8","ODT66","TES","UP196","CTBBS","MFLT","TSATU","LANL1","STB49","ITD44","DPG06","ODT67","CQ140","MGAR","MSWC","TMANE","MBVR","CQ040","CQ077","CQ093","CQ143","TUM43","URM","CLR01","CPC03","CQ031","HPASC","CMP09","CQ134","MGRN","NAM04","CLR03","KNTJC","ODT24","CMP13","CQ041","MWQEE","SKY","MTSC2","UP286","ODT17","LANL4","LEGW","TWFI","HVERN","ITD31","CQ132","SSWN2","ITD28","CQ154","MGOV","MGSA3","H100K","ITD35","DPG03","UTWTV","CRL","GROBT","MCHA3","TELKH","H100F","DPG08","VIOM8","ITD40","H200E","HHMS","CPC05","CQ117","CQ075","CQ146","CRSM","CEN","HPFP","CQ083","RES","MWQCN","NBDNB","TMANS","CMP25","CQ126","SDUSS","CTAND","DPG07","DPG24","TACAL","FVVLY","BULLF","CQ054","BURMA","CQ090","CQ170","CISCO","CUR","VRN","UP006","MWQRU","T2195","HGABW","HVSTA","ITD34","E3CAR","TKEYS","RDBM","T144T","CPC04","HBENT","CQ159","PRP","UP263","UP358","TWARD","ITD25","UTWLD","KQLX","ODT10","MMON","CSNSK","TSOUT","CQ065","ITD48","A05","A46","A13","LANL5","TMEDI","CQ052","CQ061","CQ129","CQ142","BKVO","TRITZ","CMP02","CQ162","DPG19","ODT29","KFLW"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -350,6 +380,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["ND008","ND023","ND012","ND003","ND020","ND019","ND010","ND007","ND021","ND018","ND011","ND002","ND009","ND004"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -361,6 +392,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["NE029","NE011","NE039","NE000","NE059","NE017","NE006","NE056","NE037","NE026","NE049","NE058","NE008","NE016","NE005","NE057","NE015","NE027","NE042","NE045","NE054","NE014","NE041","NE009","NE047","NE050","NE030","NE028"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -372,6 +404,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["WEXM1","BSLM2","ELXC1","NIWS1","NAXR1","MAXT2","GTXF1","RKXF1","SAXG1","GDXM6","TIXC1"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -383,6 +416,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["NHLRV","NHSFD"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -394,6 +428,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["KQ11","KQ59","KQ58","KQ43","KQ56","USFS2","USFS1","KQ55","KQ48","KQ49","KQ51","KQ52"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -405,6 +440,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["KFPK","KS34","KMPR","KMYJ","K9S2","KHAE","KMAW","K78T","K2Q3","K6S8","KPYN","KN23","KUUV","KBTN","KTYQ","K1B1","K1D1","KCZG","KOIC","KHWQ","KTRK","KFSK","K97M","KSIK","KO70","KMBY","KX26","KEVU","KM75","KLRY"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -416,6 +452,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["OH105","OH039","OH160","OH165","OH055","OH064","OH062","OH101","OH154","OH027","OH044","OH040","OH164","OH115","OH124","OH036","OH090","OH014","OH162","OH106","OH126","OH050","OH011","OH076","OH096","OH163","OH158","OH060","OH148","OH107","OH116","OH135","OH109","OH140","OH147","OH117","OH097","OH150","OH034","OH023","OH159","OH032","OH142","OH111","OH083","OH030","OH166"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -427,6 +464,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["BBRC2","CCKT1","SRUC1","BVRC1","TS712","PRGV2","BFRI1","RSAC1","TS305","CBFI1","LCKI1","DUNN5","GRVN2","WFHC1","FADT2","UMTO3","LFFT1","DBYV1","NATW2","QPVA3","PRWF1","BMEC1","CPFO3","MCBT2","SSRT2","MILW1","LRLN7","ASTM2","ESPC2","LCLT1","FCRT1","BNTC1","CDHT2","GWRT2","OLFW1","DVLW4","OZNC1","MCLI1","MDHC1","BTRT2","NBKO3","HTSC1","ALRN2","SVNS1","CEKC2","RTGC1","BSAK2","CHRC2","SAWC2","GMTC1","RFPS2","COWW4","YEFO3","TS161","CNFO3","HDZC1","FMRM7","MAYW3","PIEM4","PLPW3","SEAM5","SRSS1","POEM8","RRAC1","BEFO3","ECSC1","MLLO3","TCRA3","WPKO3","TBSU1","MYFI1","TR490","CRKI1","MDRW1","OVLW1","CSTC1","KNNC1","TSOW1","SMFO3","HBFO3","MLKM8","TS395","RRDM8","GASI1","RRKN2","MRZW3","MTHI1","ALLN2","BCHN5","QSBA3","RANM4","TS211","BADU1","CISC1","BPYW4","QFSA3","SPMN2","WMTM4","BABC1","BMFW1","KRTC1","BGRM8","PIRC2","NHPC1","CHGG1","BQFO3","SPKW4","RPRT2","TS722","HBOM8","FHLC1","PKCC1","QMRA3","LDRC1","OJIC1","MRLV1","NPTN7","TR792","FFFO3","LDOI1","CICC1","PLIC1","BBYV2","CHEO1","LXFN7","GTGW4","TS583","AVLC1","HDRI3","LBLK2","POCN7","DKYC1","QENN5","GSCN5","RNFO3","CMRW4","BLAN4","GDSV2","HMEC2","TR272","CYFW1","GCRW4","CGLK1","LSNC1","PBUI1","MVVM7","SRYM8","CHFT1","NNHM6","FRNM5","TNBM1","LKRV2","GDRC2","TCKC1","TR192","RASW4","CIMN5","GALN2","KMFW1","TABC1","BRHC1","HHFO3","JAYC2","LVMC1","MIPC1","EDTF1","WLHS1","TR127","CAMW4","GMFW1","BBNL1","ARAU1","CDDT2","DNFI1","LRCM8","RHCM6","MPAM6","MWRM1","GLFM8","BNGC1","OTRU1","STKM8","FHFI1","JMRM5","LKNC1","MORN2","RLKN2","VENU1","BRUO3","OHOI1","SETC1","BIRM5","CITM7","FNWC1","GUML1","HBRM8","KTLW1","CMDT1","ESDA4","CPGT2","HPFI1","HSRU1","SADI1","SBWU1","CONM8","HYFO3","IVET2","KRBT2","EURM8","CLRW3","CUWN7","ELOM5","WNKN6","GPRM8","BENC1","VABC1","TS123","FLEI1","STGM8","FLSO3","CMAC1","NZAC1","CAZC1","KNXC1","MZHM5","MDEC1","ATNC1","CEKC1","CYFI1","FLFI1","JVLA4","BTTC1","EPKC1","LRRA4","PPRC1","BLDT1","HOBW4","MUDW4","WRRT2","BAFN8","DMMC2","FBFW1","OWFO3","LAUM6","LOLP1","SDFO1","WCAS2","TEXT2","TR543","SPGN2","BLCM6","SHPN6","NLHV1","CDFO3","RESN1","YLSU1","BYCU1","SDLC1","WTPC1","BATN5","MCDM8","BNRI1","CRGC1","FNWO3","SBFN1","GARL1","QBMA3","RNRM5","DOUW1","OBRC1","PCRW4","RSBU1","SYWC1","CTOC1","RDVC1","CPPN5","TR201","CKNT2","QFLA3","DVLO3","DARN7","RUTN7","TCCG1","TS199","CWLW2","ROCI1","BIGI3","SNDN5","QHQA3","TWBI1","MMRC2","IPFI1","WUEW3","MFCM6","SRRM8","TS698","MIGC1","SFAN6","FCHC1","MSAT2","QMLA3","PEEW3","TS350","MPAN5","SNGN8","MPRC2","TS623","HWDW3","REXM4","TS575","CRSN2","DRYW1","QUPA3","TR956","TS529","GSPC2","BHFA1","PYNC1","MSLM8","SKFI1","TS376","TS686","OVYC1","THRW4","ROVC1","BLNN6","HCOT1","LDRC2","NEFW1","INBS2","RBTN2","CSMN5","PSAT2","GNSC1","KOSW1","WMRO2","SDAM8","CPMG1","ESXV1","CGFW1","CUHC2","DEAI1","MGFO3","FMFO3","QSPA3","BPKC1","FIVU1","LAGO3","HAFW4","LSCU1","DEHI1","NCSW1","PANN2","HRDG1","LBHM8","ASYU1","WSFM8","KEHW3","MGST1","TS663","HIBW1","TS304","GRBO3","MOUC1","NUCI1","STMN2","NUCC2","RNDC1","RSPC1","AELG1","HFMN7","GCRN7","GFSK2","RFEC2","TR130","CDAW4","SLWC1","GUIN7","APBN6","PRID1","ZSFO1","BNHT2","PSTM8","AWWN8","PNRC2","SPAI1","LGNT2","TR269","TR007","JACN4","KOMK2","MAHN7","MMOM4","WOBN4","ARFO3","ERAW4","BLCN5","CHAC1","CHEA3","TS481","BLAU1","SMYI1","SHZM1","PAFO3","PLAG1","NATN7","SAMF1","LEFW1","MTZC1","NEHW3","TS545","DYLC1","MEGT2","LSRT2","FIEM8","PJNT2","PLEC1","TS674","TS720","BHRC2","KPRU1","HBYT2","MIRT2","WRRU1","CVEC1","SSMM8","ECRN1","BOLG1","FSTM6","GDNW3","MTIN7","HTVT2","CALN4","ATRC1","CAPT2","CVBC1","EVFO3","QRCA3","ABMN6","TS338","UTMN5","SMFW1","NBRN7","RRRC1","BEFM8","DENC1","OTOW1","PIBC1","TS631","LAHC1","RLAS2","RNEM6","RVZN7","TNFM6","SNYM4","WHBU1","TS429","SWNF1","EMTW1","LITM5","MPOC1","HTRC1","MIDW1","AGOW3","DSFI2","FVRV2","ISAM5","TAWW3","FBRN7","MATT2","TGSK1","VCRT2","BOOM8","NFFI1","CEEC1","HOTM8","BRSG1","SRON6","MKLN7","OKMA1","OPNA1","RKIF1","LACL1","DAFT1","PLAM8","PRFO3","PSGT2","RCPC1","WRSS2","BNFO3","SDMW1","WNTU1","NAOG1","SRVS1","JCKS1","MRRN5","TS726","TULG1","BYDW4","GDBT2","BAFO3","UINU1","POTI1","QISA3","TWRW1","EJAG1","JEFS1","TS682","CLHC1","PGRU1","RFTI1","JCRC2","TS164","EMRV1","RHOM6","BIIC1","FMRC1","DIAU1","COIN2","MSAC1","HUFW1","CYVC1","LPSA4","ORBM5","BHMM8","HCKC2","JVAU1","KYCN2","KCPT2","BPKN2","GELT2","STOC2","TR968","MPEC1","UNFN7","WSHW3","BRLW4","HBFI1","MIAC1","TS651","THKO2","BUFC1","TS341","ZNRN5","COWI2","GLMT2","QADW4","QCAC1","MRAG1","TS098","CLBC1","SAFO3","NINM8","CKST2","TMKO3","BYRG1","LBRM4","BUGC1","STVM8","TRDK1","KLOM8","HLKC1","LANS2","LICC1","STHC2","BUCO3","SNOW4","GRYT2","DRAC2","GMLN5","RSHC1","BDEM6","MTFG1","BXYG1","RMAM6","KNGS1","KLYW4","CVFO3","LRWT2","RONM8","SIAN2","SDRC1","WWDC1","YELK2","JONG1","DLSG1","RLFO3","TS724","LWDN8","TR297","KNMM5","TRMK2","BKBW1","RACF1","BLUM8","EGLW4","NPFO3","TS390","VLYC1","RLDM6","DFSM7","TS693","CHOM7","HDRT2","BKFS2","LOMN5","RHKW4","BFYI1","BRKO2","INDI1","QGTA3","FART2","TS619","FLSN2","PCKI1","SQSC1","OCOF1","BCFI1","BNVA4","CMMM7","DENT2","GINM8","QPFO3","RTCT2","RVZU1","SWLC1","KGWW2","LCFM8","BMJM5","LEVL1","KEEO3","STNI1","TROM8","PAMC1","TR285","IRFO3","ELRN7","FRCC1","SAUC1","PLTC1","HAYI1","SDNA4","SYNO3","LPOW1","THDC1","TR077","OLSF1","WHSF1","WINM6","TURN7","LPSN6","LPRC2","ELKW4","TS312","LSFC1","MSCN5","SLTO3","WKFM4","BLGT2","CSVC1","ENTU1","HIBM5","QTWA3","OKPC1","SUAM8","PRDM8","DESN2","HOHU1","SEVN5","TAYN7","LGRW2","BNDC1","LTJC1","OKSC1","TR369","TS689","MEAM5","TR532","VLCC1","WSRM8","EMRC1","MMTC1","GSNM8","AGZM5","GMFN6","WTHS1","TRII1","TS642","GNLW1","TLGC1","ACRI1","DHOC2","KBFO3","BKSC1","GRAI1","HHRW4","LCBC1","LNCM8","MDDC1","PEFW1","VRNL1","MRFC2","BKIN7","UPTW2","SAWW4","CLFU1","CTGC1","DLVC1","SRXC1","SVFO3","TR257","JSPU1","NSWI4","LFSM5","MLCN5","BENL1","IMWN2","MCKU1","SLKO3","BCHN6","NNAG1","KIGM8","TS690","TS718","WEFI1","BRNW3","LAAW3","STOM4","WMGI2","RMFN7","SMTM8","HSEC1","TS428","CMFW1","BHRO3","PRMS2","WISC1","LOHF1","SPLS1","LDYW3","LOUG1","BNYN7","SEEM8","GBON7","LPIF1","HOAC1","MSRU1","TS713","EGKO3","PHGM8","SHFO3","TMPT2","BATN2","PCLC1","CMLG1","GMWP1","BMOC2","RCRO3","COAT2","ADFW1","CQFO3","DEDN2","EFFM5","IMTW1","QGDA3","WHHM8","MMRO3","BBEC1","FISN2","SPLW4","PCFT1","JPRC1","WALC1","QHUA3","SIGU1","BOGC1","BFSF1","WHIN7","CSPC1","FBGG1","BFRW2","LPZC1","CACM8","RSCN2","BCNC1","ENFO3","ENNM8","RVYC1","MOWC1","RTFO3","SBFN6","TS556","FORN1","LGLA1","DOEM4","REDD1","DJTC2","TS659","CADT2","QLKA3","AMDN8","SRTC1","PARN8","MVAN6","FLRW2","SHLA1","TISM6","ATSC1","TCAC1","BLRA4","QSTA3","RBYC1","SFKO3","NATL1","NBRC1","APLT2","QNRK1","WSBO3","CGLN7","CLNC1","CYNC2","SLFC1","RYDM4","BTTM5","GSFO3","BIVU1"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -438,6 +476,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["WLV","WSF","WUY","WQQ","WGN","WWN","WWP","WUT","WSU","WNC","WMI"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -449,6 +488,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["S331W","BELLW","S7WX","S61W","ROTNW","SGGEW","WRWX","BCSI","LXWS","S78W"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -460,6 +500,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["SAPC2","EBBC2"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -471,6 +512,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["LEMNT","PSCBH","CNNMN","EVRGR","LSV02","LSCRS","RSWLL","ALSTN","NWOCH","DRPRK","HNTRY","HARHN","LSVJC","PTOMC","STHGT","LVEGS","LSVRB","RVDAL","TKMPR","GLFPC","DRCUT","ADK15","WDSTC","A0022","STHTN","DGLSV","AMBLR","BNDVL","CRSRS","RPVRD","EVERT","MLTNO","DPTFR","RVRIL","MNTPR","DSNTN","MNSFL","BRNK5","DOVR1","IRVIG","SEUNI","LTTFA","BRON1","LSVGR","HENDR","NORRI","NWYK1","MSPTH","LNGBH","LSVG3","PHLDP","CLFFS","GLASB","PHLJW","PHILD","ALIVE","SPRMG","NWLNX","EWPLE","RDGFL","ALCES","CHCSS","CPTHT","MDLNL","LVGGH","CASLM","MLNPK","BLLMW","PS002","BRBNK","SHRNS","GORMS","LASVU","WBZT2","MESQT","HSTAS","REVER","PNSHH","LVGME","ATFR7","LNSDW","NRIST","LXVGS","ISVGS","HSTDW","GRMRC","WSHMG","HAKSK","LVGST","CMCRD","SCCSC","FXBRG","METRE","WNTHR","GMBRD","BRKYL","SGRLN","DWEBB","HNSPT","WSTNX","CALLS","LNBTW","HNFRS","DESOT","CLYMN","STNMO","EHDRS","AGTON","CHHCG","BLCKD","PASNA","CRLNG","NOLSV","JNBRO","YSNGL","NW7DC","OWYRK","WASDC","ARDMR","JNSYC","REGWD","NYSTS","PHL01","SLVSP","BTNRB","BTKLY","LVSVS","BX368","WHWKN","CHRCM","PHLD9","CRNYS","HDSMA","HSTWH","CHHRS","HSTNO","LVGMR","LVNGN","RTWYN","LASVG","LSVGV","LRLNL","LSNGH","DLCMC","JSBRO","LSVG6","LSVSA","PTRSN","NYSTH","LSVGS","PHLRH","MNDRS","MLVRM","HLLSD","CDRGR","TTTLT","PEPCO","NHCHL","ERNKL","PHIL2","LAVSS","BRCKT","ELZBS","NYPSW","BRX34","HNDLH","BLRNG","WDRDG","DLLS3","PHLD5","LSVG2","LSFGS","IRVNG","FRKHS","GRMKM","WSTOP","LVMJC","CINNM","BRKLA","STTCD","CANTO","NETWN","PHLDM","HSTCH","CRLTX","FSTRV","PHILA","GPRIE","CMCFD","BMILR","LNDNB","LOXES","WSING","HDSST","ADK14","BRDFR","LSVHH","ASTON","CHSTU","HVAND","LSVHF","HSTNU","LINCO","IRVIN","PRTHM","CJHCG","BTHWJ","HVRTW","ORNGM","FSTPR","ASTLL","PICYN","MOKEN","NWTVN","ADKL4","FRTWS","LSVG8","PHLDB","CHSBC","MLBRO","WRMIN","WSTKR","NBERG","SLDCS","TWKSB","WMARB","UMBC1","NEADC","ANDGL","GERTN","PHLCS","BNSLM","MS133","LWLLB","STTNL","LSV01","PS36K","SCKLV","REVSE","RCKWY","PHLDL","LTVGS","LSVG7","CNTNM","LSVCM","QNSFP","CHNOK","DLC01","CARHS","PHLD7","NRLNG","BRKLN","TCMFP","AWTY1","MCDON","ALVRD","PHLNE","CMDNN","KNTWH","GRLNC","READG","HNKES","WASTO","MCKLT","PS102","LAKMD","WTVNJ","AHSTN","BFDHQ","WLMNI","ECLFS","BKLIN","PHLDN","BRNXA","PLSDS","LFVGS","LOXLY","JMCST","BSTON","BRKAM","HSTN8","LSVGA","BROKL","PHLD3","FRTWY","NRRST","PHLD8","BRCMC","STINY","BRNSR","BRYNM","BRWYN","BLCKW","FRTWH","LSNDP","PHLPA","JNKNT","WHTMN","AWSHQ","USSAL","CRRBF","LVGRC","NWYR2","CURIE","WLLNG","PHLDO","CSVGS","PHLDY","BRST1","BRKTN","BYSD1","WSHDD","BRLNG","CHGMT","BFD32","CHHOS","NTHLV","NLMSF","HSTPN","EGLVL","LSNGN","HSGHC","BROOY","ELZBJ","HUNTI","ASNNU","ASVGS","TRRNC","FSLSS","LMBRT","CHESA","MTLR3","STHBH","HCKHL","BRKN3","LWELL","JRSYE","STPNS","BKBHS","BTRGB","DRXHL","CMDNC","BDRCT","LSVSS","HSHCH","NANDV","CHICG","MRLTN","KNRTB","MSFLD","GRMNW","LSNVT","DLLSL","LSVCT","HUTON","OKELS"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -482,6 +524,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["VA006","VA013","VA017","VA029","VA016","VA041","VA022","VA019","VA003","VA011","VA031","VA026","VA004","VA023","VA015","VA021","VA032","VA027","VA040"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -493,6 +536,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["VT002","VT001"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -504,6 +548,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["EKNW3","WAKW3","WI054","HAUW3","PAKW3","HSNW3","MNRW3"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -515,6 +560,7 @@
            - variable: MetaData/stationIdentification
              is_in: ["H0269","H0313","H0300","H0080","H0346","H0164","H0005","H0177","H0041","H0498","H0338","H0062","H0244","H0203","H0237","H0030","H0322","H0560","H0140","H0447"]
          - filter: AcceptList  # accept back selected stations
+           udescriptor: "accept_selected_providers"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -567,13 +613,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900
-             maxvalue:  900
+           - variable: ObsType/windEastward
+             is_in: 288
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/proflr_winds_227.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/proflr_winds_227.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -360
+           maxvalue: 360
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -360
-             maxvalue:  360
+           - variable: ObsType/windEastward
+             is_in: 227
            action:
              name: reduce obs space
 
@@ -267,6 +272,9 @@
          # Assign abs(windEastward)
          - filter: Variable Assignment
            udescriptor: "variable_assign_absolute_windEastward"
+           where:
+           - variable: ObsType/windEastward
+             is_in: 227
            assignments:
            - name: AbsObsValue/windEastward
              type: float
@@ -280,6 +288,9 @@
          # Assign abs(windNorthward)
          - filter: Variable Assignment
            udescriptor: "variable_assign_absolute_windNorthward"
+           where:
+           - variable: ObsType/windEastward
+             is_in: 227
            assignments:
            - name: AbsObsValue/windNorthward
              type: float
@@ -306,6 +317,8 @@
                name: AbsObsValue/windNorthward
              minvalue: 0
              maxvalue: 1
+           - variable: ObsType/windEastward
+             is_in: 227
            where operator: and
            action:
              name: reject
@@ -319,6 +332,9 @@
            test variables:
            - name: MetaData/pressure
            minvalue: 40000
+           where:
+           - variable: ObsType/windEastward
+             is_in: 227
            action:
              name: reject
 

--- a/parm/jcb-rdas/observations/atmosphere/rassda_airTemperature_126.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/rassda_airTemperature_126.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -360
+           maxvalue: 360
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -360
-             maxvalue:  360
+           - variable: ObsType/airTemperature
+             is_in: 126
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_180.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 180
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_182.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/airTemperature
+             is_in: 182
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_183.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: airTemperature
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900 # combined obs spaces -5400
-             maxvalue:  900 #                      5400
+           - variable: ObsType/airTemperature
+             is_in: 183
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_180.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/specificHumidity
+             is_in: 180
            action:
              name: reduce obs space
 
@@ -135,6 +139,7 @@
 
          # Error inflation based on pressure check (setupq.f90)
          - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
            filter variables:
            - name: specificHumidity
            where:

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_182.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/specificHumidity
+             is_in: 182
            action:
              name: reduce obs space
 
@@ -135,6 +139,7 @@
 
          # Error inflation based on pressure check (setupq.f90)
          - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
            filter variables:
            - name: specificHumidity
            where:

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_183.yaml.j2
@@ -82,13 +82,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: specificHumidity
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -900
+           maxvalue: 900
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -900 # combined obs spaces -5400
-             maxvalue:  900 #                      5400
+           - variable: ObsType/specificHumidity
+             is_in: 183
            action:
              name: reduce obs space
 
@@ -135,6 +139,7 @@
 
          # Error inflation based on pressure check (setupq.f90)
          - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
            filter variables:
            - name: specificHumidity
            where:

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_180.yaml.j2
@@ -78,13 +78,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/stationPressure
+             is_in: 180
            action:
              name: reduce obs space
 
@@ -131,8 +135,12 @@
 
          # Reduce observation error for buoy surface pressure observations (setupps.f90)
          - filter: Perform Action
+           udescriptor: "error_inflation_for_buoy"
            filter variables:
            - name: stationPressure
+           where:
+           - variable: ObsType/stationPressure
+             is_in: 180
            action:
              name: inflate error
              inflation factor: 0.7
@@ -152,7 +160,6 @@
                options:
                  geovar_geomz: geopotential_height
                  geovar_sfc_geomz: geopotential_height_at_surface
-                 #station_altitude: height
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_182.yaml.j2
@@ -78,13 +78,17 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: stationPressure
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-           - variable:
-               name: MetaData/timeOffset # units: s
-             minvalue: -5400
-             maxvalue:  5400
+           - variable: ObsType/stationPressure
+             is_in: 182
            action:
              name: reduce obs space
 
@@ -144,7 +148,6 @@
                options:
                  geovar_geomz: geopotential_height
                  geovar_sfc_geomz: geopotential_height_at_surface
-                 #station_altitude: height
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_280.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_280.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 280
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_282.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_282.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 282
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_284.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_284.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 284
            action:
              name: reduce obs space
 

--- a/parm/jcb-rdas/observations/atmosphere/tools/validate_ob_filters.py
+++ b/parm/jcb-rdas/observations/atmosphere/tools/validate_ob_filters.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+import sys
+import re
+from pathlib import Path
+
+# --------------------------------------------------------
+#  List of udescriptors that are SAFE (no where required)
+# --------------------------------------------------------
+SAFE_UDESC = {
+    "online_domain_check",
+    "quality_marker_check",
+    "duplicate_check",
+    "bounds_check_ObsError",
+    "bounds_check_ObsValue",
+    "gross_error_check",
+    "gross_error_check_0.7",
+}
+
+def extract_filters(lines):
+    filters = []
+    current = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("- filter:"):
+            if current:
+                filters.append(current)
+            current = {
+                "start": idx,
+                "udescriptor": None,
+                "lines": [line]
+            }
+        elif current:
+            current["lines"].append(line)
+            if stripped.startswith("udescriptor:"):
+                # capture udescriptor value
+                parts = stripped.split(":", 1)
+                if len(parts) == 2:
+                    val = parts[1].strip().strip('"').strip("'")
+                    current["udescriptor"] = val
+    if current:
+        filters.append(current)
+    return filters
+
+def has_where_block(lines):
+    return any(l.strip().startswith("where:") for l in lines)
+
+def where_has_obstype(lines):
+    for line in lines:
+        s = line.strip()
+        if s.startswith("variable:") and "ObsType/" in s:
+            return True
+        if "ObsType/" in s:
+            return True
+    return False
+
+def validate_file(filename):
+    with open(filename) as f:
+        lines = f.readlines()
+
+    filters = extract_filters(lines)
+    issues = []
+    fnum = 0
+
+    for flt in filters:
+        fnum += 1
+        udesc = flt["udescriptor"]
+        block = flt["lines"]
+
+        # must have a udescriptor
+        if not udesc:
+            issues.append(f"FILTER {fnum}: Missing udescriptor")
+            continue
+
+        # if udescriptor is safe, no where needed
+        if udesc in SAFE_UDESC:
+            continue
+
+        # require where block
+        if not has_where_block(block):
+            issues.append(f"FILTER {fnum} (udescriptor={udesc}): Missing where:")
+            continue
+
+        # require ObsType reference inside where
+        if not where_has_obstype(block):
+            issues.append(f"FILTER {fnum} (udescriptor={udesc}): where block missing ObsType reference")
+
+    return issues
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: validate_ob_filters.py <yaml files>")
+        sys.exit(1)
+
+    for fname in sys.argv[1:]:
+        issues = validate_file(fname)
+        print()
+        print("OBS FILTER VALIDATION REPORT")
+        print("-------------------------------------")
+        if issues:
+            for e in issues:
+                print("ERROR:", fname + ": " + e)
+            print("\nTotal issues:", len(issues))
+        else:
+            print("No issues found:", fname)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/parm/jcb-rdas/observations/atmosphere/vadwnd_winds_224.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/vadwnd_winds_224.yaml.j2
@@ -86,13 +86,18 @@
              name: reduce obs space
 
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 224
            action:
              name: reduce obs space
 
@@ -267,6 +272,9 @@
          # Assign abs(windEastward)
          - filter: Variable Assignment
            udescriptor: "variable_assign_absolute_windEastward"
+           where:
+           - variable: ObsType/windEastward
+             is_in: 224
            assignments:
            - name: AbsObsValue/windEastward
              type: float
@@ -280,6 +288,9 @@
          # Assign abs(windNorthward)
          - filter: Variable Assignment
            udescriptor: "variable_assign_absolute_windNorthward"
+           where:
+           - variable: ObsType/windEastward
+             is_in: 224
            assignments:
            - name: AbsObsValue/windNorthward
              type: float
@@ -306,6 +317,8 @@
                name: AbsObsValue/windNorthward
              minvalue: 0
              maxvalue: 1
+           - variable: ObsType/windEastward
+             is_in: 224
            where operator: and
            action:
              name: reject
@@ -319,6 +332,9 @@
            test variables:
            - name: MetaData/pressure
            minvalue: 22600
+           where:
+           - variable: ObsType/windEastward
+             is_in: 224
            action:
              name: reject
 


### PR DESCRIPTION
## Description
This PR updates all `time_window_check` filters to a safe and consistent pattern suitable for combined observation spaces, and adds a validation tool to ensure filter policies (ObsType scoping and required `where`/`udescriptor` fileds) are correctly enforced.

Previously, `time_window_check` used `Domain Check` without an ObsType guard. In a combined obs-space, this would incorrectly drop observations from other kx families, especially when different kx values use different time-window settings (e.g., from GSI convinfo).

This PR replaces the old pattern with a kx-scoped `Bounds Check`:
- Uses `filter variables:` to limit the filter to the correct observed variable(s)
- Uses `test variables:` to explicitly test `MetaData/timeOffset`
- Adds a `where: ObsType/<var> is_in: <kx>` guard to isolate each kx

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
