### PR TITLE
Prevent crash in `offline_domain_check_satrad.py` when no obs are inside the domain

### DIFF
--- a/rrfs-test/IODA/offline_domain_check_satrad.py
+++ b/rrfs-test/IODA/offline_domain_check_satrad.py
@@ -13,7 +13,6 @@ import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import matplotlib.ticker as mticker
 from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
-from operator import itemgetter
 import shapely.speedups
 from collections import defaultdict
 
@@ -289,6 +288,8 @@ fout = nc.Dataset(outfile, 'w')
 # Create dimensions and variables in the new file
 location_size = len(inside_indices)
 channel_size = obs_ds.dimensions['Channel'].size if 'Channel' in obs_ds.dimensions else 0  # Use the second dimension's size if exists
+if location_size == 0:
+    print(f"\nWARNING: no obs found within the model domain for: {obs_filename}\n")
 
 # Channel variable
 if '_FillValue' in obs_ds.variables['Channel'].ncattrs():
@@ -351,8 +352,8 @@ for group in groups:
                 g.createVariable(var, vartype, dimensions, fill_value=fill)
             except:
                 g.createVariable(var, 'str', dimensions, fill_value=fill)
-            for idy in range(0, len(invar[0,:])): # new method for slicing very large 2d arrays
-                g.variables[var][:,idy] = itemgetter(*inside_indices)(invar[:,idy])
+            idx = np.asarray(inside_indices, dtype=np.int64)
+            g.variables[var][:] = np.take(invar[:], idx, axis=0)
 
             # Copy attributes for this variable
             for attr in invar.ncattrs():


### PR DESCRIPTION
## Bug Fix Description

This is a companion PR to https://github.com/NOAA-EMC/rrfs-workflow/pull/1081. We need to apply the fix here too since the `[dev-sci]` branch of rrfs-workflow uses the domain check codes from inside RDASApp. 

This PR fixes a crash in the offline domain check that can occur if there are no radiance obs inside the MPAS model domain. We now generate a warning message if no obs are found inside the domain.

Note: the end result of this change will be the same in that only an empty IODA file gets created. But there will no longer be a confusing error and crash in the python code.

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
