### PR TITLE
Update satwnd 245_270 and 245_272 yaml.j2

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_270.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_270.yaml.j2
@@ -52,8 +52,10 @@
            where:
            - variable: ObsType/windEastward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
-             name: {{iuse_adpsfc_winds_281 | default("passivate", true)}} # accept, reject, passivate
+             name: {{iuse_satwnd_winds_245_270 | default("passivate", true)}} # accept, reject, passivate
 
          # Reject all obs not 245
          - filter: Perform Action
@@ -64,41 +66,26 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 270
            action:
              name: reduce obs space
 
-         # Pre-online regional domain check
-         - filter: Domain Check
-           udescriptor: "pre-online_domain_check_lat"
-           apply at iterations: 0,1       #pre-filters(0,1), post(2)
-           where:
-             - variable:
-                 name: MetaData/latitude
-               minvalue:  20.0            # CONUS domain lat
-               maxvalue:  60.0
-           action:
-              name: reduce obs space
-
-         # Pre-online regional domain check
-         - filter: Domain Check
-           udescriptor: "pre-online_domain_check_lon"
-           apply at iterations: 0,1
-           where:
-             - variable:
-                 name: MetaData/longitude
-               minvalue: -145.0            # CONUS domain lon
-               maxvalue: -50.0
-           action:
-              name: reduce obs space
-
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reduce obs space
 
@@ -113,6 +100,11 @@
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
              name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reduce obs space
 
@@ -136,6 +128,8 @@
            where:
            - variable: ObsType/windEastward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: assign error
              error function:
@@ -154,6 +148,8 @@
            where:
            - variable: ObsType/windEastward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: inflate error
              inflation variable:
@@ -170,6 +166,8 @@
            where:
            - variable: ObsType/windNorthward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: inflate error
              inflation variable:
@@ -184,29 +182,35 @@
            filter variables:
            - name: windEastward
            - name: windNorthward
-           minvalue: -130
-           maxvalue: 130
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reduce obs space
 
-         # GSI read routine QC (part-2)
          # Reject obs with qiWithoutForecast < 90. OR > 100.
          - filter: Bounds Check
            udescriptor: "bounds_check_qifn"
            filter variables:
            - name: windEastward
            - name: windNorthward
-           where:
-           - variable: MetaData/satelliteIdentifier
-             is_in: 250-299
            test variables:
            - name: MetaData/qiWithoutForecast
            minvalue: 90.
            maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 
-         # Bounds Check - exclude data with satellite zenith angle > 68 for all types)
+         # Reject obs with satellite zenith angle > 68
          - filter: Bounds Check
            udescriptor: "bounds_check_satellite_zenith_angle"
            filter variables:
@@ -215,85 +219,117 @@
            test variables:
            - name: MetaData/satelliteZenithAngle
            maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 
-         # Reject obs with qifn < 80%
-         - filter: Bounds Check
-           udescriptor: "bounds_check_qifn"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/qiWithoutForecast
-           minvalue: 80.0
-
-         # Reject obs with pressure < 12500 pa --- obs tossed without passing to setup routine
+         # Reject obs with pressure < 150 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
            - name: windEastward
            - name: windNorthward
-           where:
-           - variable: MetaData/satelliteIdentifier
-             is_in: 250-299
            test variables:
            - name: MetaData/pressure
-           minvalue: 12500.
+           #minvalue: 12500.
+           minvalue: 15000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 
-         # Reject obs with pressure > 850 hPa when isli=1 (land surface)
-         # Replace land_type_index_NPOESS with land_area_fraction (eliu)
-         - filter: Bounds Check
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
            udescriptor: "bounds_check_pressure_over_land"
            filter variables:
            - name: windEastward
            - name: windNorthward
            where:
-           - variable: MetaData/satelliteIdentifier
-             is_in: 250-299
+           - variable: MetaData/pressure
+             minvalue: 85000.
            - variable: GeoVaLs/land_area_fraction
              minvalue: 0.99
-           test variables:
-           - name: MetaData/pressure
-           maxvalue: 85000.
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 
-         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04–0.5, Type [240,245,246,251] ONLY
+         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
          - filter: Bounds Check
            udescriptor: "bounds_check_pct1"
            filter variables:
            - name: windEastward
            - name: windNorthward
-           where:
-           - variable: MetaData/satelliteIdentifier
-             is_in: 250-299
-           - variable: ObsType/windEastward
-             is_in: 240, 245, 246, 251
            test variables:
            - name: MetaData/coefficientOfVariation
            minvalue: 0.04
            maxvalue: 0.5
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 
-         # Exclude data over non-water surface type where latitude > 20N for type 245
-         # Replace land_type_index_NPOESS with land_area_fraction (eliu)
-         - filter: Bounds Check
-           udescriptor: "bounds_check_reject_over_water"
+         # Reject data over non-water surface type where latitude > 20N
+         - filter: Perform Action
+           udescriptor: "bounds_check_reject_over_nonwater"
            filter variables:
            - name: windEastward
            - name: windNorthward
            where:
-           - variable: ObsType/windEastward
-             is_in: 245
            - variable: MetaData/latitude
              minvalue: 20.
-           test variables:
-           - name: GeoVaLs/water_area_fraction
-           minvalue: 0.99
+           - variable: GeoVaLs/water_area_fraction
+             maxvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
+           action:
+             name: reject
+
+         # AMV expected error norm check
+         - filter: Perform Action
+           udescriptor: "amv_experr_norm_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             minvalue: 0.1
+           - variable: MetaData/exp_err_norm
+             minvalue: 0.9
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 
@@ -303,14 +339,16 @@
            filter variables:
            - name: windEastward
            - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: inflate error
              inflation factor: 0.5
 
-         # Multiple satellite platforms, reject when pressure is more than 50 mb above tropopause.
-         # CLEARED: minvalue is rejecting <, not <= as per a Perform Action, so threshold is unchanged
-         # Notes (eliu): This tropopause check reject too many obs; probably due to tropopause pressure estimation
-         #               Turn this check off for now.
+         # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
            udescriptor: "difference_check_tropopause_pressure"
            filter variables:
@@ -318,30 +356,33 @@
            - name: windNorthward
            reference: GeoVaLs/tropopause_pressure
            value: MetaData/pressure
-           minvalue: -5000.                   # 50 hPa above tropopause level, negative p-diff
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 
-         # GOES (245) reject any observation within 100 hPa of the surface pressure (as part of the LNVD # check).
-         # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
-         # Notes (eliu): Replace land_type_index_NPOESS with land_area_fraction.
+         # Reject any observation within 100 mb of the surface pressure
          - filter: Difference Check
            udescriptor: "difference_check_air_pressure_at_surface"
            filter variables:
            - name: windEastward
            - name: windNorthward
-           where:
-           - variable:
-               name: ObsType/windEastward
-             is_in: 245
            reference: GeoVaLs/air_pressure_at_surface
            value: MetaData/pressure
-           maxvalue: -10000.                   # within 100 hPa above surface pressure, negative p-diff
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 
-         # GOES IR (245) reject when pressure between 399 and 801 mb.
-         #   # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+         # Reject when pressure between 399 and 801 mb.
          - filter: Perform Action
            udescriptor: "pressure_range_check"
            filter variables:
@@ -353,6 +394,8 @@
              maxvalue: 80099.
            - variable: ObsType/windEastward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
            action:
              name: reject
 

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_270.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_270.yaml.j2
@@ -182,8 +182,8 @@
            filter variables:
            - name: windEastward
            - name: windNorthward
-           minvalue: -200
-           maxvalue: 200
+           minvalue: -130
+           maxvalue: 130
            where:
            - variable: ObsType/windEastward
              is_in: 245

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_272.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_272.yaml.j2
@@ -52,8 +52,10 @@
            where:
            - variable: ObsType/windEastward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
-             name: {{iuse_adpsfc_winds_281 | default("passivate", true)}} # accept, reject, passivate
+             name: {{iuse_satwnd_winds_245_272 | default("passivate", true)}} # accept, reject, passivate
 
          # Reject all obs not 245
          - filter: Perform Action
@@ -64,41 +66,26 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 272
            action:
              name: reduce obs space
 
-         # Pre-online regional domain check
-         - filter: Domain Check
-           udescriptor: "pre-online_domain_check_lat"
-           apply at iterations: 0,1       #pre-filters(0,1), post(2)
-           where:
-             - variable:
-                 name: MetaData/latitude
-               minvalue:  20.0            # CONUS domain lat
-               maxvalue:  60.0
-           action:
-              name: reduce obs space
-
-         # Pre-online regional domain check
-         - filter: Domain Check
-           udescriptor: "pre-online_domain_check_lon"
-           apply at iterations: 0,1
-           where:
-             - variable:
-                 name: MetaData/longitude
-               minvalue: -145.0            # CONUS domain lon
-               maxvalue: -50.0
-           action:
-              name: reduce obs space
-
          # Time window filter
-         - filter: Domain Check
+         - filter: Bounds Check
            udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
            where:
-             - variable:
-                 name: MetaData/timeOffset # units: s
-               minvalue: -5400
-               maxvalue:  5400
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reduce obs space
 
@@ -113,6 +100,11 @@
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
              name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reduce obs space
 
@@ -136,6 +128,8 @@
            where:
            - variable: ObsType/windEastward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: assign error
              error function:
@@ -154,6 +148,8 @@
            where:
            - variable: ObsType/windEastward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: inflate error
              inflation variable:
@@ -170,6 +166,8 @@
            where:
            - variable: ObsType/windNorthward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: inflate error
              inflation variable:
@@ -184,29 +182,35 @@
            filter variables:
            - name: windEastward
            - name: windNorthward
-           minvalue: -130
-           maxvalue: 130
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reduce obs space
 
-         # GSI read routine QC (part-2)
          # Reject obs with qiWithoutForecast < 90. OR > 100.
          - filter: Bounds Check
            udescriptor: "bounds_check_qifn"
            filter variables:
            - name: windEastward
            - name: windNorthward
-           where:
-           - variable: MetaData/satelliteIdentifier
-             is_in: 250-299
            test variables:
            - name: MetaData/qiWithoutForecast
            minvalue: 90.
            maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 
-         # Bounds Check - exclude data with satellite zenith angle > 68 for all types)
+         # Reject obs with satellite zenith angle > 68
          - filter: Bounds Check
            udescriptor: "bounds_check_satellite_zenith_angle"
            filter variables:
@@ -215,85 +219,117 @@
            test variables:
            - name: MetaData/satelliteZenithAngle
            maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 
-         # Reject obs with qifn < 80%
-         - filter: Bounds Check
-           udescriptor: "bounds_check_qifn"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/qiWithoutForecast
-           minvalue: 80.0
-
-         # Reject obs with pressure < 12500 pa --- obs tossed without passing to setup routine
+         # Reject obs with pressure < 150 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
            - name: windEastward
            - name: windNorthward
-           where:
-           - variable: MetaData/satelliteIdentifier
-             is_in: 250-299
            test variables:
            - name: MetaData/pressure
-           minvalue: 12500.
+           #minvalue: 12500.
+           minvalue: 15000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 
-         # Reject obs with pressure > 850 hPa when isli=1 (land surface)
-         # Replace land_type_index_NPOESS with land_area_fraction (eliu)
-         - filter: Bounds Check
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
            udescriptor: "bounds_check_pressure_over_land"
            filter variables:
            - name: windEastward
            - name: windNorthward
            where:
-           - variable: MetaData/satelliteIdentifier
-             is_in: 250-299
+           - variable: MetaData/pressure
+             minvalue: 85000.
            - variable: GeoVaLs/land_area_fraction
              minvalue: 0.99
-           test variables:
-           - name: MetaData/pressure
-           maxvalue: 85000.
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 
-         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04–0.5, Type [240,245,246,251] ONLY
+         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
          - filter: Bounds Check
            udescriptor: "bounds_check_pct1"
            filter variables:
            - name: windEastward
            - name: windNorthward
-           where:
-           - variable: MetaData/satelliteIdentifier
-             is_in: 250-299
-           - variable: ObsType/windEastward
-             is_in: 240, 245, 246, 251
            test variables:
            - name: MetaData/coefficientOfVariation
            minvalue: 0.04
            maxvalue: 0.5
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 
-         # Exclude data over non-water surface type where latitude > 20N for type 245
-         # Replace land_type_index_NPOESS with land_area_fraction (eliu)
-         - filter: Bounds Check
-           udescriptor: "bounds_check_reject_over_water"
+         # Reject data over non-water surface type where latitude > 20N
+         - filter: Perform Action
+           udescriptor: "bounds_check_reject_over_nonwater"
            filter variables:
            - name: windEastward
            - name: windNorthward
            where:
-           - variable: ObsType/windEastward
-             is_in: 245
            - variable: MetaData/latitude
              minvalue: 20.
-           test variables:
-           - name: GeoVaLs/water_area_fraction
-           minvalue: 0.99
+           - variable: GeoVaLs/water_area_fraction
+             maxvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
+           action:
+             name: reject
+
+         # AMV expected error norm check
+         - filter: Perform Action
+           udescriptor: "amv_experr_norm_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             minvalue: 0.1
+           - variable: MetaData/exp_err_norm
+             minvalue: 0.9
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 
@@ -303,14 +339,16 @@
            filter variables:
            - name: windEastward
            - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: inflate error
              inflation factor: 0.5
 
-         # Multiple satellite platforms, reject when pressure is more than 50 mb above tropopause.
-         # CLEARED: minvalue is rejecting <, not <= as per a Perform Action, so threshold is unchanged
-         # Notes (eliu): This tropopause check reject too many obs; probably due to tropopause pressure estimation
-         #               Turn this check off for now.
+         # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
            udescriptor: "difference_check_tropopause_pressure"
            filter variables:
@@ -318,30 +356,33 @@
            - name: windNorthward
            reference: GeoVaLs/tropopause_pressure
            value: MetaData/pressure
-           minvalue: -5000.                   # 50 hPa above tropopause level, negative p-diff
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 
-         # GOES (245) reject any observation within 100 hPa of the surface pressure (as part of the LNVD # check).
-         # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
-         # Notes (eliu): Replace land_type_index_NPOESS with land_area_fraction.
+         # Reject any observation within 100 mb of the surface pressure
          - filter: Difference Check
            udescriptor: "difference_check_air_pressure_at_surface"
            filter variables:
            - name: windEastward
            - name: windNorthward
-           where:
-           - variable:
-               name: ObsType/windEastward
-             is_in: 245
            reference: GeoVaLs/air_pressure_at_surface
            value: MetaData/pressure
-           maxvalue: -10000.                   # within 100 hPa above surface pressure, negative p-diff
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 
-         # GOES IR (245) reject when pressure between 399 and 801 mb.
-         #   # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+         # Reject when pressure between 399 and 801 mb.
          - filter: Perform Action
            udescriptor: "pressure_range_check"
            filter variables:
@@ -353,6 +394,8 @@
              maxvalue: 80099.
            - variable: ObsType/windEastward
              is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
            action:
              name: reject
 

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_272.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_272.yaml.j2
@@ -182,8 +182,8 @@
            filter variables:
            - name: windEastward
            - name: windNorthward
-           minvalue: -200
-           maxvalue: 200
+           minvalue: -130
+           maxvalue: 130
            where:
            - variable: ObsType/windEastward
              is_in: 245

--- a/parm/jcb-rdas/observations/atmosphere/tools/validate_ob_filters.py
+++ b/parm/jcb-rdas/observations/atmosphere/tools/validate_ob_filters.py
@@ -70,15 +70,15 @@ def validate_file(filename):
         if udesc in SAFE_UDESC:
             continue
 
-        # require where block
-        if not has_where_block(block):
-            issues.append(f"FILTER {fnum} (udescriptor={udesc}): Missing where:")
-            continue
-
         # require ObsType reference inside where except wind gross error checks
         if "gross_error" in udesc.lower():
             if "winds" in filename.lower():  # wind gross error checks
                 continue
+
+        # require where block
+        if not has_where_block(block):
+            issues.append(f"FILTER {fnum} (udescriptor={udesc}): Missing where:")
+            continue
 
         # Require ObsType reference inside where
         if not where_has_obstype(block):

--- a/rrfs-test/IODA/offline_ioda_patch.py
+++ b/rrfs-test/IODA/offline_ioda_patch.py
@@ -103,12 +103,27 @@ for group in groups:
 longitude_latitude_pressure = [f"{lon}_{lat}_{pres}" for lon, lat, pres in zip(obs_lon, obs_lat, obs_prs)]
 longitude_latitude_pressure = np.array(longitude_latitude_pressure)
 
+metadata_group = fout.groups['MetaData']
+
 # Add the longitude_latitude_pressure variable to the file
 var = "longitude_latitude_pressure"
 data = longitude_latitude_pressure
-metadata_group = fout.groups['MetaData']
-metadata_group.createVariable(f"{var}", 'str', 'Location', fill_value=fill)
+if var not in metadata_group.variables:
+    metadata_group.createVariable(f"{var}", 'str', 'Location', fill_value=fill)
 metadata_group.variables[f"{var}"][:] = data
+
+# Add the exp_err_norm to file (for goes-r amvs)
+if 'expectedError' in metadata_group.variables:
+    u = fout.groups['ObsValue'].variables['windEastward'][:]
+    v = fout.groups['ObsValue'].variables['windNorthward'][:]
+    speed = np.sqrt(u*u + v*v)
+    ee = fout.groups['MetaData'].variables['expectedError'][:]
+    experr_norm = (10.0 - 0.1 * ee) / speed
+    var = "exp_err_norm"
+    data = experr_norm.astype('f4')
+    if var not in metadata_group.variables:
+        metadata_group.createVariable(f"{var}", 'f4', 'Location', fill_value=fill)
+    metadata_group.variables[f"{var}"][:] = data
 
 # Close the datasets
 obs_ds.close()

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-remote.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-remote.ref
@@ -1,16 +1,16 @@
 CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 7.1364817388740857e+02, nobs = 463, Jo/n = 1.5413567470570380e+00, err = 9.9999997764825821e-03
-CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 1.0999952733448801e+02, nobs = 284, Jo/n = 3.8732227934678876e-01, err = 1.9779061291273781e+00
-CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 5.6696846075873758e+01, nobs = 304, Jo/n = 1.8650278314432156e-01, err = 1.9087574964639795e+00
-CostFunction: Nonlinear J = 8.8034454729777030e+02
-DRPCGMinimizer: reduction in residual norm = 2.6871068692909773e-02
+CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 1.0843756929381121e+02, nobs = 280, Jo/n = 3.8727703319218287e-01, err = 1.9782929098294915e+00
+CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 5.4426149725385955e+01, nobs = 298, Jo/n = 1.8263808632679851e-01, err = 1.9089334097718391e+00
+CostFunction: Nonlinear J = 8.7651189290660568e+02
+DRPCGMinimizer: reduction in residual norm = 2.5622218353748425e-02
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 28 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7017494473715924e+01 Max:+5.2826953468174921e+01 RMS:+1.3293654888813062e+01
-northward_wind                               | Min:-3.9884273360073706e+01 Max:+3.8607382514641337e+01 RMS:+6.4372722599064423e+00
-air_temperature                              | Min:+1.9402627008843245e+02 Max:+3.2197359427461834e+02 RMS:+2.5823275217251165e+02
+eastward_wind                                | Min:-2.7017494048834831e+01 Max:+5.2826715386346251e+01 RMS:+1.3293611625257631e+01
+northward_wind                               | Min:-3.9884641526540200e+01 Max:+3.8607344136088834e+01 RMS:+6.4372907741248078e+00
+air_temperature                              | Min:+1.9402625243395454e+02 Max:+3.2101597057847619e+02 RMS:+2.5823275983499894e+02
 air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+1.3177235730586376e-01 RMS:+5.5275783775232713e-03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+1.2615174239327770e-01 RMS:+5.5274331556652359e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -26,7 +26,7 @@ soilt                                        | Min:+2.7023922729492188e+02 Max:+
 soilm                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.3592927195821791e-01
 eastward_wind_at_surface                     | Min:-1.2974018096923828e+01 Max:+1.2164360046386719e+01 RMS:+3.6171520010516645e+00
 northward_wind_at_surface                    | Min:-1.3966897010803223e+01 Max:+1.2346966743469238e+01 RMS:+3.7014659136589292e+00
-air_pressure_at_surface                      | Min:+6.6027561600208865e+04 Max:+1.0240633239841486e+05 RMS:+9.6261262179932062e+04
+air_pressure_at_surface                      | Min:+6.6027552619075170e+04 Max:+1.0240633259637054e+05 RMS:+9.6261256078550548e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -35,19 +35,19 @@ cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 1048.927766716314, nobs = 463, Jo/n = 2.265502735888368, err = 0.009999999776482582
-CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 104.6008528071641, nobs = 284, Jo/n = 0.3683128619970567, err = 1.977906129127378
-CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 51.92395694554382, nobs = 304, Jo/n = 0.1708024899524468, err = 1.90875749646398
-CostFunction: Nonlinear J = 1205.452576469022
-DRPCGMinimizer: reduction in residual norm = 0.002418023686737077
+CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 902.3750657118741, nobs = 463, Jo/n = 1.948974223999728, err = 0.009999999776482582
+CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 103.5802643213341, nobs = 280, Jo/n = 0.3699295154333362, err = 1.978292909829491
+CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 50.38029137162552, nobs = 298, Jo/n = 0.1690613804416964, err = 1.908933409771839
+CostFunction: Nonlinear J = 1056.335621404834
+DRPCGMinimizer: reduction in residual norm = 0.002808834664295215
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 28 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7017494718350555e+01 Max:+5.2827600917580611e+01 RMS:+1.3293756281118021e+01
-northward_wind                               | Min:-3.9882718886216310e+01 Max:+3.8607344114987100e+01 RMS:+6.4373075059869027e+00
-air_temperature                              | Min:+1.9402631216603825e+02 Max:+3.2375031248126334e+02 RMS:+2.5823296510266363e+02
+eastward_wind                                | Min:-2.7017494298935791e+01 Max:+5.2827494458973305e+01 RMS:+1.3293732998579767e+01
+northward_wind                               | Min:-3.9882732752403335e+01 Max:+3.8607290767578284e+01 RMS:+6.4373336234324272e+00
+air_temperature                              | Min:+1.9402630283277577e+02 Max:+3.2316282190843162e+02 RMS:+2.5823297157092583e+02
 air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+1.4098523474914482e-01 RMS:+5.5269402294582121e-03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+1.3732211951604886e-01 RMS:+5.5268492668473857e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -63,7 +63,7 @@ soilt                                        | Min:+2.7023922729492188e+02 Max:+
 soilm                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.3592927195821791e-01
 eastward_wind_at_surface                     | Min:-1.2974018096923828e+01 Max:+1.2164360046386719e+01 RMS:+3.6171520010516645e+00
 northward_wind_at_surface                    | Min:-1.3966897010803223e+01 Max:+1.2346966743469238e+01 RMS:+3.7014659136589292e+00
-air_pressure_at_surface                      | Min:+6.6027567629483819e+04 Max:+1.0240633188292434e+05 RMS:+9.6261267891193973e+04
+air_pressure_at_surface                      | Min:+6.6027559315060018e+04 Max:+1.0240633197687284e+05 RMS:+9.6261262630708225e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -72,7 +72,7 @@ cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 100.3863454000944, nobs = 463, Jo/n = 0.2168171606913485, err = 0.009999999776482582
-CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 104.0113311747287, nobs = 284, Jo/n = 0.3662370816011575, err = 1.977906129127378
-CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 51.46792491115697, nobs = 304, Jo/n = 0.1693023845761742, err = 1.90875749646398
-CostFunction: Nonlinear J = 255.8656014859801
+CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 96.29391547586744, nobs = 463, Jo/n = 0.20797821917034, err = 0.009999999776482582
+CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 102.9054119828246, nobs = 280, Jo/n = 0.3675193285100879, err = 1.978292909829491
+CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 49.87801175213868, nobs = 298, Jo/n = 0.1673758783628815, err = 1.908933409771839
+CostFunction: Nonlinear J = 249.0773392108307


### PR DESCRIPTION
Update the satwnd obs space yamls and the ioda patch tool for another variable needed for satwnd qc.
## Description
This PR strengthens and modernizes the satwnd (245) GOES-R AMV observation-space templates (245_270 and 245_272) and updates the offline IODA patch utility to support new metadata required by recent QC filters.

Key Changes:
- Satwnd YAML Hardening (245_270 & 245_272)
  - Corrected iuse variable
  - unified and explicit `where` scoping
  - refactored time-window check
  - Fixed `bounds_check_pressure_over_land` and `bounds_check_reject_over_nonwater` by changing from `Bounds Check` to `Perform Action` and consolodiating all conditions into the `where` block.
  - Added `reject_low_speed_amv` and `amv_experr_norm_check`
  - Improved overall readability and structure
- Enhanced offline IODA patch tool by adding `exp_err_norm` calculation

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
