### PR TITLE
Update convinfo vs j2 comparison tool and add offline duplicate tagging tool

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/tools/check_j2_convinfo.py
+++ b/parm/jcb-rdas/observations/atmosphere/tools/check_j2_convinfo.py
@@ -42,25 +42,48 @@ udesc_to_filtername = {
 
 def parse_yaml(filename):
     """Extract gross/ermin/ermax/twindow from YAML structure using udescriptor mapping."""
+
+    # === READ YAML FILE ===
     with open(filename, "r") as f:
         text = f.read()
 
+    # Render Jinja template (empty context removes placeholders)
     template = jinja2.Template(text)
-    rendered = template.render()  # Render with empty context to remove placeholders
+    rendered = template.render()
     data = yaml.safe_load(rendered)
 
     if not isinstance(data, list):
         raise ValueError(f"{filename}: expected list of filters at top level")
 
+    # === EXTRACT VARIABLE, TYPECODE, SUBTYPE FROM FILENAME ===
     base = os.path.basename(filename)
-    parts = base.replace(".yaml.j2", "").split("_")
-    varname = parts[1]
-    typecode = parts[-1]
+    name = base.replace(".yaml.j2", "")
+    parts = name.split("_")
 
+    # parts format examples:
+    #   sfcshp_winds_280.yaml.j2           -> nums = [280]
+    #   satwnd_winds_245_270.yaml.j2      -> nums = [245, 270]
+
+    varname = parts[1]
+
+    # Pull numeric tokens after varname
+    nums = [p for p in parts[2:] if p.isdigit()]
+
+    if len(nums) == 1:
+        typecode = int(nums[0])
+        subtype = 0  # subtype default when not specified
+    elif len(nums) == 2:
+        typecode = int(nums[0])
+        subtype = int(nums[1])
+    else:
+        raise ValueError(f"Unexpected numeric pattern in YAML filename '{base}'")
+
+    # YAML -> otype mapping
     otype = VAR_TO_OTYPE.get(varname)
     if otype is None:
         raise ValueError(f"Unmapped variable name '{varname}' in {base}")
 
+    # === EXTRACT FILTER PARAMETERS ===
     gross = ermin = ermax = twindow = None
 
     # Find the 'obs filters' section
@@ -70,6 +93,7 @@ def parse_yaml(filename):
             filters = section['obs filters']
             break
 
+    # Loop through filter blocks
     for block in filters:
         if not isinstance(block, dict):
             continue
@@ -82,13 +106,11 @@ def parse_yaml(filename):
         if not filter_name:
             continue
 
-        # ===== NEW LOGIC FOR GROSS / ERMIN / ERMAX =====
-
-        # Only pull the main gross value from "gross_error_check"
+        # ===== GROSS ERROR CHECK =====
         if filter_name == "gross_error_check":
-            # For Background Check, threshold is directly in the block
             gross = block.get("threshold")
             if gross is None:
+                # Look for WindsSPDBCheck
                 fat = block.get("function absolute threshold", [])
                 if fat and isinstance(fat, list):
                     func = fat[0]
@@ -104,7 +126,7 @@ def parse_yaml(filename):
                         if ermax_list:
                             ermax = ermax_list[0]
 
-        # Error min
+        # ===== ERMIN =====
         elif filter_name == "ermin_set":
             fvars = block.get("filter variables", [])
             if fvars:
@@ -112,7 +134,7 @@ def parse_yaml(filename):
             if ermin is None:
                 ermin = block.get("action", {}).get("error parameter")
 
-        # Error max
+        # ===== ERMAX =====
         elif filter_name == "ermax_set":
             fvars = block.get("filter variables", [])
             if fvars:
@@ -120,21 +142,20 @@ def parse_yaml(filename):
             if ermax is None:
                 ermax = block.get("action", {}).get("error parameter")
 
-        # ===== EXTRACT TIME WINDOW =====
+        # ===== TIME WINDOW =====
         if filter_name == "time_window_check":
-            tw_min = None
-            tw_max = None
             tw_min = block.get("minvalue")
             tw_max = block.get("maxvalue")
             if tw_min is not None and tw_max is not None:
-                # typical YAML has minvalue: -twin, maxvalue: +twin
                 twindow_sec = max(abs(tw_min), abs(tw_max))
-                twindow = twindow_sec #/ 3600.0
+                twindow = twindow_sec  # seconds, matching convinfo format
 
+    # === RETURN RESULTS ===
     return {
         "file": base,
         "otype": otype,
-        "type": int(typecode),
+        "type": typecode,
+        "subtype": subtype,
         "yaml_twindow": twindow,
         "yaml_gross": gross,
         "yaml_ermin": ermin,
@@ -145,6 +166,7 @@ def parse_yaml(filename):
 def parse_convinfo(filename="convinfo.rrfs"):
     """Read convinfo.rrfs into a dataframe."""
     rows = []
+    VALID_OTYPES = {"ps", "q", "t", "uv"}
     with open(filename) as f:
         for line in f:
             if line.strip().startswith("!"):  # skip comments
@@ -152,9 +174,17 @@ def parse_convinfo(filename="convinfo.rrfs"):
             parts = line.split()
             if len(parts) < 11:
                 continue
+            # Skip any otype no in desired set
+            otype = parts[0]
+            if otype not in VALID_OTYPES:
+                continue
+            # Skip entries where iuse != 1
+            iuse = int(parts[3])
+            if iuse != 1:
+                continue
             otype = parts[0]
             typecode = int(parts[1])
-            # Based on header: otype type sub iuse twindow numgrp ngroup nmiter gross ermax ermin ...
+            subtype  = int(parts[2])
             twindow = float(parts[4])*3600.
             gross = float(parts[8])
             ermax = float(parts[9])
@@ -162,6 +192,7 @@ def parse_convinfo(filename="convinfo.rrfs"):
             rows.append({
                 "otype": otype,
                 "type": typecode,
+                "subtype": subtype,
                 "conv_twindow": twindow,
                 "conv_gross": gross,
                 "conv_ermin": ermin,
@@ -183,7 +214,8 @@ def main():
     df_conv = parse_convinfo("convinfo.rrfs")
 
     # Merge for comparison
-    df = pd.merge(df_yaml, df_conv, on=["otype", "type"], how="outer")
+    #df = pd.merge(df_yaml, df_conv, on=["otype", "type"], how="outer")
+    df = pd.merge(df_yaml, df_conv, on=["otype","type","subtype"], how="outer")
 
     # Add match column with scaling for 'ps'
     scale_factor = np.where(df['otype'] == 'ps', 100.0, 1.0)

--- a/rrfs-test/IODA/offline_duplicate_tagger.py
+++ b/rrfs-test/IODA/offline_duplicate_tagger.py
@@ -1,0 +1,180 @@
+import netCDF4 as nc
+import numpy as np
+import os
+
+# Default settings
+DEFAULT_ID_FIELDS = ('dateTime', 'longitude_latitude_pressure')
+DEFAULT_TAG_NAME = 'usedPreviously'
+DEFAULT_FILL_VALUE = -1
+
+
+def tag_previous_observations(current_filepath, previous_filepaths, output_filepath=None,
+                               id_fields=DEFAULT_ID_FIELDS,
+                               tag_name=DEFAULT_TAG_NAME,
+                               fill_value=DEFAULT_FILL_VALUE):
+    """
+    Reads the current IODA file and one or more previous IODA files,
+    tags observations in the current file that appear in any previous files.
+
+    Args:
+        current_filepath (str): Path to the current cycle's IODA .nc file.
+        previous_filepaths (list of str): Paths to previous cycles' IODA .nc files.
+        output_filepath (str, optional): Where to write the tagged IODA file.
+            If None, will overwrite current_filepath.
+        id_fields (tuple of str): MetaData field names to use as a composite key.
+        tag_name (str): Name of the new MetaData variable to create (integer: 0/1).
+        fill_value (int): Value to use for missing/uninitialized entries.
+    """
+    if output_filepath is None:
+        output_filepath = current_filepath
+    else:
+        import shutil
+        shutil.copy(current_filepath, output_filepath)
+
+    prev_keys = set()
+    valid_prev_paths = [p for p in previous_filepaths if os.path.exists(p)]
+
+    if not valid_prev_paths:
+        print("No valid previous files found. All observations will be considered new.")
+    else:
+        for p in previous_filepaths:
+            if not os.path.exists(p):
+                print(f"Warning: Previous file not found and will be skipped: {p}")
+
+        for prev_path in valid_prev_paths:
+            with nc.Dataset(prev_path) as prev_ds:
+                meta = prev_ds['MetaData']
+                values = []
+                for field in id_fields:
+                    arr = meta[field][:]
+                    if arr.dtype.kind in ('S', 'U'):
+                        arr = np.array([s.tobytes().decode('utf-8').strip() for s in arr])
+                    values.append(arr.astype(str))
+                combined = np.char.add(values[0], np.char.add('_', values[1]))
+                prev_keys.update(combined.tolist())
+
+    with nc.Dataset(output_filepath, 'r+') as cur_ds:
+        grp = cur_ds.groups['MetaData']
+        if tag_name in grp.variables:
+            tag_var = grp.variables[tag_name]
+        else:
+            tag_var = grp.createVariable(tag_name, 'i4', ('Location',), fill_value=fill_value)
+            tag_var.long_name = "Observation used previously"
+            tag_var.units = f"1=used before, 0=new, {fill_value}=missing"
+
+        cur_meta = grp
+        cur_values = []
+        for field in id_fields:
+            arr = cur_meta[field][:]
+            if arr.dtype.kind in ('S', 'U'):
+                arr = np.array([s.tobytes().decode('utf-8').strip() for s in arr])
+            cur_values.append(arr.astype(str))
+        current_keys = np.char.add(cur_values[0], np.char.add('_', cur_values[1]))
+
+        flags = np.full(current_keys.shape, fill_value, dtype=np.int32)
+        if not prev_keys:
+            flags[:] = 0  # No previous keys, mark everything as new
+        else:
+            for i, key in enumerate(current_keys):
+                flags[i] = 1 if key in prev_keys else 0
+        tag_var[:] = flags
+
+    print(f"Tagged observations saved to: {output_filepath}")
+
+
+def verify_tagging(current_filepath, tagged_filepath=None,
+                   id_fields=DEFAULT_ID_FIELDS,
+                   tag_name=DEFAULT_TAG_NAME, sample_size=5):
+    """
+    Verifies tagging by comparing raw composite keys and tag variable.
+
+    Args:
+        current_filepath (str): Path to the original current-cycle .nc file.
+        tagged_filepath (str, optional): Path to the tagged .nc file.
+        id_fields (tuple of str): Fields used for composite key. Must match tagging.
+        tag_name (str): Name of the tagging variable.
+        sample_size (int): Number of sample entries to display.
+    """
+    if tagged_filepath is None:
+        tagged_filepath = current_filepath
+
+    with nc.Dataset(current_filepath) as orig_ds:
+        orig_meta = orig_ds['MetaData']
+        values = []
+        for field in id_fields:
+            arr = orig_meta[field][:]
+            if arr.dtype.kind in ('S', 'U'):
+                arr = np.array([s.tobytes().decode('utf-8').strip() for s in arr])
+            values.append(arr.astype(str))
+        keys = np.char.add(values[0], np.char.add('_', values[1]))
+
+    with nc.Dataset(tagged_filepath) as tag_ds:
+        tag_var = tag_ds['MetaData'].variables[tag_name][:]
+
+    total = len(keys)
+    reused = np.sum(tag_var == 1)
+    new = np.sum(tag_var == 0)
+    missing = np.sum(tag_var == DEFAULT_FILL_VALUE)
+
+    print(f"Total observations: {total}")
+    print(f"Reused (tag=1): {reused} ({reused/total:.1%})")
+    print(f"New    (tag=0): {new} ({new/total:.1%})\n")
+
+    reused_indices = np.where(tag_var == 1)[0]
+    new_indices = np.where(tag_var == 0)[0]
+    missing_indices = np.where(tag_var == DEFAULT_FILL_VALUE)[0]
+
+    if sample_size > 0:
+        print("Sample reused observations:")
+        for idx in reused_indices[:sample_size]:
+            print(f"  idx={idx}, key={keys[idx]}")
+        print("\nSample new observations:")
+        for idx in new_indices[:sample_size]:
+            print(f"  idx={idx}, key={keys[idx]}")
+        print("\nSample missing observations:")
+        for idx in missing_indices[:sample_size]:
+            print(f"  idx={idx}, key={keys[idx]}")
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Tag observations in current IODA file and optionally verify tagging.')
+    subparsers = parser.add_subparsers(dest='cmd')
+
+    tag_parser = subparsers.add_parser('tag', help='Run tagging')
+    tag_parser.add_argument('current', help='Current cycle IODA .nc file')
+    tag_parser.add_argument('-p', '--previous', nargs='+', required=True,
+                            help='Previous cycle IODA .nc files')
+    tag_parser.add_argument('-o', '--output', default=None,
+                            help='Output file path')
+    tag_parser.add_argument('--id-fields', nargs=2,
+                            default=list(DEFAULT_ID_FIELDS),
+                            help='MetaData fields for composite key')
+    tag_parser.add_argument('--tag-name', default=DEFAULT_TAG_NAME,
+                            help='Name of tagging variable')
+    tag_parser.add_argument('--fill-value', type=int, default=DEFAULT_FILL_VALUE,
+                            help='Fill value for missing entries')
+
+    verify_parser = subparsers.add_parser('verify', help='Verify tagging results')
+    verify_parser.add_argument('current', help='Original current IODA .nc file')
+    verify_parser.add_argument('-t', '--tagged', default=None,
+                               help='Tagged .nc file to verify')
+    verify_parser.add_argument('--id-fields', nargs=2,
+                               default=list(DEFAULT_ID_FIELDS),
+                               help='MetaData fields for composite key')
+    verify_parser.add_argument('--tag-name', default=DEFAULT_TAG_NAME,
+                               help='Name of tagging variable')
+    verify_parser.add_argument('-n', '--sample-size', type=int, default=5,
+                               help='Number of sample entries to show')
+
+    args = parser.parse_args()
+    if args.cmd == 'tag':
+        tag_previous_observations(args.current, args.previous,
+                                   args.output, tuple(args.id_fields),
+                                   args.tag_name, args.fill_value)
+    elif args.cmd == 'verify':
+        verify_tagging(args.current, args.tagged,
+                       tuple(args.id_fields), args.tag_name, args.sample_size)
+    else:
+        parser.print_help()


### PR DESCRIPTION
## Description
This PR updates a tool and adds yet another offline tool
- Updated tool (`check_j2_convinfo.py`): Updates makes it work for satwnd j2 file. Simply run this tool without any arguments and it checks the convinfo settings vs what is actually prescribed in each j2 template.
- New tool (`offline_duplicate_tagger.py`): Takes two ioda files from different cycles (e.g., 00Z and 01Z both ioda_adpupa.nc) and find duplicated (from cycle-to-cycle). This is possible because our time window is +/-1.5h and the exact same obs are possibly assimilated more more than one cycle while treating them as independent obs. The goal at the moment is to just run this in the workflow as diagnostic only to get a better understanding of how many obs are potentially duplicate (from cycle-to-cycle). This tool simply adds a new metadata field and mark it as either 0=new or 1=usedPreviously or -1=default. In the future, we could use this metadata field to filter out those duplicate obs.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] no ctest needed for this.
