### PR TITLE
Two new tools: make_empty_ioda.py and get_obs_error.py

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/tools/get_obs_error.py
+++ b/parm/jcb-rdas/observations/atmosphere/tools/get_obs_error.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import sys
+
+def parse_file(file_path, obtype, error_col_index):
+    with open(file_path, 'r') as file:
+        lines = file.readlines()
+
+    xvals = []
+    errors = []
+    obtype_section = False
+
+    for line in lines:
+        line = line.strip()
+
+        # Check for the obtype identifier
+        if line.startswith(str(obtype)):
+            obtype_section = True
+            continue
+        elif line.startswith("c") or not line or line.startswith(tuple(map(str, range(obtype + 1, obtype + 2)))):
+            obtype_section = False
+
+        # If we're in the specified obtype section, parse the lines
+        if obtype_section:
+            columns = line.split()
+            if len(columns) >= max(2, error_col_index + 1):
+                try:
+                    xval = int(float(columns[0])*100)
+                    if(error_col_index == 2): #RH
+                      error = round(float(columns[error_col_index])/10.,13)
+                    elif(error_col_index == 4): #sfcp
+                      error = round(float(columns[error_col_index])*100.,6)
+                    else:
+                      error = float(columns[error_col_index])
+                    xvals.append(xval)
+                    errors.append(error)
+                except ValueError:
+                    continue
+
+    return xvals, errors
+
+def main():
+    if len(sys.argv) != 4:
+        print("Usage: python get_obs_error.py <file_path> <obtype> <error_col_index>")
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+    obtype = int(sys.argv[2])
+    error_col_index = int(sys.argv[3])
+    if error_col_index == 1:
+        print(f"error_col_index={error_col_index} (T)")
+    if error_col_index == 2:
+        print(f"error_col_index={error_col_index} (RH)")
+    if error_col_index == 3:
+        print(f"error_col_index={error_col_index} (UV)")
+    if error_col_index == 4:
+        print(f"error_col_index={error_col_index} (Ps)")
+
+    xvals, errors = parse_file(file_path, obtype, error_col_index)
+
+    print(f'xvals: {xvals}')
+    print(f'errors: {errors}')
+
+if __name__ == '__main__':
+    main()

--- a/parm/jcb-rdas/observations/atmosphere/tools/make_ioda_empty.py
+++ b/parm/jcb-rdas/observations/atmosphere/tools/make_ioda_empty.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+import sys
+import numpy as np
+from netCDF4 import Dataset, stringtochar, VLType
+
+def is_string_type(var):
+    """
+    Return True if var is any known form of netCDF string:
+    - netCDF4 datatype == str
+    - netCDF4 variable-length string (VLType)
+    - numpy byte string (kind='S')
+    - numpy unicode (kind='U')
+    """
+    dt = var.datatype
+
+    # netCDF4 classic variable-length string
+    if dt == str:
+        return True
+
+    # netCDF4 VLType string
+    if isinstance(dt, VLType):
+        return True
+
+    # numpy dtype cases
+    try:
+        if hasattr(var.dtype, "kind"):
+            if var.dtype.kind in ("S", "U"):
+                return True
+    except Exception:
+        pass
+
+    return False
+
+def copy_non_fill_attributes(src, dst):
+    for aname in src.ncattrs():
+        if aname == "_FillValue":
+            continue
+        dst.setncattr(aname, src.getncattr(aname))
+
+def create_empty_variable(ncout, gname, vname, var):
+    # Fill value before creation
+    fill_value = var._FillValue if "_FillValue" in var.ncattrs() else None
+
+    # Dimensions: Location -> 1
+    dims = []
+    for d in var.dimensions:
+        if d == "Location":
+            dims.append("Location")
+        else:
+            dims.append(d)
+
+    # Create variable with fill_value at creation time
+    vout = ncout.groups[gname].createVariable(
+        vname,
+        var.dtype,
+        dims,
+        fill_value=fill_value
+    )
+
+    # Copy all NON-fill-value attributes
+    copy_non_fill_attributes(var, vout)
+
+    # Build shape
+    shape = []
+    for d in dims:
+        if d == "Location":
+            shape.append(1)
+        else:
+            shape.append(ncout.dimensions[d].size)
+
+    # Construct empty data
+    if is_string_type(var):
+        arr = np.empty(shape, dtype=object)
+        fv = fill_value if fill_value not in (None, "") else ""
+        for idx in np.ndindex(*shape):
+            arr[idx] = fv
+
+        # Convert to char array if needed
+        try:
+            if vout.dtype.kind == "S":
+                arr = stringtochar(arr)
+        except Exception:
+            pass
+
+    else:
+        fv = fill_value if fill_value is not None else 0
+        arr = np.full(shape, fv, dtype=var.dtype)
+
+    vout[:] = arr
+
+def create_empty_ioda(input_file, output_file):
+    fin = Dataset(input_file, "r")
+    fout = Dataset(output_file, "w", format="NETCDF4")
+
+    # Global attributes
+    for a in fin.ncattrs():
+        fout.setncattr(a, fin.getncattr(a))
+
+    # Dimensions
+    for dname, dim in fin.dimensions.items():
+        if dname == "Location":
+            fout.createDimension("Location", 1)
+        else:
+            fout.createDimension(dname, len(dim))
+
+    # Groups
+    for gname in fin.groups:
+        fout.createGroup(gname)
+
+    # Variables
+    for gname, grp in fin.groups.items():
+        for vname, var in grp.variables.items():
+            create_empty_variable(fout, gname, vname, var)
+
+    fin.close()
+    fout.close()
+    print(f"Created empty/masked IODA file: {output_file}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: make_ioda_empty.py input.nc output.nc")
+        sys.exit(1)
+    create_empty_ioda(sys.argv[1], sys.argv[2])
+


### PR DESCRIPTION
## Description
This PR adds two new handy tools that have been floating around for some time. It seems these will be useful to have saved.
- **`make_empty_ioda.py`**
  - **What it does:** generates an IODA file that contains the full variable and group structure of an existing IODA file but with a single empty "Location" entry. It preserves all dimensions, groups, variable names, types, and attributes while replacing the data with empty or fill-value content. Every output file mirrors the schema of the input file exactly.
  - **Why this matters:** in the workflow, we pre-stage ioda_empty.nc file for every observation type (ioda_adpupa.nc, ioda_aircar.nc, etc.). The BUFR2IODA converters then either overwrite that file when real data are present or leave the empty version untouched when no data exists. This solves two problems: 1) downstream tasks always see a valid IODA file with the correct structure, even when an obs type has zero observations. 2) When the workflow consumes these files to create JEDI diagnostics, an empty IODA file leads to a zero-length jdiag that is explict and intentional. Without this, the workflow would produce no file at all, which is ambiguous and can mask silent failures.
- **`get_obs_error.py`**
  - **What it does:** extracts observation error values for a specific observation type from a legacy GSI-style errtable. Given an `obtype` identifier and an error-column index, it parses only the lines belonging to that obtype and returns the x-values (scaled heights/pressures/etc.) and the corresponding error values, applying the unit conversions required for RH and surface pressure.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] No need to run ctests for this PR as it just adds python utilities.
