### PR TITLE
Minor JCB configuration updates needed for radar DA cycling

### DIFF
--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3denvar_bump.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_3denvar_bump.yaml.j2
@@ -42,7 +42,7 @@ localization:
     active variables: {{analysis_variables}}
     read:
       io:
-        files prefix: {{atmosphere_fv3jedi_files_path}}/bump_401km_0p04sigma_mpi160/bumploc_401km0p04sigma
+        files prefix: {{atmosphere_fv3jedi_files_path}}/{{bumploc_path}}/{{bumploc_prefix}}
       drivers:
         multivariate strategy: duplicated
         read local nicas: true

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_hybrid3denvar_bump.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_hybrid3denvar_bump.yaml.j2
@@ -104,7 +104,7 @@ components:
         active variables: {{analysis_variables}}
         read:
           io:
-            files prefix: {{atmosphere_fv3jedi_files_path}}/bump_401km_0p04sigma_mpi160/bumploc_401km0p04sigma
+            files prefix: {{atmosphere_fv3jedi_files_path}}/{{bumploc_path}}/{{bumploc_prefix}}
           drivers:
              multivariate strategy: duplicated
              read local nicas: true

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_hybrid3denvar_bump_refl.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_hybrid3denvar_bump_refl.yaml.j2
@@ -19,8 +19,8 @@ components:
         function space: StructuredColumns
         custom grid matching gsi:
           type: rotated_lonlat
-          lats: {{atmosphere_npy_ges}}
-          lons: {{atmosphere_npx_ges}}
+          lats: {{gsibec_lats}}
+          lons: {{gsibec_lons}}
           lat_start: {{lat_start}}
           lat_end: {{lat_end}}
           lon_start: {{lon_start}}
@@ -41,6 +41,8 @@ components:
       - water_vapor_mixing_ratio_wrt_moist_air
       - air_pressure_at_surface
       - air_pressure_thickness
+      - geopotential_height_times_gravity_at_surface
+      - ozone_mass_mixing_ratio
     linear variable change:
       linear variable change name: Control2Analysis
       input variables:
@@ -118,7 +120,7 @@ components:
         active variables: {{analysis_variables}}
         read:
           io:
-            files prefix: {{atmosphere_fv3jedi_files_path}}/bump_401km_0p04sigma_mpi160/bumploc_401km0p04sigma
+            files prefix: {{atmosphere_fv3jedi_files_path}}/{{bumploc_path}}/{{bumploc_prefix}}
           drivers:
              multivariate strategy: duplicated
              read local nicas: true

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_hybrid3denvar_mgbf_refl.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_background_error_hybrid3denvar_mgbf_refl.yaml.j2
@@ -19,8 +19,8 @@ components:
         function space: StructuredColumns
         custom grid matching gsi:
           type: rotated_lonlat
-          lats: {{atmosphere_npy_ges}}
-          lons: {{atmosphere_npx_ges}}
+          lats: {{gsibec_lats}}
+          lons: {{gsibec_lons}}
           lat_start: {{lat_start}}
           lat_end: {{lat_end}}
           lon_start: {{lon_start}}
@@ -41,6 +41,8 @@ components:
       - water_vapor_mixing_ratio_wrt_moist_air
       - air_pressure_at_surface
       - air_pressure_thickness
+      - geopotential_height_times_gravity_at_surface
+      - ozone_mass_mixing_ratio
     linear variable change:
       linear variable change name: Control2Analysis
       input variables:

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_final_increment.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_final_increment.yaml.j2
@@ -9,9 +9,23 @@ output:
       eastward_wind: {{eastward_wind}}
       northward_wind: {{northward_wind}}
       air_temperature: {{air_temperature}}
-      air_pressure_at_surface: {{air_pressure_at_surface}}
+      air_pressure_thickness: {{air_pressure_thickness}}
       water_vapor_mixing_ratio_wrt_moist_air: {{water_vapor_mixing_ratio_wrt_moist_air}}
+      cloud_liquid_ice: {{cloud_liquid_ice}}
+      cloud_liquid_water: {{cloud_liquid_water}}
       ozone_mass_mixing_ratio: {{ozone_mass_mixing_ratio}}
+      geopotential_height_times_gravity_at_surface: {{geopotential_height_times_gravity_at_surface}}
+      skin_temperature_at_surface: {{skin_temperature_at_surface}}
+      soilt: {{soilt}}
+      soilm: {{soilm}}
+      eastward_wind_at_surface: {{eastward_wind_at_surface}}
+      northward_wind_at_surface: {{northward_wind_at_surface}}
+      rain_water: {{rain_water}}
+      snow_water: {{snow_water}}
+      graupel: {{graupel}}
+      upward_air_velocity: {{upward_air_velocity}}
+      equivalent_reflectivity_factor: {{equivalent_reflectivity_factor}}
+
 
 geometry:
   fms initialization:

--- a/parm/jcb-rdas/model/atmosphere/atmosphere_final_increment.yaml.j2
+++ b/parm/jcb-rdas/model/atmosphere/atmosphere_final_increment.yaml.j2
@@ -9,6 +9,7 @@ output:
       eastward_wind: {{eastward_wind}}
       northward_wind: {{northward_wind}}
       air_temperature: {{air_temperature}}
+      air_pressure_at_surface: {{air_pressure_at_surface}}
       air_pressure_thickness: {{air_pressure_thickness}}
       water_vapor_mixing_ratio_wrt_moist_air: {{water_vapor_mixing_ratio_wrt_moist_air}}
       cloud_liquid_ice: {{cloud_liquid_ice}}

--- a/parm/jcb-rdas/test/ci/jcb-rrfs_fv3jedi_2024052700_3denvar.yaml
+++ b/parm/jcb-rdas/test/ci/jcb-rrfs_fv3jedi_2024052700_3denvar.yaml
@@ -150,6 +150,8 @@ lon_end: 25.076254
 north_pole_lat: 51.499999
 north_pole_lon: 82.500018
 gsi_bands: 10
+bumploc_path: bump_401km_0p04sigma_mpi160
+bumploc_prefix: bumploc_401km0p04sigma
 
 # Forecasting
 atmosphere_forecast_length: PT6H

--- a/parm/jcb-rdas/test/ci/jcb-rrfs_fv3jedi_2024052700_hybrid3denvar.yaml
+++ b/parm/jcb-rdas/test/ci/jcb-rrfs_fv3jedi_2024052700_hybrid3denvar.yaml
@@ -150,6 +150,8 @@ lon_end: 25.076254
 north_pole_lat: 51.499999
 north_pole_lon: 82.500018
 gsi_bands: 10
+bumploc_path: bump_401km_0p04sigma_mpi160
+bumploc_prefix: bumploc_401km0p04sigma
 
 # Forecasting
 atmosphere_forecast_length: PT6H


### PR DESCRIPTION
## Description

This PR includes a small set of workflow and configuration updates needed to support cycling radar reflectivity DA in rrfs-workflow.

- Define BUMP localization files as a JCB variable instead of hard coding them. This allows the same JCB templates to be reused for radar DA in rrfs-workflow with different length scales.
- Update `atmosphere_background_error_hybrid3denvar_bump_refl.yaml.j2` to reflect recent gsibec variable name changes. This template was missed in #510 since it is only used in rrfs-workflow and not in a ctest.
- Extend `field io names` in `atmosphere_final_increment.yaml.j2` to include additional state variables required by radar DA so that increments are written with the expected variable names.

These changes are primarily configuration and template fixes and should not affect anything in RDASApp. But I will run CI tests here to confirm. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
