### PR TITLE
Add JCB options for writing jdiag files in parallel

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/abi_g16.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/abi_g16.yaml.j2
@@ -12,11 +12,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_abi_g16.nc4
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &abi_g16_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}

--- a/parm/jcb-rdas/observations/atmosphere/abi_g18.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/abi_g18.yaml.j2
@@ -12,11 +12,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_abi_g18.nc4
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &abi_g18_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_181.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_airTemperature_181.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_183.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_airTemperature_183.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_187.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_airTemperature_187.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_181.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_specificHumidity_181.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_183.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_specificHumidity_183.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_187.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_specificHumidity_187.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_181.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_stationPressure_181.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [stationPressure]
          simulated variables: [stationPressure]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_187.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_stationPressure_187.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [stationPressure]
          simulated variables: [stationPressure]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_281.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_281.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_winds_281.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_284.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_284.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_winds_284.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_287.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_287.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpsfc_winds_287.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_airTemperature_120.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_airTemperature_120.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpupa_airTemperature_120.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_airTemperature_132.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_airTemperature_132.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpupa_airTemperature_132.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_specificHumidity_120.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_specificHumidity_120.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpupa_specificHumidity_120.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_specificHumidity_132.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_specificHumidity_132.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpupa_specificHumidity_132.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_stationPressure_120.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_stationPressure_120.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpupa_stationPressure_120.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [stationPressure]
          simulated variables: [stationPressure]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_winds_220.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_winds_220.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpupa_winds_220.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/adpupa_winds_232.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpupa_winds_232.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_adpupa_winds_232.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircar_airTemperature_133.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircar_airTemperature_133.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircar_airTemperature_133.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircar_specificHumidity_133.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircar_specificHumidity_133.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircar_specificHumidity_133.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircar_winds_233.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircar_winds_233.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircar_winds_233.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_130.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_130.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_airTemperature_130.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_131.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_131.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_airTemperature_131.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_134.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_134.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_airTemperature_134.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_135.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_airTemperature_135.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_airTemperature_135.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_specificHumidity_134.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_specificHumidity_134.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_specificHumidity_134.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_winds_230.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_winds_230.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_winds_230.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_winds_231.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_winds_231.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_winds_231.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_winds_234.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_winds_234.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_winds_234.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/aircft_winds_235.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/aircft_winds_235.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_aircft_winds_235.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/amsua_metop-b.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/amsua_metop-b.yaml.j2
@@ -10,9 +10,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_amsua_metop-b.nc
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &amsua_metop-b_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}

--- a/parm/jcb-rdas/observations/atmosphere/amsua_metop-c.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/amsua_metop-c.yaml.j2
@@ -10,9 +10,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_amsua_metop-c.nc
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &amsua_metop-c_channels  {{ get_satellite_variable(observation_from_jcb, "simulated") }}

--- a/parm/jcb-rdas/observations/atmosphere/amsua_n19.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/amsua_n19.yaml.j2
@@ -10,9 +10,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_amsua_n19.nc
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &amsua_n19_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}

--- a/parm/jcb-rdas/observations/atmosphere/atms_n20.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/atms_n20.yaml.j2
@@ -10,9 +10,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_atms_n20.nc4
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &atms_n20_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}

--- a/parm/jcb-rdas/observations/atmosphere/atms_n21.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/atms_n21.yaml.j2
@@ -10,9 +10,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_atms_n21.nc4
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &atms_n21_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}

--- a/parm/jcb-rdas/observations/atmosphere/atms_npp.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/atms_npp.yaml.j2
@@ -10,9 +10,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_atms_npp.nc4
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]
          observed variables: [brightnessTemperature]
          channels: &atms_npp_channels {{ get_satellite_variable(observation_from_jcb, "simulated") }}

--- a/parm/jcb-rdas/observations/atmosphere/cris-fsr_n20.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/cris-fsr_n20.yaml.j2
@@ -10,11 +10,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_cris-fsr_n20.nc
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [radiance]
          simulated variables: [brightnessTemperature]
          derived variables: [brightnessTemperature]

--- a/parm/jcb-rdas/observations/atmosphere/cris-fsr_n21.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/cris-fsr_n21.yaml.j2
@@ -10,11 +10,12 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_cris-fsr_n21.nc
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [radiance]
          simulated variables: [brightnessTemperature]
          derived variables: [brightnessTemperature]

--- a/parm/jcb-rdas/observations/atmosphere/gnss_zenithTotalDelay.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/gnss_zenithTotalDelay.yaml.j2
@@ -10,12 +10,13 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_gnss_ztd.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [zenithTotalDelay]
          observed variables: [zenithTotalDelay]
 

--- a/parm/jcb-rdas/observations/atmosphere/mrms_refl.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/mrms_refl.yaml.j2
@@ -10,12 +10,13 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_mrms_refl.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [equivalentReflectivityFactor]
          observed variables: [equivalentReflectivityFactor]
 

--- a/parm/jcb-rdas/observations/atmosphere/msonet_airTemperature_188.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/msonet_airTemperature_188.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_msonet_airTemperature_188.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/msonet_specificHumidity_188.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/msonet_specificHumidity_188.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_msonet_specificHumidity_188.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/msonet_stationPressure_188.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/msonet_stationPressure_188.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_msonet_stationPressure_188.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [stationPressure]
          simulated variables: [stationPressure]
 

--- a/parm/jcb-rdas/observations/atmosphere/msonet_winds_288.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/msonet_winds_288.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_msonet_winds_288.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/proflr_winds_227.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/proflr_winds_227.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_proflr_winds_227.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/rassda_airTemperature_126.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/rassda_airTemperature_126.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_rassda_airTemperature_126.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_270.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_270.yaml.j2
@@ -10,12 +10,13 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_satwnd_winds_245_270.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_272.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_272.yaml.j2
@@ -10,12 +10,13 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_satwnd_winds_245_272.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_270.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_270.yaml.j2
@@ -10,12 +10,13 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_satwnd_winds_246_270.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_272.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_272.yaml.j2
@@ -10,12 +10,13 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_satwnd_winds_246_272.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_270.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_270.yaml.j2
@@ -10,12 +10,13 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_satwnd_winds_247_270.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_272.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_272.yaml.j2
@@ -10,12 +10,13 @@
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_satwnd_winds_247_272.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_180.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_airTemperature_180.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_182.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_airTemperature_182.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_183.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_airTemperature_183.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [airTemperature]
          simulated variables: [airTemperature]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_180.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_specificHumidity_180.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_182.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_specificHumidity_182.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_183.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_specificHumidity_183.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [specificHumidity]
          simulated variables: [specificHumidity]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_180.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_stationPressure_180.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [stationPressure]
          simulated variables: [stationPressure]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_182.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_stationPressure_182.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [stationPressure]
          simulated variables: [stationPressure]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_280.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_280.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_winds_280.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_282.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_282.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_winds_282.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_284.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_284.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_sfcshp_winds_284.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 

--- a/parm/jcb-rdas/observations/atmosphere/vadwnd_winds_224.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/vadwnd_winds_224.yaml.j2
@@ -14,12 +14,13 @@
              sort order: "descending"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
              obsfile: jdiag_vadwnd_winds_224.nc
              allow overwrite: true
          io pool:
-           max pool size: 1
+           max pool size: {{ max_pool_size | default(1) }}
          observed variables: [windEastward, windNorthward]
          simulated variables: [windEastward, windNorthward]
 


### PR DESCRIPTION
## Description

This PR adds two new JCB configuration options to control how jdiag files are written in fv3-jedi. These options are intended to significantly reduce jdiag write time in rrfs-workflow, primarily for na3km.

When including the full observation set on na3km, writing the jdiag files can take more than 20 minutes in total. The following options are introduced to address this bottleneck:

`max pool size`: sets the number of MPI tasks used for writing jdiag files
`write multiple files`: allows each MPI task to write its own portion of the jdiag output rather than aggregating to a single file

Using `max pool size: 80` together with `write multiple files: true` reduces jdiag write time to approximately 1 to 2 minutes for the na3km domain.

Note that the default values for these options (`max pool size: 1` and `write multiple files: false`) match the current behavior when the options are not specified. As a result, existing configurations and ctests are unaffected unless the new options are explicitly set in the JCB config file.

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
