### PR TITLE
Add option to turn on per outerloop increments

### DIFF
--- a/parm/jcb-rdas/model/fv3/atmosphere/atmosphere_3dvar_outer_loop_1.yaml.j2
+++ b/parm/jcb-rdas/model/fv3/atmosphere/atmosphere_3dvar_outer_loop_1.yaml.j2
@@ -16,3 +16,33 @@
     ntiles: {{atmosphere_ntiles}}
     fieldsets:
     - fieldset: dynamics_lam_cmaq.yaml
+  online diagnostics:
+    write increment: {{write_increment_outer_loop_1 | default(false)}}
+    increment:
+      state component:
+        filetype: fms restart
+        datapath: ./
+        prefix: inc_outer1
+        frequency: {{atmosphere_forecast_timestep}}
+        state variables: {{analysis_variables}}
+        field io names:
+          eastward_wind: {{eastward_wind}}
+          northward_wind: {{northward_wind}}
+          air_temperature: {{air_temperature}}
+          air_pressure_at_surface: {{air_pressure_at_surface}}
+          air_pressure_thickness: {{air_pressure_thickness}}
+          water_vapor_mixing_ratio_wrt_moist_air: {{water_vapor_mixing_ratio_wrt_moist_air}}
+          cloud_liquid_ice: {{cloud_liquid_ice}}
+          cloud_liquid_water: {{cloud_liquid_water}}
+          ozone_mass_mixing_ratio: {{ozone_mass_mixing_ratio}}
+          geopotential_height_times_gravity_at_surface: {{geopotential_height_times_gravity_at_surface}}
+          skin_temperature_at_surface: {{skin_temperature_at_surface}}
+          tslb: {{tslb}}
+          smois: {{smois}}
+          eastward_wind_at_surface: {{eastward_wind_at_surface}}
+          northward_wind_at_surface: {{northward_wind_at_surface}}
+          rain_water: {{rain_water}}
+          snow_water: {{snow_water}}
+          graupel: {{graupel}}
+          upward_air_velocity: {{upward_air_velocity}}
+          equivalent_reflectivity_factor: {{equivalent_reflectivity_factor}}

--- a/parm/jcb-rdas/model/fv3/atmosphere/atmosphere_3dvar_outer_loop_2.yaml.j2
+++ b/parm/jcb-rdas/model/fv3/atmosphere/atmosphere_3dvar_outer_loop_2.yaml.j2
@@ -16,3 +16,33 @@
     ntiles: {{atmosphere_ntiles}}
     fieldsets:
     - fieldset: dynamics_lam_cmaq.yaml
+  online diagnostics:
+    write increment: {{write_increment_outer_loop_2 | default(false)}}
+    increment:
+      state component:
+        filetype: fms restart
+        datapath: ./
+        prefix: inc_outer2
+        frequency: {{atmosphere_forecast_timestep}}
+        state variables: {{analysis_variables}}
+        field io names:
+          eastward_wind: {{eastward_wind}}
+          northward_wind: {{northward_wind}}
+          air_temperature: {{air_temperature}}
+          air_pressure_at_surface: {{air_pressure_at_surface}}
+          air_pressure_thickness: {{air_pressure_thickness}}
+          water_vapor_mixing_ratio_wrt_moist_air: {{water_vapor_mixing_ratio_wrt_moist_air}}
+          cloud_liquid_ice: {{cloud_liquid_ice}}
+          cloud_liquid_water: {{cloud_liquid_water}}
+          ozone_mass_mixing_ratio: {{ozone_mass_mixing_ratio}}
+          geopotential_height_times_gravity_at_surface: {{geopotential_height_times_gravity_at_surface}}
+          skin_temperature_at_surface: {{skin_temperature_at_surface}}
+          tslb: {{tslb}}
+          smois: {{smois}}
+          eastward_wind_at_surface: {{eastward_wind_at_surface}}
+          northward_wind_at_surface: {{northward_wind_at_surface}}
+          rain_water: {{rain_water}}
+          snow_water: {{snow_water}}
+          graupel: {{graupel}}
+          upward_air_velocity: {{upward_air_velocity}}
+          equivalent_reflectivity_factor: {{equivalent_reflectivity_factor}}


### PR DESCRIPTION
## Description
This PR adds the option to turn on writing out per outer loop analysis increment fields if the following is used. The option is off by default.
```
write_increment_outer_loop_1: true
write_increment_outer_loop_2: true
```

## Issue(s) addressed
In part https://github.com/NOAA-EMC/RDASApp/issues/518. Turning this on allows us to confirm that delp is updated between outerloops when used as analysis variable and not control variable.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
