### PR TITLE
Bug fix in cris yaml file

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/abi_g16.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/abi_g16.yaml.j2
@@ -12,7 +12,7 @@
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_abi_g16.nc4
+             obsfile: jdiag_abi_g16.nc
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]

--- a/parm/jcb-rdas/observations/atmosphere/abi_g18.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/abi_g18.yaml.j2
@@ -12,7 +12,7 @@
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_abi_g18.nc4
+             obsfile: jdiag_abi_g18.nc
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]

--- a/parm/jcb-rdas/observations/atmosphere/atms_n20.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/atms_n20.yaml.j2
@@ -10,7 +10,7 @@
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_atms_n20.nc4
+             obsfile: jdiag_atms_n20.nc
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]

--- a/parm/jcb-rdas/observations/atmosphere/atms_n21.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/atms_n21.yaml.j2
@@ -10,7 +10,7 @@
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_atms_n21.nc4
+             obsfile: jdiag_atms_n21.nc
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]

--- a/parm/jcb-rdas/observations/atmosphere/atms_npp.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/atms_npp.yaml.j2
@@ -10,7 +10,7 @@
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_atms_npp.nc4
+             obsfile: jdiag_atms_npp.nc
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          simulated variables: [brightnessTemperature]

--- a/parm/jcb-rdas/observations/atmosphere/cris-fsr_n20.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/cris-fsr_n20.yaml.j2
@@ -10,7 +10,7 @@
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_cris-fsr_n20.nc4
+             obsfile: jdiag_cris-fsr_n20.nc
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          observed variables: [radiance]

--- a/parm/jcb-rdas/observations/atmosphere/cris-fsr_n20.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/cris-fsr_n20.yaml.j2
@@ -10,7 +10,7 @@
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_cris-fsr_n20.nc
+             obsfile: jdiag_cris-fsr_n20.nc4
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          observed variables: [radiance]

--- a/parm/jcb-rdas/observations/atmosphere/cris-fsr_n21.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/cris-fsr_n21.yaml.j2
@@ -3,14 +3,14 @@
          obsdatain:
            engine:
              type: H5File
-             obsfile: data/obs/ioda_crisf4_n20.nc
+             obsfile: data/obs/ioda_crisf4_n21.nc
              missing file action: "warn"
          obsdataout:
            empty obs space action: "{{empty_obs_space_action}}"
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_cris-fsr_n21.nc
+             obsfile: jdiag_cris-fsr_n21.nc4
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          observed variables: [radiance]

--- a/parm/jcb-rdas/observations/atmosphere/cris-fsr_n21.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/cris-fsr_n21.yaml.j2
@@ -10,7 +10,7 @@
            write multiple files: {{write_multiple_files | default(false) }}
            engine:
              type: H5File
-             obsfile: jdiag_cris-fsr_n21.nc4
+             obsfile: jdiag_cris-fsr_n21.nc
          io pool:
            max pool size: {{ max_pool_size | default(1) }}
          observed variables: [radiance]


### PR DESCRIPTION


* [Feature](?expand=1&template=feature_pr.md)
This PR address one bug fix, and unified two cris jdiag file names (*.nc)  to other satellites  jdiag file name (*.nc4).
* [Bugfix](?expand=1&template=bugfix_pr.md)
Accidently put the wrong ioda data file ioda_crisf4_**n20**.nc in the cris-fsr_**n21**.yaml.j2. This bug led the unexpected JEDI job crash because read in the wrong data.  This bug fix has been fully tested in May retro run.

