### PR TITLE
Fix RDASApp build failure by updating MPAS submodule 

### DIFF
--- a/rrfs-test/testinput/streams.atmosphere
+++ b/rrfs-test/testinput/streams.atmosphere
@@ -13,7 +13,7 @@
                   io_type="pnetcdf,cdf5"
                   input_interval="initial_only" />
 
-<immutable_stream name="da_state"
+<stream name="da_state"
                   type="output"
                   precision="single"
                   io_type="pnetcdf,cdf5"


### PR DESCRIPTION

## Bug Fix Description

This PR resolves a build error for RDASApp on WCOSS2 related to MPAS codes (#542). Updating the MPAS submodule to the same hash used in the `rrfs-mpas-jedi` branch of `rrfs-workflow` eliminates the error. This new version of MPAS no longer allows the `da_state` stream to be immutable, so `streams.atmosphere` is also updated as a result. 

## Issue(s) addressed
#542

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
