### PR TITLE
Add delp update workaround in fv3jedi_state_mod

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -303,20 +303,26 @@ if [[ $BUILD_WORKAROUND == 'YES' ]]; then
   cp ../sorc/_workaround_/fv3-jedi/fv3jedi_vc_model2geovals_mod.f90 ../sorc/fv3-jedi/src/fv3jedi/VariableChange/Model2GeoVaLs
 
   # Workaround for gsl sfcCorrected observation operator
-    # T
+    # T merged (but not done): ufo PR https://github.com/JCSDA-internal/ufo/pull/3622
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/EvalSurfaceTemperature.cc   ../sorc/ufo/src/ufo/operators/sfccorrected/EvalSurfaceTemperature.cc
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/EvalSurfaceTemperature.h    ../sorc/ufo/src/ufo/operators/sfccorrected/EvalSurfaceTemperature.h
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/ObsSfcCorrectedParameters.h ../sorc/ufo/src/ufo/operators/sfccorrected/ObsSfcCorrectedParameters.h
-    # q
+    # q: ufo PR planned by GSL
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/CMakeLists.txt         ../sorc/ufo/src/ufo/operators/sfccorrected/CMakeLists.txt
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/EvalSurfaceHumidity.cc ../sorc/ufo/src/ufo/operators/sfccorrected/EvalSurfaceHumidity.cc
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/EvalSurfaceHumidity.h  ../sorc/ufo/src/ufo/operators/sfccorrected/EvalSurfaceHumidity.h
-    # uv
+    # uv: ufo PR planned by GSL
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/EvalSurfaceWind.cc ../sorc/ufo/src/ufo/operators/sfccorrected/EvalSurfaceWind.cc
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/EvalSurfaceWind.h  ../sorc/ufo/src/ufo/operators/sfccorrected/EvalSurfaceWind.h
   cp ../sorc/_workaround_/ufo/operators/sfccorrected/ObsSfcCorrected.cc ../sorc/ufo/src/ufo/operators/sfccorrected/ObsSfcCorrected.cc
-    # fv3-jedi things
+    # fv3-jedi metadata: PR planned by EMC
   cp ../sorc/_workaround_/fv3-jedi/FieldsMetadataDefault.h ../sorc/fv3-jedi/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
+
+  # Workaround for updating fields between outerloops (needed for sfc operator).
+    # surface fields:
+    #   - PR planned by EMC
+    # delp:
+    #   - fv3-jedi PR opened: https://github.com/JCSDA-internal/fv3-jedi/pull/1381
   cp ../sorc/_workaround_/fv3-jedi/fv3jedi_state_mod.F90   ../sorc/fv3-jedi/src/fv3jedi/State/fv3jedi_state_mod.F90
 
 fi

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3denvar.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3denvar.ref
@@ -9,7 +9,7 @@ State print | number of fields = 30 | cube sphere face size: C420
 eastward_wind                                | Min:-2.7017492294311523e+01 Max:+5.6223032102531590e+01 RMS:+1.3311833298347493e+01
 northward_wind                               | Min:-4.2521160641750093e+01 Max:+4.1905506750101615e+01 RMS:+6.4757897420779305e+00
 air_temperature                              | Min:+1.9402590942382812e+02 Max:+3.1449734497070312e+02 RMS:+2.5825672960043528e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
+air_pressure_thickness                       | Min:+1.4039876591949485e+02 Max:+3.3267851562500000e+03 RMS:+1.7746675851029963e+03
 water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.7096521429656965e-02 RMS:+5.5229969766314290e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
@@ -37,22 +37,22 @@ water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3824545025418855e-03 Max:+
 eastward_wind_at_surface                     | Min:-1.4085562996701132e+01 Max:+1.2164370345556842e+01 RMS:+3.6003505222811452e+00
 northward_wind_at_surface                    | Min:-1.3986063135976439e+01 Max:+1.2013773333899731e+01 RMS:+3.6817059470922771e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 7141.753618318437, nobs = 26912, Jo/n = 0.2653743169708099, err = 0.9070335331040665
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 671.6992255182859, nobs = 3846, Jo/n = 0.1746487845861378, err = 0.001846312116315512
-CostJo   : Nonlinear Jo(aircar_winds_233) = 14764.9010982934, nobs = 57216, Jo/n = 0.2580554582335954, err = 2.650318593315721
-CostFunction: Nonlinear J = 22578.35394213012
-DRPCGMinimizer: reduction in residual norm = 0.001218385022115733
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 7161.10653426403, nobs = 26912, Jo/n = 0.2660934354289547, err = 0.9070335331040665
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 671.6443237100266, nobs = 3846, Jo/n = 0.1746345095449887, err = 0.001846312116315512
+CostJo   : Nonlinear Jo(aircar_winds_233) = 14776.17790740696, nobs = 57216, Jo/n = 0.258252550115474, err = 2.650318593315721
+CostFunction: Nonlinear J = 22608.92876538102
+DRPCGMinimizer: reduction in residual norm = 0.0008642285483637264
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7017492294311523e+01 Max:+5.6219159751773503e+01 RMS:+1.3311842572700687e+01
-northward_wind                               | Min:-4.2524353342076289e+01 Max:+4.1902236002129904e+01 RMS:+6.4757853643731353e+00
-air_temperature                              | Min:+1.9402590942382812e+02 Max:+3.1449734497070312e+02 RMS:+2.5825672362249708e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.7094168777418888e-02 RMS:+5.5230033803621657e-03
+eastward_wind                                | Min:-2.7017492294311523e+01 Max:+5.6219149318883190e+01 RMS:+1.3311940033850377e+01
+northward_wind                               | Min:-4.2523529662042293e+01 Max:+4.1925924136681679e+01 RMS:+6.4759619480059918e+00
+air_temperature                              | Min:+1.9402590942382812e+02 Max:+3.1449734497070312e+02 RMS:+2.5825605323298674e+02
+air_pressure_thickness                       | Min:+1.4039878766227497e+02 Max:+3.3267851562500000e+03 RMS:+1.7746608324101710e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.7414631399722268e-02 RMS:+5.5230546856362235e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
-ozone_mass_mixing_ratio                      | Min:+2.2688649423505375e-11 Max:+1.6040661648730747e-05 RMS:+4.4486503998032096e-06
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486504141839393e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223757e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586809e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -63,7 +63,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6027352777187087e+04 Max:+1.0240633677673340e+05 RMS:+9.6258971748694254e+04
+air_pressure_at_surface                      | Min:+6.6027363027163228e+04 Max:+1.0240633677673340e+05 RMS:+9.6258640949356704e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -71,12 +71,12 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7084362322354400e+02 Max:+3.1503152465820312e+02 RMS:+2.9391812515754799e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3826399466469708e-03 Max:+2.8859080255642662e-02 RMS:+1.1352713750239274e-02
-eastward_wind_at_surface                     | Min:-1.4089163785134673e+01 Max:+1.2164370299097172e+01 RMS:+3.6003634831684357e+00
-northward_wind_at_surface                    | Min:-1.3986029568189361e+01 Max:+1.2002527077699371e+01 RMS:+3.6816912099457269e+00
+air_temperature_at_2m                        | Min:+2.7084362944072484e+02 Max:+3.1503152465820312e+02 RMS:+2.9391908489976760e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3826324785856351e-03 Max:+2.9200649676482671e-02 RMS:+1.1355270313122398e-02
+eastward_wind_at_surface                     | Min:-1.3472607561456194e+01 Max:+1.2164370474274660e+01 RMS:+3.6000064026701071e+00
+northward_wind_at_surface                    | Min:-1.3985609487124204e+01 Max:+1.2379811827308895e+01 RMS:+3.6840121881298078e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 7141.503329914338, nobs = 26912, Jo/n = 0.2653650167179822, err = 0.9070335331040665
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 671.4678991810796, nobs = 3846, Jo/n = 0.174588637332574, err = 0.001846312116315512
-CostJo   : Nonlinear Jo(aircar_winds_233) = 14764.47805323522, nobs = 57216, Jo/n = 0.2580480644091726, err = 2.650318593315721
-CostFunction: Nonlinear J = 22577.44928233064
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 7142.724323887074, nobs = 26912, Jo/n = 0.2654103865891451, err = 0.9070335331040665
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 671.3777236977207, nobs = 3846, Jo/n = 0.1745651907690381, err = 0.001846312116315512
+CostJo   : Nonlinear Jo(aircar_winds_233) = 14766.95888314256, nobs = 57216, Jo/n = 0.2580914234330006, err = 2.650318593315721
+CostFunction: Nonlinear J = 22581.06093072736

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3denvar_mgbf.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3denvar_mgbf.ref
@@ -9,7 +9,7 @@ State print | number of fields = 30 | cube sphere face size: C420
 eastward_wind                                | Min:-2.7017492294311523e+01 Max:+5.5337978184153805e+01 RMS:+1.3323563083296090e+01
 northward_wind                               | Min:-4.5226179348417212e+01 Max:+4.0336882262153154e+01 RMS:+6.4935156857873961e+00
 air_temperature                              | Min:+1.9402618026858133e+02 Max:+3.1449734497070312e+02 RMS:+2.5825978148033317e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076129e+03
+air_pressure_thickness                       | Min:+1.4039896175367437e+02 Max:+3.3267851562500000e+03 RMS:+1.7746692985271138e+03
 water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6475114050935635e-02 RMS:+5.5190455365890078e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263384e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694528e-05
@@ -37,22 +37,22 @@ water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3849673752278195e-03 Max:+
 eastward_wind_at_surface                     | Min:-1.2591936798419271e+01 Max:+1.2164360198650911e+01 RMS:+3.6025626050785395e+00
 northward_wind_at_surface                    | Min:-1.3967808030275050e+01 Max:+1.4455538133706728e+01 RMS:+3.6870933460729223e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6436.905565048216, nobs = 26912, Jo/n = 0.2391834707583315, err = 0.9070335331040666
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 567.2227929091773, nobs = 3846, Jo/n = 0.1474838255094065, err = 0.001846312116315513
-CostJo   : Nonlinear Jo(aircar_winds_233) = 13872.52113167875, nobs = 57216, Jo/n = 0.2424587725754815, err = 2.650318593315722
-CostFunction: Nonlinear J = 20876.64948963614
-DRPCGMinimizer: reduction in residual norm = 0.03839370510165859
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6462.536258045024, nobs = 26912, Jo/n = 0.2401358597668335, err = 0.9070335331040666
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 566.8911399160415, nobs = 3846, Jo/n = 0.1473975922818621, err = 0.001846312116315513
+CostJo   : Nonlinear Jo(aircar_winds_233) = 13881.24445516024, nobs = 57216, Jo/n = 0.242611235583757, err = 2.650318593315722
+CostFunction: Nonlinear J = 20910.6718531213
+DRPCGMinimizer: reduction in residual norm = 0.01053818442107305
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7017492294311523e+01 Max:+5.5350232350503440e+01 RMS:+1.3324101054747812e+01
-northward_wind                               | Min:-4.5260137852209439e+01 Max:+4.0313107373583833e+01 RMS:+6.4933813155777864e+00
-air_temperature                              | Min:+1.9402625682539374e+02 Max:+3.1449734497070312e+02 RMS:+2.5825977763169965e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076129e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6391229895913141e-02 RMS:+5.5192094526611418e-03
+eastward_wind                                | Min:-2.7017492294311523e+01 Max:+5.5351776396936671e+01 RMS:+1.3324199732196128e+01
+northward_wind                               | Min:-4.5259254005429725e+01 Max:+4.0312577834982072e+01 RMS:+6.4936783773165558e+00
+air_temperature                              | Min:+1.9402625762293877e+02 Max:+3.1449734497070312e+02 RMS:+2.5825907018406065e+02
+air_pressure_thickness                       | Min:+1.4039896468595336e+02 Max:+3.3267851562500000e+03 RMS:+1.7746599312109086e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6636046785887976e-02 RMS:+5.5192363182930484e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263384e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694528e-05
-ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486329555585363e-06
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486328695719079e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223739e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586811e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -63,7 +63,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359011e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741260e-01
-air_pressure_at_surface                      | Min:+6.6027443499503541e+04 Max:+1.0240633677673340e+05 RMS:+9.6259045050583285e+04
+air_pressure_at_surface                      | Min:+6.6027446277744559e+04 Max:+1.0240633677673340e+05 RMS:+9.6258597269166945e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338740e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177572e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145332e-06
@@ -71,12 +71,12 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120682e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806405e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424869e-02
-air_temperature_at_2m                        | Min:+2.7084287731128052e+02 Max:+3.1503152465820312e+02 RMS:+2.9391503824705165e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3850669730100904e-03 Max:+2.8272752021004058e-02 RMS:+1.1349428861783539e-02
-eastward_wind_at_surface                     | Min:-1.2595891854842726e+01 Max:+1.2164360190889246e+01 RMS:+3.6022252731428823e+00
-northward_wind_at_surface                    | Min:-1.3967875179293749e+01 Max:+1.4361267846157643e+01 RMS:+3.6868345749378832e+00
+air_temperature_at_2m                        | Min:+2.7084287703516850e+02 Max:+3.1503152465820312e+02 RMS:+2.9391606996689256e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3850525489398783e-03 Max:+2.8512520536030088e-02 RMS:+1.1351816211755671e-02
+eastward_wind_at_surface                     | Min:-1.2342660907956430e+01 Max:+1.2164360192724320e+01 RMS:+3.6017078920868122e+00
+northward_wind_at_surface                    | Min:-1.3967731589991887e+01 Max:+1.4884460434675340e+01 RMS:+3.6902482975993269e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6423.303636715884, nobs = 26912, Jo/n = 0.2386780483321895, err = 0.9070335331040666
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 566.3106398381906, nobs = 3846, Jo/n = 0.1472466562241785, err = 0.001846312116315513
-CostJo   : Nonlinear Jo(aircar_winds_233) = 13847.58089511543, nobs = 57216, Jo/n = 0.2420228763827501, err = 2.650318593315722
-CostFunction: Nonlinear J = 20837.1951716695
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6424.616645428468, nobs = 26912, Jo/n = 0.2387268373004039, err = 0.9070335331040666
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 566.1584661679253, nobs = 3846, Jo/n = 0.1472070894872401, err = 0.001846312116315513
+CostJo   : Nonlinear Jo(aircar_winds_233) = 13850.5922807449, nobs = 57216, Jo/n = 0.2420755082624599, err = 2.650318593315722
+CostFunction: Nonlinear J = 20841.3673923413

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3denvar_refl.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3denvar_refl.ref
@@ -7,7 +7,7 @@ State print | number of fields = 31 | cube sphere face size: C420
 eastward_wind                                | Min:-3.0110721738901901e+01 Max:+5.2821486243297642e+01 RMS:+1.3297393005879298e+01
 northward_wind                               | Min:-3.9898377751627422e+01 Max:+4.0478634657811220e+01 RMS:+6.4905194350867550e+00
 air_temperature                              | Min:+1.9402565485627721e+02 Max:+3.1449734497070312e+02 RMS:+2.5824199310659816e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076129e+03
+air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267874180800854e+03 RMS:+1.7747156954339732e+03
 water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4484869411650918e-02 RMS:+5.5016424614381821e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5848739319369565e-04 RMS:+3.4618080238829739e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.5860744434366583e-03 RMS:+1.8833331180080719e-05
@@ -36,20 +36,20 @@ water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3829292729496956e-03 Max:+
 eastward_wind_at_surface                     | Min:-1.2992406792981180e+01 Max:+1.2164360046386719e+01 RMS:+3.6174470743355398e+00
 northward_wind_at_surface                    | Min:-1.3966897010803223e+01 Max:+1.2063875030000386e+01 RMS:+3.7007584218808676e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(refl10cm) = 42144.71844889395, nobs = 637916, Jo/n = 0.06606625080558248, err = 6.654007668620585
-CostFunction: Nonlinear J = 42144.71844889395
-DRPCGMinimizer: reduction in residual norm = 0.03747693614707482
+CostJo   : Nonlinear Jo(refl10cm) = 42144.83858319573, nobs = 637916, Jo/n = 0.06606643912865601, err = 6.654007668620585
+CostFunction: Nonlinear J = 42144.83858319573
+DRPCGMinimizer: reduction in residual norm = 0.0374754001364306
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 31 | cube sphere face size: C420
-eastward_wind                                | Min:-2.9666513075706497e+01 Max:+5.2821485008487279e+01 RMS:+1.3306981041122064e+01
-northward_wind                               | Min:-3.9898377057910373e+01 Max:+3.8606959189756623e+01 RMS:+6.4643890217135942e+00
-air_temperature                              | Min:+1.9402567385971153e+02 Max:+3.1449734497070312e+02 RMS:+2.5824190252701425e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076129e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4484868770584561e-02 RMS:+5.4849484105691871e-03
-cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5653402236467921e-04 RMS:+2.7100072373723881e-06
-cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4772532923182109e-03 RMS:+1.8173094173490780e-05
-ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486297551018097e-06
+eastward_wind                                | Min:-2.9666410031425158e+01 Max:+5.2821485008485141e+01 RMS:+1.3306981177637006e+01
+northward_wind                               | Min:-3.9898377057910515e+01 Max:+3.8606957846854264e+01 RMS:+6.4643892160685725e+00
+air_temperature                              | Min:+1.9402567385972401e+02 Max:+3.1449734497070312e+02 RMS:+2.5824190239232854e+02
+air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267878143799826e+03 RMS:+1.7747183515024242e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4484868770583819e-02 RMS:+5.4849483905693884e-03
+cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5653405016969873e-04 RMS:+2.7099999073774744e-06
+cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4772529644030282e-03 RMS:+1.8173117586073579e-05
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486297551191950e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223739e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586811e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -60,19 +60,19 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359011e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741260e-01
-air_pressure_at_surface                      | Min:+6.6027499740600586e+04 Max:+1.0240640481561578e+05 RMS:+9.6261475975943540e+04
-rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7953894225111752e-03 RMS:+1.5480968659294205e-05
-snow_water                                   | Min:+0.0000000000000000e+00 Max:+3.4925435466011475e-03 RMS:+4.2210869334811254e-05
-graupel                                      | Min:+0.0000000000000000e+00 Max:+6.3210098577683020e-04 RMS:+3.1318943392646422e-06
+air_pressure_at_surface                      | Min:+6.6027499740600586e+04 Max:+1.0240640481562105e+05 RMS:+9.6261475977553753e+04
+rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7953894227588155e-03 RMS:+1.5480969838773554e-05
+snow_water                                   | Min:+0.0000000000000000e+00 Max:+3.4925436071741043e-03 RMS:+4.2210742693709705e-05
+graupel                                      | Min:+0.0000000000000000e+00 Max:+6.3210098578635394e-04 RMS:+3.1318904780841786e-06
 cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+1.5055759360000000e+09 RMS:+2.0745188331041779e+07
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120682e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806405e+03
-upward_air_velocity                          | Min:-2.2700529866486567e+00 Max:+2.1677347533149369e+00 RMS:+5.7786342350010247e-02
-equivalent_reflectivity_factor               | Min:-3.8621883551700520e+01 Max:+5.4432301931589620e+01 RMS:+3.0851583182437468e+00
-air_temperature_at_2m                        | Min:+2.7084340000400101e+02 Max:+3.1503152465820312e+02 RMS:+2.9386465850786539e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3829292729496956e-03 Max:+2.5000204941377141e-02 RMS:+1.1311386769397209e-02
-eastward_wind_at_surface                     | Min:-1.2981828152756561e+01 Max:+1.2164360046386719e+01 RMS:+3.6168903441338869e+00
-northward_wind_at_surface                    | Min:-1.3966897010803223e+01 Max:+1.2086782262195815e+01 RMS:+3.7002445535587927e+00
+upward_air_velocity                          | Min:-2.2700529053699801e+00 Max:+2.1677347872482242e+00 RMS:+5.7786295542689090e-02
+equivalent_reflectivity_factor               | Min:-3.8622073859119084e+01 Max:+5.4432290568264627e+01 RMS:+3.0851583240373439e+00
+air_temperature_at_2m                        | Min:+2.7084340000370969e+02 Max:+3.1503152465820312e+02 RMS:+2.9386465850947013e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3829292729496956e-03 Max:+2.5000204941376399e-02 RMS:+1.1311386763840151e-02
+eastward_wind_at_surface                     | Min:-1.2981828255915627e+01 Max:+1.2164360046386719e+01 RMS:+3.6168903375933659e+00
+northward_wind_at_surface                    | Min:-1.3966897010803223e+01 Max:+1.2086782465151410e+01 RMS:+3.7002445506763366e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(refl10cm) = 41703.04904461651, nobs = 637916, Jo/n = 0.06537388785453964, err = 6.654007668620585
-CostFunction: Nonlinear J = 41703.04904461651
+CostJo   : Nonlinear Jo(refl10cm) = 41703.17642836816, nobs = 637916, Jo/n = 0.06537408754188351, err = 6.654007668620585
+CostFunction: Nonlinear J = 41703.17642836816

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-conv-surface.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-conv-surface.ref
@@ -25,15 +25,15 @@ CostJo   : Nonlinear Jo(sfcshp_winds_280) = 3.8883248109337944e+02, nobs = 1764,
 CostJo   : Nonlinear Jo(sfcshp_winds_282) = 2.6475416723912247e+01, nobs = 18, Jo/n = 1.4708564846617915e+00, err = 1.1064412466726061e+00
 CostJo   : Nonlinear Jo(sfcshp_winds_284) = 1.6874857572561558e+02, nobs = 124, Jo/n = 1.3608756106904483e+00, err = 1.3148107267083624e+00
 CostFunction: Nonlinear J = 8.8635955082318047e+04
-DRPCGMinimizer: reduction in residual norm = 9.8485641600749374e-04
+DRPCGMinimizer: reduction in residual norm = 9.8485622648962858e-04
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7020076516701270e+01 Max:+5.2716377611403388e+01 RMS:+1.3255913060862358e+01
-northward_wind                               | Min:-4.0063801309762127e+01 Max:+3.8548830598934018e+01 RMS:+6.3748759643950441e+00
-air_temperature                              | Min:+1.9402124337657949e+02 Max:+3.1591649852160805e+02 RMS:+2.5842653525022030e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.3842202530633898e-02 RMS:+5.7331522297583313e-03
+eastward_wind                                | Min:-2.7020076516694814e+01 Max:+5.2716377611471692e+01 RMS:+1.3255913061014729e+01
+northward_wind                               | Min:-4.0063801305710825e+01 Max:+3.8548830598872328e+01 RMS:+6.3748759642097417e+00
+air_temperature                              | Min:+1.9402124337658282e+02 Max:+3.1591649834560718e+02 RMS:+2.5842653525213859e+02
+air_pressure_thickness                       | Min:+1.4048402608793748e+02 Max:+3.3253799381185449e+03 RMS:+1.7748054068822344e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.3842202524363972e-02 RMS:+5.7331522080537817e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -47,7 +47,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6067448898792500e+04 Max:+1.0237043969324253e+05 RMS:+9.6266107474205783e+04
+air_pressure_at_surface                      | Min:+6.6067448899029798e+04 Max:+1.0237043969325125e+05 RMS:+9.6266107474213088e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -55,47 +55,47 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7160915881795978e+02 Max:+3.1628477795487038e+02 RMS:+2.9464836386540298e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+0.0000000000000000e+00 Max:+2.5344706559121480e-02 RMS:+1.1878022000790389e-02
-eastward_wind_at_surface                     | Min:-1.3038342100281694e+01 Max:+1.2335743172511929e+01 RMS:+3.4879843863628759e+00
-northward_wind_at_surface                    | Min:-1.3141236281830148e+01 Max:+1.1191722404307619e+01 RMS:+3.5764054123122673e+00
+air_temperature_at_2m                        | Min:+2.7160915881736952e+02 Max:+3.1628477783232921e+02 RMS:+2.9464836386755809e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+0.0000000000000000e+00 Max:+2.5344706591710876e-02 RMS:+1.1878021988206453e-02
+eastward_wind_at_surface                     | Min:-1.3038342103240677e+01 Max:+1.2335743170723063e+01 RMS:+3.4879843862869495e+00
+northward_wind_at_surface                    | Min:-1.3141236282357543e+01 Max:+1.1191722402275557e+01 RMS:+3.5764054122045792e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 140.8225863004203, nobs = 578, Jo/n = 0.2436376925612807, err = 4282417581.929717
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 21.153693016339, nobs = 218, Jo/n = 0.09703528906577522, err = 4740998230.350175
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 1235.77537490239, nobs = 2048, Jo/n = 0.6034059447765574, err = 1.129250049591064
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 134.8110395487543, nobs = 570, Jo/n = 0.2365105956995689, err = 0.002508104936353363
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 42.77530017238227, nobs = 215, Jo/n = 0.1989548845227082, err = 0.002582167498415306
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 966.119879419281, nobs = 2059, Jo/n = 0.4692180084600685, err = 0.0037554408693362
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 141.1173724740844, nobs = 578, Jo/n = 0.2441477032423606, err = 4282417581.929717
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 20.958978563376, nobs = 218, Jo/n = 0.09614210350172477, err = 4740998230.350175
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 1235.775307021385, nobs = 2048, Jo/n = 0.6034059116315356, err = 1.129250049591064
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 134.7942353794959, nobs = 570, Jo/n = 0.2364811147008701, err = 0.002508104936353363
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 42.76913461920707, nobs = 215, Jo/n = 0.1989262075311957, err = 0.002582167498415306
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 966.1198935200269, nobs = 2059, Jo/n = 0.4692180153084152, err = 0.0037554408693362
 CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 415.7760170109128, nobs = 570, Jo/n = 0.7294316087910752, err = 76.62005977562958
-CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 1016.15202356154, nobs = 2138, Jo/n = 0.4752815825825725, err = 61.00751504910026
-CostJo   : Nonlinear Jo(adpsfc_winds_281) = 542.256787777317, nobs = 1096, Jo/n = 0.4947598428625155, err = 2.052808542867812
-CostJo   : Nonlinear Jo(adpsfc_winds_284) = 260.3196327252958, nobs = 408, Jo/n = 0.638038315503176, err = 1.972703082821662
-CostJo   : Nonlinear Jo(adpsfc_winds_287) = 1876.261386836782, nobs = 4038, Jo/n = 0.4646511606827098, err = 1.831580075501386
-CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 836.008612586494, nobs = 21341, Jo/n = 0.03917382562140921, err = 4577659806.921542
-CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 9357.518160091511, nobs = 19879, Jo/n = 0.4707237869154138, err = 0.005160471002939835
-CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 36997.84609694478, nobs = 19629, Jo/n = 1.884856390898404, err = 70.12100214206191
-CostJo   : Nonlinear Jo(msonet_winds_288) = 1209.817077144827, nobs = 6164, Jo/n = 0.1962714271811855, err = 3.371246373937797
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 80.50595976732609, nobs = 490, Jo/n = 0.1642978770761757, err = 1749635530.559413
+CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 1016.151634831383, nobs = 2138, Jo/n = 0.4752814007630415, err = 61.00751504910026
+CostJo   : Nonlinear Jo(adpsfc_winds_281) = 538.9824880531972, nobs = 1096, Jo/n = 0.4917723431142311, err = 2.052808542867812
+CostJo   : Nonlinear Jo(adpsfc_winds_284) = 257.079010921446, nobs = 408, Jo/n = 0.6300956150035442, err = 1.972703082821662
+CostJo   : Nonlinear Jo(adpsfc_winds_287) = 1876.261386660196, nobs = 4038, Jo/n = 0.4646511606389786, err = 1.831580075501386
+CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 837.0235798347952, nobs = 21341, Jo/n = 0.03922138511947872, err = 4577659806.921542
+CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 9362.469034019405, nobs = 19879, Jo/n = 0.4709728373670408, err = 0.005160471002939835
+CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 36997.91006911414, nobs = 19629, Jo/n = 1.884859649962512, err = 70.12100214206191
+CostJo   : Nonlinear Jo(msonet_winds_288) = 1205.430155325728, nobs = 6164, Jo/n = 0.19555972669139, err = 3.371246373937797
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 79.94533054934632, nobs = 490, Jo/n = 0.1631537358149925, err = 1749635530.559413
 CostJo   : Nonlinear Jo(sfcshp_airTemperature_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 7.10325043089945, nobs = 44, Jo/n = 0.1614375097931693, err = 3370999312.31621
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 95.34858612233249, nobs = 416, Jo/n = 0.2292033320248377, err = 0.001246274841437346
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 7.081479956822909, nobs = 44, Jo/n = 0.1609427262914297, err = 3370999312.31621
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 94.81695872080994, nobs = 416, Jo/n = 0.2279253815404085, err = 0.001246274841437346
 CostJo   : Nonlinear Jo(sfcshp_specificHumidity_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 2.351942556343056, nobs = 9, Jo/n = 0.261326950704784, err = 0.001324398666700635
-CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 2283.041804258527, nobs = 1211, Jo/n = 1.885253347860055, err = 39.70642084915645
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 2.345790737339511, nobs = 9, Jo/n = 0.2606434152599457, err = 0.001324398666700635
+CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 2283.038746135413, nobs = 1211, Jo/n = 1.885250822572595, err = 39.70642084915645
 CostJo   : Nonlinear Jo(sfcshp_stationPressure_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_winds_280) = 294.5187426347717, nobs = 1764, Jo/n = 0.166960738455086, err = 2.694602820739344
-CostJo   : Nonlinear Jo(sfcshp_winds_282) = 20.97544809488899, nobs = 18, Jo/n = 1.165302671938277, err = 1.106441246672606
-CostJo   : Nonlinear Jo(sfcshp_winds_284) = 124.2616118454027, nobs = 124, Jo/n = 1.002109772946796, err = 1.314810726708362
-CostFunction: Nonlinear J = 57961.52101374952
-DRPCGMinimizer: reduction in residual norm = 0.0009527677840473475
+CostJo   : Nonlinear Jo(sfcshp_winds_280) = 292.9761237756203, nobs = 1764, Jo/n = 0.1660862379680387, err = 2.694602820739344
+CostJo   : Nonlinear Jo(sfcshp_winds_282) = 20.97343233754883, nobs = 18, Jo/n = 1.165190685419379, err = 1.106441246672606
+CostJo   : Nonlinear Jo(sfcshp_winds_284) = 131.9852323938989, nobs = 122, Jo/n = 1.081846167163106, err = 1.317635866944773
+CostFunction: Nonlinear J = 57961.78139195557
+DRPCGMinimizer: reduction in residual norm = 0.0009670706217690906
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7020073252437161e+01 Max:+5.2716114230543781e+01 RMS:+1.3256015875225390e+01
-northward_wind                               | Min:-4.0063921414025465e+01 Max:+3.8548446537689671e+01 RMS:+6.3742089074931201e+00
-air_temperature                              | Min:+1.9402125444131912e+02 Max:+3.1590623340239739e+02 RMS:+2.5842638948445926e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.3833779756462288e-02 RMS:+5.7332457753336225e-03
+eastward_wind                                | Min:-2.7020080637682735e+01 Max:+5.2715702017486876e+01 RMS:+1.3256242090197230e+01
+northward_wind                               | Min:-4.0063765431991690e+01 Max:+3.8548183720843603e+01 RMS:+6.3763588105073250e+00
+air_temperature                              | Min:+1.9402118828306453e+02 Max:+3.1591301198510178e+02 RMS:+2.5842734316225329e+02
+air_pressure_thickness                       | Min:+1.4048494569513400e+02 Max:+3.3253667237225682e+03 RMS:+1.7748160638283489e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.3841894086486834e-02 RMS:+5.7339695834440945e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -109,7 +109,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6067884534382087e+04 Max:+1.0237014682875013e+05 RMS:+9.6266641689918499e+04
+air_pressure_at_surface                      | Min:+6.6067881371309297e+04 Max:+1.0237010145064868e+05 RMS:+9.6266642895863508e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -117,35 +117,35 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7160333999366952e+02 Max:+3.1627534210516961e+02 RMS:+2.9464835541342995e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+0.0000000000000000e+00 Max:+2.5347670432741509e-02 RMS:+1.1877759843668009e-02
-eastward_wind_at_surface                     | Min:-1.3139365486507394e+01 Max:+1.2330428569059096e+01 RMS:+3.4910064236149063e+00
-northward_wind_at_surface                    | Min:-1.3136176039423997e+01 Max:+1.0959587931068398e+01 RMS:+3.5759411171024897e+00
+air_temperature_at_2m                        | Min:+2.7160343171505247e+02 Max:+3.1628443714707549e+02 RMS:+2.9464907102846303e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+0.0000000000000000e+00 Max:+2.5338817349043766e-02 RMS:+1.1875863866381627e-02
+eastward_wind_at_surface                     | Min:-1.3378076642887356e+01 Max:+1.2337251557119497e+01 RMS:+3.4930197983321953e+00
+northward_wind_at_surface                    | Min:-1.3137000603918427e+01 Max:+1.1064676703584331e+01 RMS:+3.5797500639778081e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 140.8398957672331, nobs = 578, Jo/n = 0.2436676397356973, err = 4282417581.929717
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 21.14982233751705, nobs = 218, Jo/n = 0.0970175336583351, err = 4740998230.350175
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 1234.819634744081, nobs = 2048, Jo/n = 0.6029392747773831, err = 1.129250049591064
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 134.7853151668494, nobs = 570, Jo/n = 0.236465465204999, err = 0.002508104936353363
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 42.74615901724329, nobs = 215, Jo/n = 0.1988193442662478, err = 0.002582167498415306
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 966.2638706471882, nobs = 2059, Jo/n = 0.4692879410622575, err = 0.0037554408693362
-CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 416.0161213440832, nobs = 570, Jo/n = 0.7298528444633039, err = 76.62005977562958
-CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 1016.06106949641, nobs = 2138, Jo/n = 0.47523904092442, err = 61.00751504910026
-CostJo   : Nonlinear Jo(adpsfc_winds_281) = 542.0879379259189, nobs = 1096, Jo/n = 0.4946057827791231, err = 2.052808542867812
-CostJo   : Nonlinear Jo(adpsfc_winds_284) = 259.4435689664559, nobs = 408, Jo/n = 0.6358911004079802, err = 1.972703082821662
-CostJo   : Nonlinear Jo(adpsfc_winds_287) = 1874.072489463768, nobs = 4038, Jo/n = 0.4641090860484813, err = 1.831580075501386
-CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 836.1397964313437, nobs = 21341, Jo/n = 0.03917997265504633, err = 4577659806.921542
-CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 9357.572650353142, nobs = 19879, Jo/n = 0.4707265280121305, err = 0.005160471002939835
-CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 36945.21461607779, nobs = 19629, Jo/n = 1.882175078510255, err = 70.12100214206191
-CostJo   : Nonlinear Jo(msonet_winds_288) = 1211.395622948083, nobs = 6164, Jo/n = 0.1965275183238292, err = 3.371246373937797
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 80.65994778332364, nobs = 490, Jo/n = 0.1646121383333136, err = 1749635530.559413
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 141.0369926031025, nobs = 578, Jo/n = 0.2440086377216306, err = 4282417581.929717
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 20.95250803234126, nobs = 218, Jo/n = 0.09611242216670302, err = 4740998230.350175
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 1235.287198877184, nobs = 2048, Jo/n = 0.60316757757675, err = 1.129250049591064
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 134.7121093651041, nobs = 570, Jo/n = 0.2363370339738668, err = 0.002508104936353363
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 42.68098535792204, nobs = 215, Jo/n = 0.1985162109670792, err = 0.002582167498415306
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 967.3506613732757, nobs = 2059, Jo/n = 0.4698157656013967, err = 0.0037554408693362
+CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 416.0508983564675, nobs = 570, Jo/n = 0.7299138567657325, err = 76.62005977562958
+CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 1016.071473641175, nobs = 2138, Jo/n = 0.4752439072222521, err = 61.00751504910026
+CostJo   : Nonlinear Jo(adpsfc_winds_281) = 539.9807716444291, nobs = 1096, Jo/n = 0.4926831858069609, err = 2.052808542867812
+CostJo   : Nonlinear Jo(adpsfc_winds_284) = 256.6338800543582, nobs = 408, Jo/n = 0.6290046079763681, err = 1.972703082821662
+CostJo   : Nonlinear Jo(adpsfc_winds_287) = 1873.884107381019, nobs = 4038, Jo/n = 0.4640624337248686, err = 1.831580075501386
+CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 836.5451568646686, nobs = 21341, Jo/n = 0.03919896709923006, err = 4577659806.921542
+CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 9360.849241281283, nobs = 19879, Jo/n = 0.4708913547603644, err = 0.005160471002939835
+CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 36945.46926876327, nobs = 19629, Jo/n = 1.882188051799036, err = 70.12100214206191
+CostJo   : Nonlinear Jo(msonet_winds_288) = 1208.671054732496, nobs = 6164, Jo/n = 0.1960855053102687, err = 3.371246373937797
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 80.23522739823434, nobs = 490, Jo/n = 0.1637453620372129, err = 1749635530.559413
 CostJo   : Nonlinear Jo(sfcshp_airTemperature_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 7.103227028785288, nobs = 44, Jo/n = 0.1614369779269384, err = 3370999312.31621
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 95.2636763199674, nobs = 416, Jo/n = 0.2289992219229986, err = 0.001246274841437346
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 7.095348602354962, nobs = 44, Jo/n = 0.1612579227807946, err = 3370999312.31621
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 95.05147365881236, nobs = 416, Jo/n = 0.2284891193721451, err = 0.001246274841437346
 CostJo   : Nonlinear Jo(sfcshp_specificHumidity_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 2.35006226213697, nobs = 9, Jo/n = 0.26111802912633, err = 0.001324398666700635
-CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 2279.325947881102, nobs = 1211, Jo/n = 1.882184928060365, err = 39.70642084915645
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 2.343966413564897, nobs = 9, Jo/n = 0.2604407126183219, err = 0.001324398666700635
+CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 2279.353810448368, nobs = 1211, Jo/n = 1.882207935960667, err = 39.70642084915645
 CostJo   : Nonlinear Jo(sfcshp_stationPressure_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_winds_280) = 294.7178683003817, nobs = 1764, Jo/n = 0.1670736214854771, err = 2.694602820739344
-CostJo   : Nonlinear Jo(sfcshp_winds_282) = 20.9812063986063, nobs = 18, Jo/n = 1.16562257770035, err = 1.106441246672606
-CostJo   : Nonlinear Jo(sfcshp_winds_284) = 122.4114114466034, nobs = 124, Jo/n = 0.9871888019887374, err = 1.314810726708362
-CostFunction: Nonlinear J = 57901.42191810801
+CostJo   : Nonlinear Jo(sfcshp_winds_280) = 293.6958138812492, nobs = 1764, Jo/n = 0.1664942255562637, err = 2.694602820739344
+CostJo   : Nonlinear Jo(sfcshp_winds_282) = 21.01771893638459, nobs = 18, Jo/n = 1.167651052021366, err = 1.106441246672606
+CostJo   : Nonlinear Jo(sfcshp_winds_284) = 126.7240935987018, nobs = 122, Jo/n = 1.038722078677884, err = 1.317635866944773
+CostFunction: Nonlinear J = 57901.69376126577

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-conv-upperair.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-conv-upperair.ref
@@ -21,15 +21,15 @@ CostJo   : Nonlinear Jo(proflr_winds_227) = 1.1594491748842424e+02, nobs = 1311,
 CostJo   : Nonlinear Jo(vadwnd_winds_224) = 9.3606166855251475e+04, nobs = 24813, Jo/n = 3.7724647102426743e+00, err = 2.8337077063401401e+00
 CostJo   : Nonlinear Jo(rassda_airTemperature_126) = 4.4416831073981186e+01, nobs = 118, Jo/n = 3.7641382266085749e-01, err = 3.0714528445990452e+00
 CostFunction: Nonlinear J = 1.6859048933398075e+05
-DRPCGMinimizer: reduction in residual norm = 9.9927365207458049e-04
+DRPCGMinimizer: reduction in residual norm = 9.9927418208850256e-04
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7377078605088428e+01 Max:+5.3266023576164528e+01 RMS:+1.3035430030732780e+01
-northward_wind                               | Min:-4.3360448495932793e+01 Max:+3.8948849845976753e+01 RMS:+6.4777415196338222e+00
-air_temperature                              | Min:+1.9409620101013795e+02 Max:+3.1434454323268056e+02 RMS:+2.5830027873418402e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4356419249742137e-02 RMS:+5.5419957690652092e-03
+eastward_wind                                | Min:-2.7377078599795020e+01 Max:+5.3266023578229131e+01 RMS:+1.3035430041775239e+01
+northward_wind                               | Min:-4.3360448441928114e+01 Max:+3.8948849774654221e+01 RMS:+6.4777415167577521e+00
+air_temperature                              | Min:+1.9409620102320028e+02 Max:+3.1434454324663295e+02 RMS:+2.5830027863744590e+02
+air_pressure_thickness                       | Min:+1.4042550839741270e+02 Max:+3.3258916591403226e+03 RMS:+1.7748338843727640e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4356419217468835e-02 RMS:+5.5419958727344534e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -43,7 +43,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6039929242210157e+04 Max:+1.0238346635593426e+05 RMS:+9.6267340935362576e+04
+air_pressure_at_surface                      | Min:+6.6039929237256700e+04 Max:+1.0238346635660242e+05 RMS:+9.6267340933536383e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -51,43 +51,43 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7095567807728173e+02 Max:+3.1487872292018056e+02 RMS:+2.9405577651171808e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+5.2360403194301897e-04 Max:+2.4871755420534717e-02 RMS:+1.1389417541392879e-02
-eastward_wind_at_surface                     | Min:-1.4847129675433129e+01 Max:+1.2359934866024160e+01 RMS:+3.4536411569717487e+00
-northward_wind_at_surface                    | Min:-1.1893900182015173e+01 Max:+1.0833240968123619e+01 RMS:+3.6096809511149348e+00
+air_temperature_at_2m                        | Min:+2.7095567805404704e+02 Max:+3.1487872293413295e+02 RMS:+2.9405577649645869e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+5.2360461027241897e-04 Max:+2.4871755388261415e-02 RMS:+1.1389417539103540e-02
+eastward_wind_at_surface                     | Min:-1.4847129698427690e+01 Max:+1.2359934839602110e+01 RMS:+3.4536411456304976e+00
+northward_wind_at_surface                    | Min:-1.1893900204140397e+01 Max:+1.0833241000802074e+01 RMS:+3.6096809484834473e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(adpupa_airTemperature_120) = 1153.087237815649, nobs = 21444, Jo/n = 0.05377202190895582, err = 3.086792367274468
+CostJo   : Nonlinear Jo(adpupa_airTemperature_120) = 1150.157570305592, nobs = 21444, Jo/n = 0.05363540245782464, err = 3.086792367274468
 CostJo   : Nonlinear Jo(adpupa_airTemperature_132) = 0 --- No Observations
-CostJo   : Nonlinear Jo(adpupa_specificHumidity_120) = 707.024082964638, nobs = 20911, Jo/n = 0.03381110817104098, err = 0.001697619491013602
+CostJo   : Nonlinear Jo(adpupa_specificHumidity_120) = 707.3042463105966, nobs = 20911, Jo/n = 0.03382450606430092, err = 0.001697619491013602
 CostJo   : Nonlinear Jo(adpupa_specificHumidity_132) = 0 --- No Observations
 CostJo   : Nonlinear Jo(adpupa_stationPressure_120) = 68.51644113612571, nobs = 129, Jo/n = 0.5311352026056256, err = 73.23476481740181
-CostJo   : Nonlinear Jo(adpupa_winds_220) = 8238.143547788157, nobs = 49578, Jo/n = 0.1661653061395812, err = 7.24679124321929
+CostJo   : Nonlinear Jo(adpupa_winds_220) = 8237.339129957261, nobs = 49578, Jo/n = 0.166149080841447, err = 7.24679124321929
 CostJo   : Nonlinear Jo(adpupa_winds_232) = 0 --- No Observations
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 8260.484310069114, nobs = 26912, Jo/n = 0.306944274303995, err = 0.9070335331040665
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 771.1428603269414, nobs = 3846, Jo/n = 0.2005051638915605, err = 0.001846312116315512
-CostJo   : Nonlinear Jo(aircar_winds_233) = 33519.28040107825, nobs = 57216, Jo/n = 0.5858375349741025, err = 2.650318593315721
-CostJo   : Nonlinear Jo(aircft_airTemperature_130) = 0.01386074542860735, nobs = 2, Jo/n = 0.006930372714303675, err = 1.256700038909912
-CostJo   : Nonlinear Jo(aircft_airTemperature_131) = 26.01799434107731, nobs = 59, Jo/n = 0.4409829549335137, err = 0.8331908104660286
-CostJo   : Nonlinear Jo(aircft_airTemperature_134) = 26.08077711900005, nobs = 31, Jo/n = 0.8413153909354854, err = 1.411693376331939
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 8261.717793742831, nobs = 26912, Jo/n = 0.3069901082692788, err = 0.9070335331040665
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 771.2407459594705, nobs = 3846, Jo/n = 0.2005306151740693, err = 0.001846312116315512
+CostJo   : Nonlinear Jo(aircar_winds_233) = 33526.08198750353, nobs = 57216, Jo/n = 0.5859564105757747, err = 2.650318593315721
+CostJo   : Nonlinear Jo(aircft_airTemperature_130) = 0.01485679954911537, nobs = 2, Jo/n = 0.007428399774557687, err = 1.256700038909912
+CostJo   : Nonlinear Jo(aircft_airTemperature_131) = 26.00361243008976, nobs = 59, Jo/n = 0.4407391937303349, err = 0.8331908104660286
+CostJo   : Nonlinear Jo(aircft_airTemperature_134) = 26.11972421773748, nobs = 31, Jo/n = 0.8425717489592734, err = 1.411693376331939
 CostJo   : Nonlinear Jo(aircft_airTemperature_135) = 0 --- No Observations
-CostJo   : Nonlinear Jo(aircft_specificHumidity_134) = 3.996480698593454, nobs = 23, Jo/n = 0.1737600303736284, err = 0.0007520080218636635
-CostJo   : Nonlinear Jo(aircft_winds_230) = 6.687829109340435, nobs = 8, Jo/n = 0.8359786386675544, err = 3.295099973678589
-CostJo   : Nonlinear Jo(aircft_winds_231) = 22.60143532149922, nobs = 118, Jo/n = 0.1915375874703323, err = 5.656700134277344
-CostJo   : Nonlinear Jo(aircft_winds_234) = 2.972959941663274, nobs = 44, Jo/n = 0.06756727140143805, err = 5.216947699010702
+CostJo   : Nonlinear Jo(aircft_specificHumidity_134) = 3.986873413695098, nobs = 23, Jo/n = 0.1733423223345695, err = 0.0007520080218636635
+CostJo   : Nonlinear Jo(aircft_winds_230) = 6.687676927798823, nobs = 8, Jo/n = 0.8359596159748529, err = 3.295099973678589
+CostJo   : Nonlinear Jo(aircft_winds_231) = 22.6239770960731, nobs = 118, Jo/n = 0.1917286194582466, err = 5.656700134277344
+CostJo   : Nonlinear Jo(aircft_winds_234) = 2.973233079677924, nobs = 44, Jo/n = 0.06757347908358918, err = 5.216947699010702
 CostJo   : Nonlinear Jo(aircft_winds_235) = 0 --- No Observations
-CostJo   : Nonlinear Jo(proflr_winds_227) = 91.93403551060021, nobs = 1311, Jo/n = 0.07012512243371488, err = 6.508472741405964
-CostJo   : Nonlinear Jo(vadwnd_winds_224) = 23603.60616394488, nobs = 24813, Jo/n = 0.9512596688810253, err = 2.83370770634014
-CostJo   : Nonlinear Jo(rassda_airTemperature_126) = 30.8666594382867, nobs = 118, Jo/n = 0.2615818596464974, err = 3.071452844599045
-CostFunction: Nonlinear J = 76532.45707734923
-DRPCGMinimizer: reduction in residual norm = 0.0008309969343926754
+CostJo   : Nonlinear Jo(proflr_winds_227) = 91.58484864162237, nobs = 1311, Jo/n = 0.06985877089368601, err = 6.508472741405964
+CostJo   : Nonlinear Jo(vadwnd_winds_224) = 23598.30111667254, nobs = 24813, Jo/n = 0.9510458677577295, err = 2.83370770634014
+CostJo   : Nonlinear Jo(rassda_airTemperature_126) = 30.92385706708568, nobs = 118, Jo/n = 0.2620665853142854, err = 3.071452844599045
+CostFunction: Nonlinear J = 76531.57769126129
+DRPCGMinimizer: reduction in residual norm = 0.0008887173669479831
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7373316180278060e+01 Max:+5.3256748706912965e+01 RMS:+1.3035419200216419e+01
-northward_wind                               | Min:-4.3364300384693216e+01 Max:+3.8946961950588090e+01 RMS:+6.4776319428605440e+00
-air_temperature                              | Min:+1.9409630614173344e+02 Max:+3.1434471046817015e+02 RMS:+2.5830020334419351e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4356852080652570e-02 RMS:+5.5420651650116247e-03
+eastward_wind                                | Min:-2.7373501498228645e+01 Max:+5.3255182029907658e+01 RMS:+1.3034901787881216e+01
+northward_wind                               | Min:-4.3368163132352201e+01 Max:+3.8947310581322313e+01 RMS:+6.4782690227250814e+00
+air_temperature                              | Min:+1.9409619231352764e+02 Max:+3.1434639868086356e+02 RMS:+2.5830277205212792e+02
+air_pressure_thickness                       | Min:+1.4042486039260703e+02 Max:+3.3258929513786170e+03 RMS:+1.7748311779565406e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4355151528692578e-02 RMS:+5.5419049238434100e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -101,7 +101,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6039780090740867e+04 Max:+1.0238343293639654e+05 RMS:+9.6267270906931488e+04
+air_pressure_at_surface                      | Min:+6.6039624493974465e+04 Max:+1.0238349943341083e+05 RMS:+9.6267205720309736e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -109,31 +109,31 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7095477408840168e+02 Max:+3.1487889015567015e+02 RMS:+2.9405568609075158e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+5.2139120456210668e-04 Max:+2.4872188251445149e-02 RMS:+1.1389713097215896e-02
-eastward_wind_at_surface                     | Min:-1.4845199894297927e+01 Max:+1.2359644943265952e+01 RMS:+3.4535148106811913e+00
-northward_wind_at_surface                    | Min:-1.1899336169799994e+01 Max:+1.0831066790225593e+01 RMS:+3.6096383174847571e+00
+air_temperature_at_2m                        | Min:+2.7097897307031519e+02 Max:+3.1488057836836356e+02 RMS:+2.9406102538353730e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+5.0697195898377590e-04 Max:+2.4870487699485157e-02 RMS:+1.1389421686883882e-02
+eastward_wind_at_surface                     | Min:-1.4875415480623147e+01 Max:+1.2351898213753360e+01 RMS:+3.4531985721134668e+00
+northward_wind_at_surface                    | Min:-1.1907785772622685e+01 Max:+1.0892233182972813e+01 RMS:+3.6100583279459673e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(adpupa_airTemperature_120) = 1153.343312064334, nobs = 21444, Jo/n = 0.05378396344265688, err = 3.086792367274468
+CostJo   : Nonlinear Jo(adpupa_airTemperature_120) = 1152.469289108042, nobs = 21444, Jo/n = 0.05374320505073875, err = 3.086792367274468
 CostJo   : Nonlinear Jo(adpupa_airTemperature_132) = 0 --- No Observations
-CostJo   : Nonlinear Jo(adpupa_specificHumidity_120) = 707.2123461376419, nobs = 20911, Jo/n = 0.03382011123990445, err = 0.001697619491013602
+CostJo   : Nonlinear Jo(adpupa_specificHumidity_120) = 707.4960835203175, nobs = 20911, Jo/n = 0.03383368004974977, err = 0.001697619491013602
 CostJo   : Nonlinear Jo(adpupa_specificHumidity_132) = 0 --- No Observations
-CostJo   : Nonlinear Jo(adpupa_stationPressure_120) = 68.59924681717766, nobs = 129, Jo/n = 0.5317771071099043, err = 73.23476481740181
-CostJo   : Nonlinear Jo(adpupa_winds_220) = 8238.198990975856, nobs = 49578, Jo/n = 0.166166424441806, err = 7.24679124321929
+CostJo   : Nonlinear Jo(adpupa_stationPressure_120) = 68.66423536331233, nobs = 129, Jo/n = 0.5322808942892429, err = 73.23476481740181
+CostJo   : Nonlinear Jo(adpupa_winds_220) = 8237.177280787899, nobs = 49578, Jo/n = 0.1661458163053753, err = 7.24679124321929
 CostJo   : Nonlinear Jo(adpupa_winds_232) = 0 --- No Observations
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 8260.406523341699, nobs = 26912, Jo/n = 0.3069413838934936, err = 0.9070335331040665
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 771.1661997894221, nobs = 3846, Jo/n = 0.2005112323945455, err = 0.001846312116315512
-CostJo   : Nonlinear Jo(aircar_winds_233) = 33519.53039610152, nobs = 57216, Jo/n = 0.5858419042942798, err = 2.650318593315721
-CostJo   : Nonlinear Jo(aircft_airTemperature_130) = 0.01377581368369371, nobs = 2, Jo/n = 0.006887906841846857, err = 1.256700038909912
-CostJo   : Nonlinear Jo(aircft_airTemperature_131) = 26.03352996753027, nobs = 59, Jo/n = 0.4412462706361063, err = 0.8331908104660286
-CostJo   : Nonlinear Jo(aircft_airTemperature_134) = 26.05102023657314, nobs = 31, Jo/n = 0.8403554915023596, err = 1.411693376331939
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 8258.335343145916, nobs = 26912, Jo/n = 0.3068644226793221, err = 0.9070335331040665
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 771.0161625721705, nobs = 3846, Jo/n = 0.2004722211576106, err = 0.001846312116315512
+CostJo   : Nonlinear Jo(aircar_winds_233) = 33520.28081055635, nobs = 57216, Jo/n = 0.585855019759444, err = 2.650318593315721
+CostJo   : Nonlinear Jo(aircft_airTemperature_130) = 0.01382975835571478, nobs = 2, Jo/n = 0.006914879177857391, err = 1.256700038909912
+CostJo   : Nonlinear Jo(aircft_airTemperature_131) = 26.04832092053687, nobs = 59, Jo/n = 0.4414969647548622, err = 0.8331908104660286
+CostJo   : Nonlinear Jo(aircft_airTemperature_134) = 26.03734088643304, nobs = 31, Jo/n = 0.8399142221430014, err = 1.411693376331939
 CostJo   : Nonlinear Jo(aircft_airTemperature_135) = 0 --- No Observations
-CostJo   : Nonlinear Jo(aircft_specificHumidity_134) = 3.993271983960016, nobs = 23, Jo/n = 0.1736205210417398, err = 0.0007520080218636635
-CostJo   : Nonlinear Jo(aircft_winds_230) = 6.687865001847538, nobs = 8, Jo/n = 0.8359831252309422, err = 3.295099973678589
-CostJo   : Nonlinear Jo(aircft_winds_231) = 22.58196166319948, nobs = 118, Jo/n = 0.1913725564677922, err = 5.656700134277344
-CostJo   : Nonlinear Jo(aircft_winds_234) = 2.976311524933627, nobs = 44, Jo/n = 0.06764344374849153, err = 5.216947699010702
+CostJo   : Nonlinear Jo(aircft_specificHumidity_134) = 3.989027914927839, nobs = 23, Jo/n = 0.1734359963012104, err = 0.0007520080218636635
+CostJo   : Nonlinear Jo(aircft_winds_230) = 6.687199063413642, nobs = 8, Jo/n = 0.8358998829267053, err = 3.295099973678589
+CostJo   : Nonlinear Jo(aircft_winds_231) = 22.59866432600874, nobs = 118, Jo/n = 0.1915141044577012, err = 5.656700134277344
+CostJo   : Nonlinear Jo(aircft_winds_234) = 2.974448611092441, nobs = 44, Jo/n = 0.06760110479755548, err = 5.216947699010702
 CostJo   : Nonlinear Jo(aircft_winds_235) = 0 --- No Observations
-CostJo   : Nonlinear Jo(proflr_winds_227) = 92.01423908685628, nobs = 1311, Jo/n = 0.07018629983741898, err = 6.508472741405964
-CostJo   : Nonlinear Jo(vadwnd_winds_224) = 23601.18948102816, nobs = 24813, Jo/n = 0.9511622730434917, err = 2.83370770634014
-CostJo   : Nonlinear Jo(rassda_airTemperature_126) = 30.86682113036888, nobs = 118, Jo/n = 0.2615832299183803, err = 3.071452844599045
-CostFunction: Nonlinear J = 76530.86529266478
+CostJo   : Nonlinear Jo(proflr_winds_227) = 91.94242360289232, nobs = 1311, Jo/n = 0.07013152067344952, err = 6.508472741405964
+CostJo   : Nonlinear Jo(vadwnd_winds_224) = 23602.2507720644, nobs = 24813, Jo/n = 0.9512050446163061, err = 2.83370770634014
+CostJo   : Nonlinear Jo(rassda_airTemperature_126) = 30.84059840929643, nobs = 118, Jo/n = 0.2613610034686139, err = 3.071452844599045
+CostFunction: Nonlinear J = 76528.82183061137

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-remote.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-remote.ref
@@ -6,15 +6,15 @@ CostJo   : Nonlinear Jo(satwnd_winds_246_272) = 2.0305885470608743e+01, nobs = 5
 CostJo   : Nonlinear Jo(satwnd_winds_247_270) = 1.8510449944006899e+02, nobs = 590, Jo/n = 3.1373643972893051e-01, err = 3.0891362037998458e+00
 CostJo   : Nonlinear Jo(satwnd_winds_247_272) = 1.5000805458239256e+02, nobs = 460, Jo/n = 3.2610446648346209e-01, err = 3.0640959445386398e+00
 CostFunction: Nonlinear J = 1.4033928704290531e+03
-DRPCGMinimizer: reduction in residual norm = 5.3139542299822514e-04
+DRPCGMinimizer: reduction in residual norm = 5.3137401632688866e-04
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7019640383639228e+01 Max:+5.3049758559826202e+01 RMS:+1.3282632747133968e+01
-northward_wind                               | Min:-3.9561085516290930e+01 Max:+3.8200321043812259e+01 RMS:+6.4400580429840701e+00
-air_temperature                              | Min:+1.9402699090513457e+02 Max:+3.1448460551826776e+02 RMS:+2.5822378588316752e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4609927008981063e-02 RMS:+5.5152847723794864e-03
+eastward_wind                                | Min:-2.7019640422041675e+01 Max:+5.3049758787177517e+01 RMS:+1.3282632729430683e+01
+northward_wind                               | Min:-3.9561084674107548e+01 Max:+3.8200320767514938e+01 RMS:+6.4400579460451883e+00
+air_temperature                              | Min:+1.9402699089494774e+02 Max:+3.1448460552189107e+02 RMS:+2.5822378563140046e+02
+air_pressure_thickness                       | Min:+1.4040053283290737e+02 Max:+3.3267886092385347e+03 RMS:+1.7747357551415489e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4609931572104400e-02 RMS:+5.5152844155935132e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -28,7 +28,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6028183742240086e+04 Max:+1.0240642515959607e+05 RMS:+9.6262341531512604e+04
+air_pressure_at_surface                      | Min:+6.6028183744883107e+04 Max:+1.0240642516123698e+05 RMS:+9.6262341545646763e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -36,28 +36,28 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7095254308387683e+02 Max:+3.1501878520576776e+02 RMS:+2.9383641512778763e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+2.0771307214179045e-03 Max:+2.5125263179773642e-02 RMS:+1.1340731641323721e-02
-eastward_wind_at_surface                     | Min:-1.2953625857242093e+01 Max:+1.2192287703055824e+01 RMS:+3.6146520783243092e+00
-northward_wind_at_surface                    | Min:-1.3917024721553275e+01 Max:+1.2423729154327008e+01 RMS:+3.6937521423745538e+00
+air_temperature_at_2m                        | Min:+2.7095254418923554e+02 Max:+3.1501878520939107e+02 RMS:+2.9383641475807610e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+2.0771315694070860e-03 Max:+2.5125267742896980e-02 RMS:+1.1340731324551191e-02
+eastward_wind_at_surface                     | Min:-1.2953624171924659e+01 Max:+1.2192287896064352e+01 RMS:+3.6146519219516504e+00
+northward_wind_at_surface                    | Min:-1.3917024805807820e+01 Max:+1.2423730273183811e+01 RMS:+3.6937520857995381e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 325.2802944843309, nobs = 463, Jo/n = 0.7025492321475828, err = 0.009999999776482582
-CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 57.67553543932235, nobs = 278, Jo/n = 0.2074659548177063, err = 1.978135880703919
-CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 29.61675002345199, nobs = 298, Jo/n = 0.0993850671927919, err = 1.908933409771839
-CostJo   : Nonlinear Jo(satwnd_winds_246_270) = 101.1572149473451, nobs = 368, Jo/n = 0.2748837362699594, err = 3.402220483690042
-CostJo   : Nonlinear Jo(satwnd_winds_246_272) = 13.14883149161027, nobs = 58, Jo/n = 0.2267039912346599, err = 3.355959527040198
-CostJo   : Nonlinear Jo(satwnd_winds_247_270) = 110.0252569154991, nobs = 590, Jo/n = 0.1864834862974562, err = 3.089136203799846
-CostJo   : Nonlinear Jo(satwnd_winds_247_272) = 81.23765448341173, nobs = 460, Jo/n = 0.176603596703069, err = 3.06409594453864
-CostFunction: Nonlinear J = 718.1415377849714
-DRPCGMinimizer: reduction in residual norm = 0.0007327012172742083
+CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 325.7917761559736, nobs = 463, Jo/n = 0.7036539441813685, err = 0.009999999776482582
+CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 57.6742641866184, nobs = 278, Jo/n = 0.2074613819662532, err = 1.978135880703919
+CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 29.61913331668504, nobs = 298, Jo/n = 0.09939306482109075, err = 1.908933409771839
+CostJo   : Nonlinear Jo(satwnd_winds_246_270) = 101.1547622843588, nobs = 368, Jo/n = 0.274877071424888, err = 3.402220483690042
+CostJo   : Nonlinear Jo(satwnd_winds_246_272) = 13.14866316053168, nobs = 58, Jo/n = 0.2267010889746842, err = 3.355959527040198
+CostJo   : Nonlinear Jo(satwnd_winds_247_270) = 110.0241191459028, nobs = 590, Jo/n = 0.1864815578744116, err = 3.089136203799846
+CostJo   : Nonlinear Jo(satwnd_winds_247_272) = 81.23832575133878, nobs = 460, Jo/n = 0.1766050559811713, err = 3.06409594453864
+CostFunction: Nonlinear J = 718.6510440014092
+DRPCGMinimizer: reduction in residual norm = 0.0006424264372344568
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7019644174328803e+01 Max:+5.3050315019721694e+01 RMS:+1.3282544575588442e+01
-northward_wind                               | Min:-3.9547217044761794e+01 Max:+3.8199118126517597e+01 RMS:+6.4398101714068741e+00
-air_temperature                              | Min:+1.9402699340160845e+02 Max:+3.1448531826342190e+02 RMS:+2.5822388111324040e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4600225553090906e-02 RMS:+5.5152301228668767e-03
+eastward_wind                                | Min:-2.7019652740497044e+01 Max:+5.3050475197968218e+01 RMS:+1.3282568854682268e+01
+northward_wind                               | Min:-3.9546972959417182e+01 Max:+3.8199300720190351e+01 RMS:+6.4397403564661415e+00
+air_temperature                              | Min:+1.9402699451539775e+02 Max:+3.1448529056388418e+02 RMS:+2.5822358505156649e+02
+air_pressure_thickness                       | Min:+1.4040057401463335e+02 Max:+3.3267884821601865e+03 RMS:+1.7747359933779881e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4601378211553983e-02 RMS:+5.5148359788554716e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -71,7 +71,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6028187748844721e+04 Max:+1.0240641648224650e+05 RMS:+9.6262335298524791e+04
+air_pressure_at_surface                      | Min:+6.6028203111798648e+04 Max:+1.0240642190847301e+05 RMS:+9.6262353385932482e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -79,16 +79,16 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7095511417749628e+02 Max:+3.1501949795092190e+02 RMS:+2.9383717435661850e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+2.0421675225113355e-03 Max:+2.5115561723883486e-02 RMS:+1.1339439057415390e-02
-eastward_wind_at_surface                     | Min:-1.2954165593558802e+01 Max:+1.2192202541277419e+01 RMS:+3.6147472918807391e+00
-northward_wind_at_surface                    | Min:-1.3917783019586610e+01 Max:+1.2424178416284802e+01 RMS:+3.6936993113551608e+00
+air_temperature_at_2m                        | Min:+2.7095364437114819e+02 Max:+3.1501947025138418e+02 RMS:+2.9383669893732559e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+2.0428406972912701e-03 Max:+2.5116714382346562e-02 RMS:+1.1339062087679512e-02
+eastward_wind_at_surface                     | Min:-1.2953575169354396e+01 Max:+1.2192044945543010e+01 RMS:+3.6146388861106744e+00
+northward_wind_at_surface                    | Min:-1.3916974768030979e+01 Max:+1.2424129639935938e+01 RMS:+3.6936760493455250e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 324.4196053115937, nobs = 463, Jo/n = 0.7006902922496624, err = 0.009999999776482582
-CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 57.25575360900093, nobs = 278, Jo/n = 0.2059559482338163, err = 1.978135880703919
-CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 29.61528102302711, nobs = 298, Jo/n = 0.0993801376611648, err = 1.908933409771839
-CostJo   : Nonlinear Jo(satwnd_winds_246_270) = 100.8074171633954, nobs = 368, Jo/n = 0.2739331988135745, err = 3.402220483690042
-CostJo   : Nonlinear Jo(satwnd_winds_246_272) = 13.14487898217882, nobs = 58, Jo/n = 0.2266358445203245, err = 3.355959527040198
-CostJo   : Nonlinear Jo(satwnd_winds_247_270) = 109.8643180804598, nobs = 590, Jo/n = 0.1862107086109488, err = 3.089136203799846
-CostJo   : Nonlinear Jo(satwnd_winds_247_272) = 81.23722208139969, nobs = 460, Jo/n = 0.176602656698695, err = 3.06409594453864
-CostFunction: Nonlinear J = 716.3444762510555
+CostJo   : Nonlinear Jo(gnss_ztd_zenithTotalDelay) = 324.6432361428053, nobs = 463, Jo/n = 0.7011732962047631, err = 0.009999999776482582
+CostJo   : Nonlinear Jo(satwnd_winds_245_270) = 57.25556600970127, nobs = 278, Jo/n = 0.2059552734161916, err = 1.978135880703919
+CostJo   : Nonlinear Jo(satwnd_winds_245_272) = 29.61564469047627, nobs = 298, Jo/n = 0.09938135802173245, err = 1.908933409771839
+CostJo   : Nonlinear Jo(satwnd_winds_246_270) = 100.8082844002148, nobs = 368, Jo/n = 0.2739355554353664, err = 3.402220483690042
+CostJo   : Nonlinear Jo(satwnd_winds_246_272) = 13.14482406989661, nobs = 58, Jo/n = 0.2266348977568381, err = 3.355959527040198
+CostJo   : Nonlinear Jo(satwnd_winds_247_270) = 109.8652406147929, nobs = 590, Jo/n = 0.1862122722284626, err = 3.089136203799846
+CostJo   : Nonlinear Jo(satwnd_winds_247_272) = 81.23771081768689, nobs = 460, Jo/n = 0.1766037191688845, err = 3.06409594453864
+CostFunction: Nonlinear J = 716.5705067455741

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-satrad.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-satrad.ref
@@ -7,18 +7,18 @@ CostJo   : Nonlinear Jo(atms_npp) = 9.7891908794840458e+02, nobs = 11566, Jo/n =
 CostJo   : Nonlinear Jo(atms_n20) = 3.7662329446048574e+02, nobs = 3156, Jo/n = 1.1933564463260005e-01, err = 4.3429907672523624e+00
 CostJo   : Nonlinear Jo(atms_n21) = 3.0225538533159302e+03, nobs = 16237, Jo/n = 1.8615223583888219e-01, err = 4.9371537752374968e+00
 CostFunction: Nonlinear J = 5.2488813266078305e+03
-DRPCGMinimizer: reduction in residual norm = 2.9312206440864203e-02
+DRPCGMinimizer: reduction in residual norm = 2.9312206434442430e-02
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
 eastward_wind                                | Min:-2.7017492294290520e+01 Max:+5.2821491240813479e+01 RMS:+1.3292761706280364e+01
 northward_wind                               | Min:-3.9898376464870090e+01 Max:+3.8607715606191213e+01 RMS:+6.4370448328598817e+00
 air_temperature                              | Min:+1.9402590942380320e+02 Max:+3.1449734497058847e+02 RMS:+2.5823280233367541e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
+air_pressure_thickness                       | Min:+1.4039907836915731e+02 Max:+3.3267851562500023e+03 RMS:+1.7747128794077955e+03
 water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4484865367434074e-02 RMS:+5.5260043490561010e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
-ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6988892302174129e-05 RMS:+4.4530494339376456e-06
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6988892301862506e-05 RMS:+4.4530494339367782e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223757e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586809e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -39,8 +39,8 @@ rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
 air_temperature_at_2m                        | Min:+2.7084295654383806e+02 Max:+3.1503152465808847e+02 RMS:+2.9386084352260815e+02
 water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3829292729392979e-03 Max:+2.5000201538226654e-02 RMS:+1.1317537983944467e-02
-eastward_wind_at_surface                     | Min:-1.2974018096909907e+01 Max:+1.2164360045735354e+01 RMS:+3.6171520011220482e+00
-northward_wind_at_surface                    | Min:-1.3966897012612508e+01 Max:+1.2346966743489308e+01 RMS:+3.7014659136531010e+00
+eastward_wind_at_surface                     | Min:-1.2974018096909907e+01 Max:+1.2164360045735352e+01 RMS:+3.6171520011220482e+00
+northward_wind_at_surface                    | Min:-1.3966897012612510e+01 Max:+1.2346966743489308e+01 RMS:+3.7014659136531014e+00
 ----------------------------------------------------------------------------------------------------
 Obs bias coefficients: 
 ---------------------------------------------------------------
@@ -130,27 +130,27 @@ sensorScanAngle_order_3:  Min= -4.3194479942321777,  Max= 0.2986190038570832,  N
 sensorScanAngle_order_2:  Min= -22.9652671771855132,  Max= 4.6946859372133991,  Norm= 33.1227317713677394
      sensorScanAngle:  Min= -0.1856029921728745,  Max= 1.1675239802103221,  Norm= 1.9335939677654823
 ---------------------------------------------------------------
-CostJo   : Nonlinear Jo(abi_g16) = 967.4868069863875917, nobs = 6227, Jo/n = 0.1553696494277160, err = 1.9850985657678344
-CostJo   : Nonlinear Jo(abi_g18) = 918.8665051542013771, nobs = 4148, Jo/n = 0.2215203725058345, err = 1.9485332820487384
+CostJo   : Nonlinear Jo(abi_g16) = 967.4868069342007857, nobs = 6227, Jo/n = 0.1553696494193353, err = 1.9850985657678344
+CostJo   : Nonlinear Jo(abi_g18) = 918.8665050458322412, nobs = 4148, Jo/n = 0.2215203724797088, err = 1.9485332820487384
 CostJo   : Nonlinear Jo(amsua_n19) = 16.1774122283480466, nobs = 5, Jo/n = 3.2354824456696094, err = 0.3517965917449892
 CostJo   : Nonlinear Jo(amsua_metop-b) = 4.2363376224427514, nobs = 2, Jo/n = 2.1181688112213757, err = 0.3052757520588904
 CostJo   : Nonlinear Jo(amsua_metop-c) = 0.0000000000000000 --- No Observations
-CostJo   : Nonlinear Jo(atms_npp) = 978.9190430430364813, nobs = 11566, Jo/n = 0.0846376485425416, err = 4.2451227919671579
-CostJo   : Nonlinear Jo(atms_n20) = 376.6232804192086405, nobs = 3156, Jo/n = 0.1193356401835262, err = 4.3429907672523624
-CostJo   : Nonlinear Jo(atms_n21) = 3022.5538016794635041, nobs = 16237, Jo/n = 0.1861522326587093, err = 4.9371537752374968
-CostFunction: Nonlinear J = 6284.8631871330881040
-DRPCGMinimizer: reduction in residual norm = 0.0144033978263844
+CostJo   : Nonlinear Jo(atms_npp) = 978.9190430116832431, nobs = 11566, Jo/n = 0.0846376485398308, err = 4.2451227919671579
+CostJo   : Nonlinear Jo(atms_n20) = 376.6232804429359931, nobs = 3156, Jo/n = 0.1193356401910444, err = 4.3429907672523624
+CostJo   : Nonlinear Jo(atms_n21) = 3022.5538016677851374, nobs = 16237, Jo/n = 0.1861522326579901, err = 4.9371537752374968
+CostFunction: Nonlinear J = 6284.8631869532282508
+DRPCGMinimizer: reduction in residual norm = 0.0144033978104795
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
 eastward_wind                                | Min:-2.7017492294273609e+01 Max:+5.2821491240295508e+01 RMS:+1.3292761706018711e+01
 northward_wind                               | Min:-3.9898376464891470e+01 Max:+3.8607715605788790e+01 RMS:+6.4370448330600407e+00
 air_temperature                              | Min:+1.9402590942378296e+02 Max:+3.1449734497050645e+02 RMS:+2.5823280233310294e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4484865367451911e-02 RMS:+5.5260043490947229e-03
+air_pressure_thickness                       | Min:+1.4039907836917072e+02 Max:+3.3267851562500041e+03 RMS:+1.7747128794079522e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4484865367451911e-02 RMS:+5.5260043490947220e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
-ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.8584928005268669e-05 RMS:+4.4578052806220267e-06
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.8584928005029830e-05 RMS:+4.4578052806215354e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223757e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586809e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -171,8 +171,8 @@ rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
 air_temperature_at_2m                        | Min:+2.7084295654454030e+02 Max:+3.1503152465800645e+02 RMS:+2.9386084352262537e+02
 water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3829292729314450e-03 Max:+2.5000201538244490e-02 RMS:+1.1317537983988071e-02
-eastward_wind_at_surface                     | Min:-1.2974018096899224e+01 Max:+1.2164360045206815e+01 RMS:+3.6171520011783089e+00
-northward_wind_at_surface                    | Min:-1.3966897014074165e+01 Max:+1.2346966743505170e+01 RMS:+3.7014659136486370e+00
+eastward_wind_at_surface                     | Min:-1.2974018096899224e+01 Max:+1.2164360045206813e+01 RMS:+3.6171520011783085e+00
+northward_wind_at_surface                    | Min:-1.3966897014074169e+01 Max:+1.2346966743505170e+01 RMS:+3.7014659136486374e+00
 ----------------------------------------------------------------------------------------------------
 Obs bias coefficients: 
 ---------------------------------------------------------------
@@ -262,12 +262,12 @@ sensorScanAngle_order_3:  Min= -4.3194479942321777,  Max= 0.2986190052733244,  N
 sensorScanAngle_order_2:  Min= -22.9652671737840244,  Max= 4.6946859382144481,  Norm= 33.1227317670247388
      sensorScanAngle:  Min= -0.1856029916880673,  Max= 1.1675239802665718,  Norm= 1.9335939676935112
 ---------------------------------------------------------------
-CostJo   : Nonlinear Jo(abi_g16) = 962.4794652504286887, nobs = 6227, Jo/n = 0.1545655155372457, err = 1.9850985657678344
-CostJo   : Nonlinear Jo(abi_g18) = 660.7284529475764430, nobs = 4148, Jo/n = 0.1592884409227523, err = 1.9485332820487384
+CostJo   : Nonlinear Jo(abi_g16) = 962.4794652522211891, nobs = 6227, Jo/n = 0.1545655155375335, err = 1.9850985657678344
+CostJo   : Nonlinear Jo(abi_g18) = 660.7284531023539103, nobs = 4148, Jo/n = 0.1592884409600660, err = 1.9485332820487384
 CostJo   : Nonlinear Jo(amsua_n19) = 16.1774122104994689, nobs = 5, Jo/n = 3.2354824420998938, err = 0.3517965917449892
 CostJo   : Nonlinear Jo(amsua_metop-b) = 4.2363376206383609, nobs = 2, Jo/n = 2.1181688103191805, err = 0.3052757520588904
 CostJo   : Nonlinear Jo(amsua_metop-c) = 0.0000000000000000 --- No Observations
-CostJo   : Nonlinear Jo(atms_npp) = 978.9190056781211524, nobs = 11566, Jo/n = 0.0846376453119593, err = 4.2451227919671579
-CostJo   : Nonlinear Jo(atms_n20) = 376.6232689510163141, nobs = 3156, Jo/n = 0.1193356365497517, err = 4.3429907672523624
-CostJo   : Nonlinear Jo(atms_n21) = 3022.5537615272314724, nobs = 16237, Jo/n = 0.1861522301858244, err = 4.9371537752374968
-CostFunction: Nonlinear J = 6021.7177041855120478
+CostJo   : Nonlinear Jo(atms_npp) = 978.9190056135744271, nobs = 11566, Jo/n = 0.0846376453063786, err = 4.2451227919671579
+CostJo   : Nonlinear Jo(atms_n20) = 376.6232688521196224, nobs = 3156, Jo/n = 0.1193356365184156, err = 4.3429907672523624
+CostJo   : Nonlinear Jo(atms_n21) = 3022.5537614840927745, nobs = 16237, Jo/n = 0.1861522301831676, err = 4.9371537752374968
+CostFunction: Nonlinear J = 6021.7177041354989342

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3dvar.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3dvar.ref
@@ -2,15 +2,15 @@ CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 1.7109300271492430e+04, nob
 CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 1.1576104621804132e+03, nobs = 3846, Jo/n = 3.0099075979729933e-01, err = 1.8463121163155125e-03
 CostJo   : Nonlinear Jo(aircar_winds_233) = 4.5918477878981983e+04, nobs = 57216, Jo/n = 8.0254610386923209e-01, err = 2.6503185933157209e+00
 CostFunction: Nonlinear J = 6.4185388612654824e+04
-DRPCGMinimizer: reduction in residual norm = 9.2738445419687939e-04
+DRPCGMinimizer: reduction in residual norm = 9.2738491422364878e-04
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7018117560232767e+01 Max:+5.3272016147325076e+01 RMS:+1.3325057758419470e+01
-northward_wind                               | Min:-4.3506296272556433e+01 Max:+3.9032192008082710e+01 RMS:+6.5157656126191608e+00
-air_temperature                              | Min:+1.9401739267717318e+02 Max:+3.1455207635562641e+02 RMS:+2.5830110211338263e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4708422986068561e-02 RMS:+5.5565091240326707e-03
+eastward_wind                                | Min:-2.7018117546532054e+01 Max:+5.3272016163520121e+01 RMS:+1.3325057767337354e+01
+northward_wind                               | Min:-4.3506296358434980e+01 Max:+3.9032192017613930e+01 RMS:+6.5157656314714245e+00
+air_temperature                              | Min:+1.9401739267064860e+02 Max:+3.1455207636191693e+02 RMS:+2.5830110211787246e+02
+air_pressure_thickness                       | Min:+1.4036361484671656e+02 Max:+3.3267068993302673e+03 RMS:+1.7746911064675021e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4708422942074273e-02 RMS:+5.5565092370895063e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -24,7 +24,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6010821978586362e+04 Max:+1.0240433367269840e+05 RMS:+9.6260137730994989e+04
+air_pressure_at_surface                      | Min:+6.6010821978138643e+04 Max:+1.0240433367161638e+05 RMS:+9.6260137724718195e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -32,24 +32,24 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7109399053747825e+02 Max:+3.1508625604312641e+02 RMS:+2.9399205806616033e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.1626136867472334e-03 Max:+2.5223759156861141e-02 RMS:+1.1378071402513975e-02
-eastward_wind_at_surface                     | Min:-1.7099622135236999e+01 Max:+1.2297151242111680e+01 RMS:+3.5573325222353360e+00
-northward_wind_at_surface                    | Min:-1.4333609391727956e+01 Max:+9.9412894605945894e+00 RMS:+3.6785938191928014e+00
+air_temperature_at_2m                        | Min:+2.7109399054815856e+02 Max:+3.1508625604941693e+02 RMS:+2.9399205808102977e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.1626137088405694e-03 Max:+2.5223759112866853e-02 RMS:+1.1378071406617313e-02
+eastward_wind_at_surface                     | Min:-1.7099622264718587e+01 Max:+1.2297151251347485e+01 RMS:+3.5573325234902171e+00
+northward_wind_at_surface                    | Min:-1.4333609437275543e+01 Max:+9.9412894808398544e+00 RMS:+3.6785938344375122e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 8203.186524285065, nobs = 26912, Jo/n = 0.3048151948679052, err = 0.9070335331040665
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 784.5164727876924, nobs = 3846, Jo/n = 0.2039824422224889, err = 0.001846312116315512
-CostJo   : Nonlinear Jo(aircar_winds_233) = 24639.63034812159, nobs = 57216, Jo/n = 0.4306423089366889, err = 2.650318593315721
-CostFunction: Nonlinear J = 33627.33334519435
-DRPCGMinimizer: reduction in residual norm = 0.000918904493770453
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 8205.193768034451, nobs = 26912, Jo/n = 0.3048897803223265, err = 0.9070335331040665
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 784.4467537025424, nobs = 3846, Jo/n = 0.2039643145352424, err = 0.001846312116315512
+CostJo   : Nonlinear Jo(aircar_winds_233) = 24642.67004013417, nobs = 57216, Jo/n = 0.4306954355448506, err = 2.650318593315721
+CostFunction: Nonlinear J = 33632.31056187117
+DRPCGMinimizer: reduction in residual norm = 0.0009225387245418062
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7018117083816403e+01 Max:+5.3272359664396163e+01 RMS:+1.3325070806438173e+01
-northward_wind                               | Min:-4.3507110317947323e+01 Max:+3.9028199835348744e+01 RMS:+6.5156827921065545e+00
-air_temperature                              | Min:+1.9401737740506013e+02 Max:+3.1455201799086086e+02 RMS:+2.5830108691327985e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4707253673206305e-02 RMS:+5.5564068188281206e-03
+eastward_wind                                | Min:-2.7018001862059350e+01 Max:+5.3272549352384239e+01 RMS:+1.3325033836028910e+01
+northward_wind                               | Min:-4.3509958770489519e+01 Max:+3.9026936880200772e+01 RMS:+6.5156637793706480e+00
+air_temperature                              | Min:+1.9401727879355573e+02 Max:+3.1455184967820946e+02 RMS:+2.5830080568220041e+02
+air_pressure_thickness                       | Min:+1.4036387020726377e+02 Max:+3.3267063390602675e+03 RMS:+1.7746911844408503e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.4703171424593134e-02 RMS:+5.5562595358222052e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
@@ -63,7 +63,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6010857991586570e+04 Max:+1.0240432778204541e+05 RMS:+9.6260139043217467e+04
+air_pressure_at_surface                      | Min:+6.6010942068932156e+04 Max:+1.0240431933065194e+05 RMS:+9.6260141773467098e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -71,12 +71,12 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7109321400852718e+02 Max:+3.1508619767836086e+02 RMS:+2.9399205075864052e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.1613550776698859e-03 Max:+2.5222589843998885e-02 RMS:+1.1377986436704658e-02
-eastward_wind_at_surface                     | Min:-1.7098481329792854e+01 Max:+1.2297041412336650e+01 RMS:+3.5574299945666765e+00
-northward_wind_at_surface                    | Min:-1.4333134747955697e+01 Max:+9.9389875713057840e+00 RMS:+3.6786745671773837e+00
+air_temperature_at_2m                        | Min:+2.7109431433158886e+02 Max:+3.1508602936570946e+02 RMS:+2.9399174745513352e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.1603726076944891e-03 Max:+2.5218507595385714e-02 RMS:+1.1377727311484087e-02
+eastward_wind_at_surface                     | Min:-1.7080677619553068e+01 Max:+1.2296147828818039e+01 RMS:+3.5574455463725272e+00
+northward_wind_at_surface                    | Min:-1.4332424447002742e+01 Max:+9.9413046713145938e+00 RMS:+3.6783544136004789e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 8203.226907863205, nobs = 26912, Jo/n = 0.30481669544676, err = 0.9070335331040665
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 784.5750119503442, nobs = 3846, Jo/n = 0.2039976630136101, err = 0.001846312116315512
-CostJo   : Nonlinear Jo(aircar_winds_233) = 24639.50538674236, nobs = 57216, Jo/n = 0.4306401249081089, err = 2.650318593315721
-CostFunction: Nonlinear J = 33627.30730655591
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 8203.744706048592, nobs = 26912, Jo/n = 0.3048359358668472, err = 0.9070335331040665
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 784.685424641674, nobs = 3846, Jo/n = 0.2040263714616937, err = 0.001846312116315512
+CostJo   : Nonlinear Jo(aircar_winds_233) = 24641.66835011526, nobs = 57216, Jo/n = 0.4306779283786923, err = 2.650318593315721
+CostFunction: Nonlinear J = 33630.09848080552

--- a/rrfs-test/testoutput/rrfs-fv3jedi-hybrid3denvar.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-hybrid3denvar.ref
@@ -2,18 +2,18 @@ CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 1.7109300271492430e+04, nob
 CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 1.1576104621804132e+03, nobs = 3846, Jo/n = 3.0099075979729933e-01, err = 1.8463121163155125e-03
 CostJo   : Nonlinear Jo(aircar_winds_233) = 4.5918477878981983e+04, nobs = 57216, Jo/n = 8.0254610386923209e-01, err = 2.6503185933157209e+00
 CostFunction: Nonlinear J = 6.4185388612654824e+04
-DRPCGMinimizer: reduction in residual norm = 9.8649875715514168e-04
+DRPCGMinimizer: reduction in residual norm = 9.8649875270921715e-04
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7016833041580036e+01 Max:+5.6038006564102425e+01 RMS:+1.3311530748163729e+01
-northward_wind                               | Min:-4.2662637430440363e+01 Max:+4.1719998803559740e+01 RMS:+6.4821733792234406e+00
-air_temperature                              | Min:+1.9402507645674129e+02 Max:+3.1450907700517143e+02 RMS:+2.5827580419628390e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6759370692581240e-02 RMS:+5.5433977283182142e-03
+eastward_wind                                | Min:-2.7016833040015708e+01 Max:+5.6038006577138447e+01 RMS:+1.3311530747993764e+01
+northward_wind                               | Min:-4.2662637433669460e+01 Max:+4.1719998815791463e+01 RMS:+6.4821733750068935e+00
+air_temperature                              | Min:+1.9402507645565549e+02 Max:+3.1450907700635332e+02 RMS:+2.5827580419034405e+02
+air_pressure_thickness                       | Min:+1.4039622958483776e+02 Max:+3.3267574263842789e+03 RMS:+1.7746600454500856e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6759370715455463e-02 RMS:+5.5433977928118520e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
-ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486449691556652e-06
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486449691584536e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223757e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586809e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -24,7 +24,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6026160015834990e+04 Max:+1.0240562698888221e+05 RMS:+9.6258610161994206e+04
+air_pressure_at_surface                      | Min:+6.6026160016155278e+04 Max:+1.0240562698856246e+05 RMS:+9.6258610160105774e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -32,27 +32,27 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7087346047442799e+02 Max:+3.1504325669267143e+02 RMS:+2.9394352515255815e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3614323562718186e-03 Max:+2.8508259658638617e-02 RMS:+1.1376475594362044e-02
-eastward_wind_at_surface                     | Min:-1.4159605812323500e+01 Max:+1.2267064730136173e+01 RMS:+3.5718079309408592e+00
-northward_wind_at_surface                    | Min:-1.4056683845651236e+01 Max:+1.1623958009095883e+01 RMS:+3.6620062841962175e+00
+air_temperature_at_2m                        | Min:+2.7087346047609981e+02 Max:+3.1504325669385332e+02 RMS:+2.9394352515508336e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3614323603077382e-03 Max:+2.8508259677062463e-02 RMS:+1.1376475596645485e-02
+eastward_wind_at_surface                     | Min:-1.4159605828078487e+01 Max:+1.2267064729702653e+01 RMS:+3.5718079329489463e+00
+northward_wind_at_surface                    | Min:-1.4056683849511259e+01 Max:+1.1623958022044446e+01 RMS:+3.6620062875962276e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6996.792046103699, nobs = 26912, Jo/n = 0.2599878138415465, err = 0.9070335331040665
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 658.6852477294492, nobs = 3846, Jo/n = 0.1712650150102572, err = 0.001846312116315512
-CostJo   : Nonlinear Jo(aircar_winds_233) = 14828.88610504762, nobs = 57216, Jo/n = 0.2591737644198758, err = 2.650318593315721
-CostFunction: Nonlinear J = 22484.36339888076
-DRPCGMinimizer: reduction in residual norm = 0.0009424785225365096
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 7017.426451337954, nobs = 26912, Jo/n = 0.2607545500645791, err = 0.9070335331040665
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 658.6013645994017, nobs = 3846, Jo/n = 0.1712432045240254, err = 0.001846312116315512
+CostJo   : Nonlinear Jo(aircar_winds_233) = 14837.77728108131, nobs = 57216, Jo/n = 0.2593291610927243, err = 2.650318593315721
+CostFunction: Nonlinear J = 22513.80509701867
+DRPCGMinimizer: reduction in residual norm = 0.000896721757066197
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7016818456615560e+01 Max:+5.6039488658921712e+01 RMS:+1.3311545517719249e+01
-northward_wind                               | Min:-4.2668951500247573e+01 Max:+4.1724285363540083e+01 RMS:+6.4821649893381927e+00
-air_temperature                              | Min:+1.9402505387758382e+02 Max:+3.1450908148793616e+02 RMS:+2.5827581110813998e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076111e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6756427470073878e-02 RMS:+5.5434230098571988e-03
+eastward_wind                                | Min:-2.7016753275571066e+01 Max:+5.6037654526418258e+01 RMS:+1.3311617379622504e+01
+northward_wind                               | Min:-4.2669392261469817e+01 Max:+4.1743571661684463e+01 RMS:+6.4820692349954534e+00
+air_temperature                              | Min:+1.9402512175364313e+02 Max:+3.1450877848063897e+02 RMS:+2.5827484713412946e+02
+air_pressure_thickness                       | Min:+1.4039613732529600e+02 Max:+3.3267575834491918e+03 RMS:+1.7746549348708327e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6981574977420389e-02 RMS:+5.5427832263419043e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
-ozone_mass_mixing_ratio                      | Min:+1.3012566016662470e-10 Max:+1.6040661648730747e-05 RMS:+4.4486450251527118e-06
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486450426222768e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223757e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586809e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -63,7 +63,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359028e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
-air_pressure_at_surface                      | Min:+6.6026155160680559e+04 Max:+1.0240562643655317e+05 RMS:+9.6258608403846694e+04
+air_pressure_at_surface                      | Min:+6.6026116628397460e+04 Max:+1.0240563100887826e+05 RMS:+9.6258357400932116e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
@@ -71,12 +71,12 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
-air_temperature_at_2m                        | Min:+2.7087345654078740e+02 Max:+3.1504326117543616e+02 RMS:+2.9394357082786587e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3613930588833179e-03 Max:+2.8505448267772630e-02 RMS:+1.1376497206298424e-02
-eastward_wind_at_surface                     | Min:-1.4162647623153868e+01 Max:+1.2267075854151347e+01 RMS:+3.5718514234548104e+00
-northward_wind_at_surface                    | Min:-1.4056393401559186e+01 Max:+1.1611014408426076e+01 RMS:+3.6619734921826597e+00
+air_temperature_at_2m                        | Min:+2.7087417054689769e+02 Max:+3.1504295816813897e+02 RMS:+2.9394406704906606e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3623702525541090e-03 Max:+2.8753639891732179e-02 RMS:+1.1377613388114549e-02
+eastward_wind_at_surface                     | Min:-1.3658688647664725e+01 Max:+1.2264246171616129e+01 RMS:+3.5717887724126194e+00
+northward_wind_at_surface                    | Min:-1.4056567040695590e+01 Max:+1.1926187885126410e+01 RMS:+3.6635175705513459e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6996.411835833735, nobs = 26912, Jo/n = 0.2599736859331798, err = 0.9070335331040665
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 658.4630983632148, nobs = 3846, Jo/n = 0.1712072538645904, err = 0.001846312116315512
-CostJo   : Nonlinear Jo(aircar_winds_233) = 14828.53340141723, nobs = 57216, Jo/n = 0.2591675999968057, err = 2.650318593315721
-CostFunction: Nonlinear J = 22483.40833561418
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6999.269234349238, nobs = 26912, Jo/n = 0.2600798615617285, err = 0.9070335331040665
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 658.5687330358143, nobs = 3846, Jo/n = 0.1712347199781108, err = 0.001846312116315512
+CostJo   : Nonlinear Jo(aircar_winds_233) = 14831.1529749791, nobs = 57216, Jo/n = 0.2592133839307029, err = 2.650318593315721
+CostFunction: Nonlinear J = 22488.99094236415

--- a/rrfs-test/testoutput/rrfs-fv3jedi-hybrid3denvar_mgbf.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-hybrid3denvar_mgbf.ref
@@ -2,18 +2,18 @@ CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 1.7109300271492430e+04, nob
 CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 1.1576104621804134e+03, nobs = 3846, Jo/n = 3.0099075979729939e-01, err = 1.8463121163155127e-03
 CostJo   : Nonlinear Jo(aircar_winds_233) = 4.5918477878981983e+04, nobs = 57216, Jo/n = 8.0254610386923209e-01, err = 2.6503185933157223e+00
 CostFunction: Nonlinear J = 6.4185388612654824e+04
-DRPCGMinimizer: reduction in residual norm = 4.6850437017554036e-03
+DRPCGMinimizer: reduction in residual norm = 4.6850437525768887e-03
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7017136038270014e+01 Max:+5.5299448819742217e+01 RMS:+1.3321100968013642e+01
-northward_wind                               | Min:-4.5032256856432966e+01 Max:+4.0352342237425127e+01 RMS:+6.4943752890208799e+00
-air_temperature                              | Min:+1.9402598541798119e+02 Max:+3.1450646752209906e+02 RMS:+2.5827085940788282e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076129e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6296992250688222e-02 RMS:+5.5361578541593230e-03
+eastward_wind                                | Min:-2.7017136038094073e+01 Max:+5.5299448819373183e+01 RMS:+1.3321100967419181e+01
+northward_wind                               | Min:-4.5032256857178972e+01 Max:+4.0352342225744223e+01 RMS:+6.4943752861076813e+00
+air_temperature                              | Min:+1.9402598541781666e+02 Max:+3.1450646752232700e+02 RMS:+2.5827085940514672e+02
+air_pressure_thickness                       | Min:+1.4039925719721248e+02 Max:+3.3267708978078163e+03 RMS:+1.7746656657683350e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6296992265207715e-02 RMS:+5.5361578781763666e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263384e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694528e-05
-ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486356078900387e-06
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486356078941552e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223739e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586811e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -24,7 +24,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359011e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741260e-01
-air_pressure_at_surface                      | Min:+6.6027583839328508e+04 Max:+1.0240597181031287e+05 RMS:+9.6258887641074674e+04
+air_pressure_at_surface                      | Min:+6.6027583839750936e+04 Max:+1.0240597181017713e+05 RMS:+9.6258887640292989e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338740e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177572e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145332e-06
@@ -32,27 +32,27 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120682e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806405e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424869e-02
-air_temperature_at_2m                        | Min:+2.7086256582455826e+02 Max:+3.1504064720959906e+02 RMS:+2.9393274038223637e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3708519382511625e-03 Max:+2.8176527185923495e-02 RMS:+1.1369753103846586e-02
-eastward_wind_at_surface                     | Min:-1.2798613640303421e+01 Max:+1.2274379027986715e+01 RMS:+3.5786186366396349e+00
-northward_wind_at_surface                    | Min:-1.3995566355362456e+01 Max:+1.4124694069879924e+01 RMS:+3.6725311759192842e+00
+air_temperature_at_2m                        | Min:+2.7086256582510902e+02 Max:+3.1504064720982700e+02 RMS:+2.9393274038293282e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3708519390021104e-03 Max:+2.8176527201881844e-02 RMS:+1.1369753103845999e-02
+eastward_wind_at_surface                     | Min:-1.2798613654853030e+01 Max:+1.2274379027358721e+01 RMS:+3.5786186375618096e+00
+northward_wind_at_surface                    | Min:-1.3995566357281845e+01 Max:+1.4124694069314796e+01 RMS:+3.6725311775310385e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6475.281387723602, nobs = 26912, Jo/n = 0.2406094451443075, err = 0.9070335331040666
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 566.2678030320121, nobs = 3846, Jo/n = 0.1472355182090515, err = 0.001846312116315513
-CostJo   : Nonlinear Jo(aircar_winds_233) = 14086.50466702134, nobs = 57216, Jo/n = 0.2461986973402779, err = 2.650318593315722
-CostFunction: Nonlinear J = 21128.05385777695
-DRPCGMinimizer: reduction in residual norm = 0.02800595565697869
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6499.721810891207, nobs = 26912, Jo/n = 0.2415176059338291, err = 0.9070335331040666
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 566.0417644167799, nobs = 3846, Jo/n = 0.1471767458181955, err = 0.001846312116315513
+CostJo   : Nonlinear Jo(aircar_winds_233) = 14093.6263452503, nobs = 57216, Jo/n = 0.246323167387624, err = 2.650318593315722
+CostFunction: Nonlinear J = 21159.38992055828
+DRPCGMinimizer: reduction in residual norm = 0.006011875559395212
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-eastward_wind                                | Min:-2.7017131944184136e+01 Max:+5.5304154140006823e+01 RMS:+1.3321533495883671e+01
-northward_wind                               | Min:-4.5052639797707641e+01 Max:+4.0328534794509579e+01 RMS:+6.4941434539885483e+00
-air_temperature                              | Min:+1.9402596108490854e+02 Max:+3.1450650801338981e+02 RMS:+2.5827089780503326e+02
-air_pressure_thickness                       | Min:+1.4039907836914062e+02 Max:+3.3267851562500000e+03 RMS:+1.7747128794076129e+03
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6244455183733813e-02 RMS:+5.5365298058212909e-03
+eastward_wind                                | Min:-2.7017092199565308e+01 Max:+5.5304324660062939e+01 RMS:+1.3321665157295083e+01
+northward_wind                               | Min:-4.5051285606726232e+01 Max:+4.0328335246432857e+01 RMS:+6.4942833236946749e+00
+air_temperature                              | Min:+1.9402600141564889e+02 Max:+3.1450624921881223e+02 RMS:+2.5827000001751867e+02
+air_pressure_thickness                       | Min:+1.4039914174152537e+02 Max:+3.3267710158563755e+03 RMS:+1.7746575341456894e+03
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.6418420836145557e-02 RMS:+5.5359872932858011e-03
 cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263384e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694528e-05
-ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486354265341394e-06
+ozone_mass_mixing_ratio                      | Min:+0.0000000000000000e+00 Max:+1.6040661648730747e-05 RMS:+4.4486353553583226e-06
 geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223739e+03
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586811e+00
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
@@ -63,7 +63,7 @@ stype                                        | Min:+0.0000000000000000e+00 Max:+
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 tslb                                         | Min:+2.6350683593750000e+02 Max:+3.2296466064453125e+02 RMS:+2.9078003979359011e+02
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741260e-01
-air_pressure_at_surface                      | Min:+6.6027571878666829e+04 Max:+1.0240597005242748e+05 RMS:+9.6258864873205792e+04
+air_pressure_at_surface                      | Min:+6.6027529543324839e+04 Max:+1.0240597483180990e+05 RMS:+9.6258485578582666e+04
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338740e-05
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177572e-05
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145332e-06
@@ -71,12 +71,12 @@ cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120682e+04
 rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806405e+03
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424869e-02
-air_temperature_at_2m                        | Min:+2.7086179975307579e+02 Max:+3.1504068770088981e+02 RMS:+2.9393314776379725e+02
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3709575354477620e-03 Max:+2.8121516969201434e-02 RMS:+1.1370408796666247e-02
-eastward_wind_at_surface                     | Min:-1.2805072875984118e+01 Max:+1.2274439688879607e+01 RMS:+3.5785129072383652e+00
-northward_wind_at_surface                    | Min:-1.3995094891849158e+01 Max:+1.4050004171876907e+01 RMS:+3.6721872287919410e+00
+air_temperature_at_2m                        | Min:+2.7086245418263843e+02 Max:+3.1504042890631223e+02 RMS:+2.9393370586192913e+02
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+1.3723162309878768e-03 Max:+2.8297593702961765e-02 RMS:+1.1371561230663921e-02
+eastward_wind_at_surface                     | Min:-1.2572291968155136e+01 Max:+1.2272217066230445e+01 RMS:+3.5783928584453069e+00
+northward_wind_at_surface                    | Min:-1.3995679518174978e+01 Max:+1.4516013735618861e+01 RMS:+3.6750753910874803e+00
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6466.365932598797, nobs = 26912, Jo/n = 0.2402781633694559, err = 0.9070335331040666
-CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 565.696965583633, nobs = 3846, Jo/n = 0.147087094535526, err = 0.001846312116315513
-CostJo   : Nonlinear Jo(aircar_winds_233) = 14072.2108242964, nobs = 57216, Jo/n = 0.2459488748653594, err = 2.650318593315722
-CostFunction: Nonlinear J = 21104.27372247883
+CostJo   : Nonlinear Jo(aircar_airTemperature_133) = 6467.789667769086, nobs = 26912, Jo/n = 0.2403310667274482, err = 0.9070335331040666
+CostJo   : Nonlinear Jo(aircar_specificHumidity_133) = 565.6398901098008, nobs = 3846, Jo/n = 0.147072254318721, err = 0.001846312116315513
+CostJo   : Nonlinear Jo(aircar_winds_233) = 14074.13818588373, nobs = 57216, Jo/n = 0.2459825605754288, err = 2.650318593315722
+CostFunction: Nonlinear J = 21107.56774376262

--- a/sorc/_workaround_/fv3-jedi/fv3jedi_state_mod.F90
+++ b/sorc/_workaround_/fv3-jedi/fv3jedi_state_mod.F90
@@ -191,7 +191,7 @@ endif
 ! ----------------------------------------------------------------------
 ! Workaround: update air_pressure_thickness from surface pressure increment
 ! Only do this when air_pressure_thickness is not itself an analysis increment
-! Once delp is updatee, air_pressure_levels and air_pressure will be updated
+! Once delp is updated, air_pressure_levels and air_pressure will be updated
 ! via VADER pathway: delp -> air_pressuree_levels -> air_pressure
 ! ----------------------------------------------------------------------
 

--- a/sorc/_workaround_/fv3-jedi/fv3jedi_state_mod.F90
+++ b/sorc/_workaround_/fv3-jedi/fv3jedi_state_mod.F90
@@ -59,8 +59,7 @@ type(fv3jedi_field), pointer :: t2m_state, t_inc
 type(fv3jedi_field), pointer :: q2m_state, q_inc
 type(fv3jedi_field), pointer :: u10m_state, u_inc
 type(fv3jedi_field), pointer :: v10m_state, v_inc
-!type(fv3jedi_field), pointer :: ps_state, ps_inc
-!type(fv3jedi_field), pointer :: delp_state, p_state
+type(fv3jedi_field), pointer :: delp_state, ps_inc
 
 ! Loop over the increment fields and add them to the state
 do f = 1, size(increment_fields)
@@ -186,6 +185,58 @@ if (hasfield(self%fields, 'northward_wind_at_surface') .and. &
 
   nullify(v10m_state)
   nullify(v_inc)
+
+endif
+
+! ----------------------------------------------------------------------
+! Workaround: update air_pressure_thickness from surface pressure increment
+! Only do this when air_pressure_thickness is not itself an analysis increment
+! Once delp is updatee, air_pressure_levels and air_pressure will be updated
+! via VADER pathway: delp -> air_pressuree_levels -> air_pressure
+! ----------------------------------------------------------------------
+
+if (hasfield(self%fields, 'air_pressure_thickness') .and. &
+    hasfield(increment_fields, 'air_pressure_at_surface') .and. &
+    .not. hasfield(increment_fields, 'air_pressure_thickness')) then
+
+  call self%get_field('air_pressure_thickness', delp_state)
+  call get_field(increment_fields, 'air_pressure_at_surface', ps_inc)
+
+!  DEBUG: delp update sanity check
+!  if (self%f_comm%rank() == 0) then
+!    write(6,'(A,ES16.8)') 'DELP sanity pre-update sample_bot = ', &
+!      delp_state%array(delp_state%isc, delp_state%jsc, self%npz)
+!    write(6,'(A,ES16.8)') 'DELP sanity pre-update sample_mid = ', &
+!      delp_state%array(delp_state%isc, delp_state%jsc, max(1,self%npz/2))
+!    write(6,'(A,ES16.8)') 'DELP sanity pre-update sample_top = ', &
+!      delp_state%array(delp_state%isc, delp_state%jsc, 1)
+!    write(6,'(A,ES16.8)') 'PS increment sample = ', &
+!      ps_inc%array(delp_state%isc, delp_state%jsc, 1)
+!  endif
+
+  do k = 1, self%npz
+    do j = delp_state%jsc, delp_state%jec
+      do i = delp_state%isc, delp_state%iec
+        delp_state%array(i,j,k) = delp_state%array(i,j,k) + &
+          (geom%bk(k+1) - geom%bk(k)) * ps_inc%array(i,j,1)
+      enddo
+    enddo
+  enddo
+
+!  DEBUG: delp update sanity check
+!  if (self%f_comm%rank() == 0) then
+!    write(6,'(A,ES16.8)') 'DELP sanity post-update sample_bot = ', &
+!      delp_state%array(delp_state%isc, delp_state%jsc, self%npz)
+!    write(6,'(A,ES16.8)') 'DELP sanity post-update sample_mid = ', &
+!      delp_state%array(delp_state%isc, delp_state%jsc, max(1,self%npz/2))
+!    write(6,'(A,ES16.8)') 'DELP sanity post-update sample_top = ', &
+!      delp_state%array(delp_state%isc, delp_state%jsc, 1)
+!    write(6,'(A,ES16.8)') 'PS increment sample = ', &
+!      ps_inc%array(delp_state%isc, delp_state%jsc, 1)
+!  endif
+
+  nullify(delp_state)
+  nullify(ps_inc)
 
 endif
 


### PR DESCRIPTION
## Description
This PR adds a workaround for updating `delp` between outer loops and updating the ctest refs.

It has been found that `delp` must be updated between outer loops because it is the basic ingredient in vader recipe for eventually computing `air_pressure`. All the machinery exists for computing the downstream pressure fields using `delp`, however, these were all using a stale `delp` state in those calculations between outer loops ultimately resulting in stale downstream pressure fields. This PR fixes that.

The vader pathway is this:
`delp` -> `air_pressure_levels` -> `air_pressure`

See the following vader recipes:
- `AirPressureAtInterface_B.cc`
- `AirPressure_A.cc`

## Issue(s) addressed
This PR is a workaround for https://github.com/JCSDA-internal/fv3-jedi/pull/1381. At the time of this PR, more discussion is needed on fv3-jedi PR1381.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [x] Unit tests added/updated (if applicable).
