### PR TITLE
Update sfc yamls

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_181.yaml.j2
@@ -109,7 +109,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/airTemperature
              is_in: 181

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_183.yaml.j2
@@ -109,7 +109,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/airTemperature
              is_in: 183

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_airTemperature_187.yaml.j2
@@ -109,7 +109,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/airTemperature
              is_in: 187

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_181.yaml.j2
@@ -103,7 +103,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/specificHumidity
              is_in: 181

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_183.yaml.j2
@@ -103,7 +103,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/specificHumidity
              is_in: 183

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_specificHumidity_187.yaml.j2
@@ -103,7 +103,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/specificHumidity
              is_in: 187

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_181.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_181.yaml.j2
@@ -105,7 +105,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/stationPressure
              is_in: 181

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_187.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_stationPressure_187.yaml.j2
@@ -105,7 +105,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/stationPressure
              is_in: 187

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_281.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_281.yaml.j2
@@ -108,7 +108,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/windEastward
              is_in: 281

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_284.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_284.yaml.j2
@@ -108,7 +108,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/windEastward
              is_in: 284

--- a/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_287.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/adpsfc_winds_287.yaml.j2
@@ -108,7 +108,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/stationIdentification
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/windEastward
              is_in: 287

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_180.yaml.j2
@@ -22,16 +22,19 @@
          simulated variables: [airTemperature]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
+           gsl parameters:
+             temperature lapse rate option: NoAdjustment
+             temperature local lapse rate level: 5
+             temperature lapse rate threshold: true
+             min threshold: 0.5
+             max threshold: 10.0
            variables:
            - name: airTemperature
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -106,7 +109,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/airTemperature
              is_in: 180
@@ -140,6 +143,14 @@
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253, 2.1253]
+
+#         # Reduce observation error and turn off ObsErrorFactorPressureCheck (l_gsd_terrain_match_surfTobs=.true., l_sfcobserror_ramp_t=.true.,)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: airTemperature
+#           action:
+#             name: inflate error
+#             inflation factor: 0.5
 
          # Error inflation based on pressure check (setupt.f90)
          - filter: Perform Action

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_182.yaml.j2
@@ -22,16 +22,19 @@
          simulated variables: [airTemperature]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
+           gsl parameters:
+             temperature lapse rate option: NoAdjustment
+             temperature local lapse rate level: 5
+             temperature lapse rate threshold: true
+             min threshold: 0.5
+             max threshold: 10.0
            variables:
            - name: airTemperature
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -106,7 +109,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/airTemperature
              is_in: 182
@@ -140,6 +143,14 @@
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054, 1.054]
+
+#         # Reduce observation error and turn off ObsErrorFactorPressureCheck (l_gsd_terrain_match_surfTobs=.true., l_sfcobserror_ramp_t=.true.,)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: airTemperature
+#           action:
+#             name: inflate error
+#             inflation factor: 0.5
 
          # Error inflation based on pressure check (setupt.f90)
          - filter: Perform Action

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_airTemperature_183.yaml.j2
@@ -22,16 +22,19 @@
          simulated variables: [airTemperature]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
+           gsl parameters:
+             temperature lapse rate option: NoAdjustment
+             temperature local lapse rate level: 5
+             temperature lapse rate threshold: true
+             min threshold: 0.5
+             max threshold: 10.0
            variables:
            - name: airTemperature
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -106,7 +109,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/airTemperature
              is_in: 183
@@ -140,6 +143,14 @@
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349, 2.6349]
+
+#         # Reduce observation error and turn off ObsErrorFactorPressureCheck (l_gsd_terrain_match_surfTobs=.true., l_sfcobserror_ramp_t=.true.,)
+#         - filter: Perform Action
+#           filter variables:
+#           - name: airTemperature
+#           action:
+#             name: inflate error
+#             inflation factor: 0.5
 
          # Error inflation based on pressure check (setupt.f90)
          - filter: Perform Action

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_180.yaml.j2
@@ -22,16 +22,13 @@
          simulated variables: [specificHumidity]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
            variables:
            - name: specificHumidity
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -106,7 +103,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/specificHumidity
              is_in: 180
@@ -135,13 +132,14 @@
              name: assign error
              error function:
                name: ObsFunction/ObsErrorModelStepwiseLinear
+               #name: ObsFunction/ObsErrorModelHumidity
                options:
                  xvar:
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912]
 
-         # Error inflation based on pressure check (setupq.f90)
+         # Error inflation based on pressure check (setupq.f90) -- if this is off, use ObsFunction/ObsErrorModelHumidity
          - filter: Perform Action
            udescriptor: "error_inflation_pressure_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_182.yaml.j2
@@ -22,16 +22,13 @@
          simulated variables: [specificHumidity]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
            variables:
            - name: specificHumidity
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -106,7 +103,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/specificHumidity
              is_in: 182
@@ -135,13 +132,14 @@
              name: assign error
              error function:
                name: ObsFunction/ObsErrorModelStepwiseLinear
+               #name: ObsFunction/ObsErrorModelHumidity
                options:
                  xvar:
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912]
 
-         # Error inflation based on pressure check (setupq.f90)
+         # Error inflation based on pressure check (setupq.f90) -- if this is off, use ObsFunction/ObsErrorModelHumidity
          - filter: Perform Action
            udescriptor: "error_inflation_pressure_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_183.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_specificHumidity_183.yaml.j2
@@ -22,16 +22,13 @@
          simulated variables: [specificHumidity]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
            variables:
            - name: specificHumidity
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -135,13 +132,14 @@
              name: assign error
              error function:
                name: ObsFunction/ObsErrorModelStepwiseLinear
+               #name: ObsFunction/ObsErrorModelHumidity
                options:
                  xvar:
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
                  errors: [0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912, 0.05912]
 
-         # Error inflation based on pressure check (setupq.f90)
+         # Error inflation based on pressure check (setupq.f90) -- if this is off, use ObsFunction/ObsErrorModelHumidity
          - filter: Perform Action
            udescriptor: "error_inflation_pressure_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_180.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_180.yaml.j2
@@ -26,6 +26,9 @@
          correction scheme to use: GSL
          geovar_sfc_geomz: geopotential_height_at_surface
          geovar_geomz: geopotential_height
+         variables:
+         - name: stationPressure
+
        linear obs operator:
          name: Identity
 
@@ -102,7 +105,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/stationPressure
              is_in: 180
@@ -163,7 +166,8 @@
                name: ObsFunction/ObsErrorFactorSfcPressure
                options:
                  geovar_geomz: geopotential_height
-                 geovar_sfc_geomz: geopotential_height_at_surface
+                 #geovar_sfc_geomz: geopotential_height_at_surface
+                 station_altitude: height
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_182.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_stationPressure_182.yaml.j2
@@ -26,6 +26,9 @@
          correction scheme to use: GSL
          geovar_sfc_geomz: geopotential_height_at_surface
          geovar_geomz: geopotential_height
+         variables:
+         - name: stationPressure
+
        linear obs operator:
          name: Identity
 
@@ -102,7 +105,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/stationPressure
              is_in: 182
@@ -151,7 +154,8 @@
                name: ObsFunction/ObsErrorFactorSfcPressure
                options:
                  geovar_geomz: geopotential_height
-                 geovar_sfc_geomz: geopotential_height_at_surface
+                 #geovar_sfc_geomz: geopotential_height_at_surface
+                 station_altitude: height
 
 #         # Error inflation based on errormod (qcmod.f90)
 #         - filter: Perform Action

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_280.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_280.yaml.j2
@@ -22,17 +22,14 @@
          simulated variables: [windEastward, windNorthward]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
            variables:
            - name: windEastward
            - name: windNorthward
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -111,7 +108,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/windEastward
              is_in: 280

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_282.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_282.yaml.j2
@@ -22,17 +22,14 @@
          simulated variables: [windEastward, windNorthward]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
            variables:
            - name: windEastward
            - name: windNorthward
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -111,7 +108,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/windEastward
              is_in: 282

--- a/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_284.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/sfcshp_winds_284.yaml.j2
@@ -22,17 +22,14 @@
          simulated variables: [windEastward, windNorthward]
 
        obs operator:
-           name: VertInterp
-           vertical coordinate: air_pressure
-           observation vertical coordinate: pressure
-           observation vertical coordinate group: MetaData
-           interpolation method: log-linear
+           name: SfcCorrected
+           correction scheme to use: GSL
            variables:
            - name: windEastward
            - name: windNorthward
 
        linear obs operator:
-         name: VertInterp
+         name: Identity
 
        obs error:
          covariance model: diagonal
@@ -111,7 +108,7 @@
            tolerance: PT0H
            seed_time: "{{atmosphere_background_time_iso}}"
            category_variable:
-             name: MetaData/longitude_latitude_pressure
+             name: MetaData/longitude_latitude
            where:
            - variable: ObsType/windEastward
              is_in: 284

--- a/rrfs-test/IODA/offline_ioda_patch.py
+++ b/rrfs-test/IODA/offline_ioda_patch.py
@@ -120,6 +120,19 @@ if var not in metadata_group.variables:
     metadata_group.createVariable(f"{var}", 'str', 'Location', fill_value=fill)
 metadata_group.variables[f"{var}"][:] = data
 
+# Generate longitude_latitude location strings (for dup checking)
+longitude_latitude = [f"{lon}_{lat}" for lon, lat in zip(obs_lon, obs_lat)]
+longitude_latitude = np.array(longitude_latitude)
+
+metadata_group = fout.groups['MetaData']
+
+# Add the longitude_latitude variable to the file
+var = "longitude_latitude"
+data = longitude_latitude
+if var not in metadata_group.variables:
+    metadata_group.createVariable(f"{var}", 'str', 'Location', fill_value=fill)
+metadata_group.variables[f"{var}"][:] = data
+
 # Add the exp_err_norm to file (for goes-r amvs)
 if 'expectedError' in metadata_group.variables:
     u = fout.groups['ObsValue'].variables['windEastward'][:]

--- a/rrfs-test/IODA/offline_ioda_patch.py
+++ b/rrfs-test/IODA/offline_ioda_patch.py
@@ -117,7 +117,7 @@ metadata_group = fout.groups['MetaData']
 var = "longitude_latitude_pressure"
 data = longitude_latitude_pressure
 if var not in metadata_group.variables:
-    metadata_group.createVariable(f"{var}", 'str', 'Location', fill_value=fill)
+    metadata_group.createVariable(f"{var}", 'str', 'Location')
 metadata_group.variables[f"{var}"][:] = data
 
 # Generate longitude_latitude location strings (for dup checking)
@@ -130,7 +130,7 @@ metadata_group = fout.groups['MetaData']
 var = "longitude_latitude"
 data = longitude_latitude
 if var not in metadata_group.variables:
-    metadata_group.createVariable(f"{var}", 'str', 'Location', fill_value=fill)
+    metadata_group.createVariable(f"{var}", 'str', 'Location')
 metadata_group.variables[f"{var}"][:] = data
 
 # Add the exp_err_norm to file (for goes-r amvs)

--- a/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-conv-surface.ref
+++ b/rrfs-test/testoutput/rrfs-fv3jedi-3dvar-conv-surface.ref
@@ -1,54 +1,54 @@
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 2.7964426203453590e+03, nobs = 551, Jo/n = 5.0752134670514684e+00, err = 7.5279998779296875e-01
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 7.4320907359453656e+01, nobs = 218, Jo/n = 3.4092159339198924e-01, err = 4.7409982303501749e+09
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 2.8325684199849306e+03, nobs = 560, Jo/n = 5.0581578928302333e+00, err = 7.5279998779296875e-01
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 7.4320907359453628e+01, nobs = 218, Jo/n = 3.4092159339198913e-01, err = 4.7409982303501749e+09
 CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 4.4793484111222642e+03, nobs = 2048, Jo/n = 2.1871818413682931e+00, err = 1.1292500495910645e+00
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 3.7650817409104690e+02, nobs = 562, Jo/n = 6.6994337026876671e-01, err = 2.4118893988548263e-03
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 1.4693835951430466e+02, nobs = 215, Jo/n = 6.8343423029909145e-01, err = 2.5821688833545858e-03
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 3.9032574591683613e+02, nobs = 570, Jo/n = 6.8478201038041431e-01, err = 2.5081061839107334e-03
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 1.4693835951430464e+02, nobs = 215, Jo/n = 6.8343423029909134e-01, err = 2.5821688833545858e-03
 CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 1.2064746668798116e+03, nobs = 2059, Jo/n = 5.8595175661962684e-01, err = 3.7554419131789617e-03
-CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 7.9229534330830791e+02, nobs = 562, Jo/n = 1.4097781909400497e+00, err = 7.6832924283212449e+01
+CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 8.4412757390006959e+02, nobs = 570, Jo/n = 1.4809255682457361e+00, err = 7.6630364589107415e+01
 CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 2.7139751801157408e+03, nobs = 2138, Jo/n = 1.2693990552459031e+00, err = 6.1007515058098441e+01
-CostJo   : Nonlinear Jo(adpsfc_winds_281) = 6.9738804154791228e+02, nobs = 1084, Jo/n = 6.4334690179696707e-01, err = 2.0513525569931277e+00
-CostJo   : Nonlinear Jo(adpsfc_winds_284) = 2.1486059126958330e+02, nobs = 418, Jo/n = 5.1402055327651508e-01, err = 2.3896622652508608e+00
-CostJo   : Nonlinear Jo(adpsfc_winds_287) = 2.4056696914969266e+03, nobs = 4040, Jo/n = 5.9546279492498178e-01, err = 1.8314772530192900e+00
-CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 2.0322301026976008e+03, nobs = 21348, Jo/n = 9.5195339268203144e-02, err = 4.5779325837778711e+09
-CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 1.3740564574016886e+04, nobs = 19879, Jo/n = 6.9121004950032128e-01, err = 5.1604729835655868e-03
-CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 5.2840324091677998e+04, nobs = 19752, Jo/n = 2.6751885425110369e+00, err = 7.0168164732601852e+01
-CostJo   : Nonlinear Jo(msonet_winds_288) = 1.6164563198112580e+03, nobs = 6164, Jo/n = 2.6224145357093737e-01, err = 3.3712463739377974e+00
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 9.0335466851356713e+01, nobs = 490, Jo/n = 1.8435809561501371e-01, err = 1.7496355305594130e+09
+CostJo   : Nonlinear Jo(adpsfc_winds_281) = 7.1537445984646479e+02, nobs = 1102, Jo/n = 6.4916012690241809e-01, err = 2.0512648346031259e+00
+CostJo   : Nonlinear Jo(adpsfc_winds_284) = 2.1486059126958327e+02, nobs = 418, Jo/n = 5.1402055327651497e-01, err = 2.3896622652508608e+00
+CostJo   : Nonlinear Jo(adpsfc_winds_287) = 2.4056696914969270e+03, nobs = 4040, Jo/n = 5.9546279492498189e-01, err = 1.8314772530192895e+00
+CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 2.0322301026975979e+03, nobs = 21348, Jo/n = 9.5195339268203005e-02, err = 4.5779325837778711e+09
+CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 1.3740564574016833e+04, nobs = 19879, Jo/n = 6.9121004950031861e-01, err = 5.1604729835655868e-03
+CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 5.2840324091677991e+04, nobs = 19752, Jo/n = 2.6751885425110364e+00, err = 7.0168164732601852e+01
+CostJo   : Nonlinear Jo(msonet_winds_288) = 1.6164563198112605e+03, nobs = 6164, Jo/n = 2.6224145357093781e-01, err = 3.3712463739377974e+00
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 6.5395882680725094e+01, nobs = 266, Jo/n = 2.4584918301024472e-01, err = 2.1239769762143664e+09
 CostJo   : Nonlinear Jo(sfcshp_airTemperature_182) = 0.0000000000000000e+00 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 8.0379412496227207e+00, nobs = 44, Jo/n = 1.8268048294597092e-01, err = 3.3709993123162103e+09
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 4.7044823241555548e+02, nobs = 416, Jo/n = 1.1308851740758545e+00, err = 1.2462754771894403e-03
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 1.2685081057624711e+01, nobs = 28, Jo/n = 4.5303860920088251e-01, err = 3.2732683535398855e+09
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 1.8943663524196793e+02, nobs = 214, Jo/n = 8.8521792169143898e-01, err = 1.3512045073606808e-03
 CostJo   : Nonlinear Jo(sfcshp_specificHumidity_182) = 0.0000000000000000e+00 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 2.1294572523834820e+00, nobs = 9, Jo/n = 2.3660636137594246e-01, err = 1.3243993443566202e-03
-CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 3.6108969368226844e+03, nobs = 1211, Jo/n = 2.9817480898618367e+00, err = 3.9706420876712478e+01
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 3.3905222441329839e+00, nobs = 9, Jo/n = 3.7672469379255374e-01, err = 1.3243993443566202e-03
+CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 1.9349075294283100e+03, nobs = 499, Jo/n = 3.8775701992551301e+00, err = 3.9700199112626038e+01
 CostJo   : Nonlinear Jo(sfcshp_stationPressure_182) = 0.0000000000000000e+00 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_winds_280) = 3.8883248109372039e+02, nobs = 1764, Jo/n = 2.2042657658374171e-01, err = 2.6946028207393438e+00
-CostJo   : Nonlinear Jo(sfcshp_winds_282) = 2.6475416723911895e+01, nobs = 18, Jo/n = 1.4708564846617720e+00, err = 1.1064412466726061e+00
-CostJo   : Nonlinear Jo(sfcshp_winds_284) = 1.6874857572581467e+02, nobs = 124, Jo/n = 1.3608756106920539e+00, err = 1.3148107267083624e+00
-CostFunction: Nonlinear J = 9.0899701583389513e+04
-DRPCGMinimizer: reduction in residual norm = 9.6970431017975216e-04
+CostJo   : Nonlinear Jo(sfcshp_winds_280) = 1.7031705204019232e+02, nobs = 710, Jo/n = 2.3988317188759481e-01, err = 2.7153796921267581e+00
+CostJo   : Nonlinear Jo(sfcshp_winds_282) = 2.6017385803190248e+01, nobs = 18, Jo/n = 1.4454103223994581e+00, err = 1.1064412466726061e+00
+CostJo   : Nonlinear Jo(sfcshp_winds_284) = 7.2573535943686920e+01, nobs = 56, Jo/n = 1.2959559989944094e+00, err = 1.3081385218146975e+00
+CostFunction: Nonlinear J = 8.8728282720049901e+04
+DRPCGMinimizer: reduction in residual norm = 8.4599880631031478e-04
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-air_pressure_at_surface                      | Min:+6.6067468387876012e+04 Max:+1.0237048022007881e+05 RMS:+9.6264786698152689e+04
-air_pressure_thickness                       | Min:+1.4048406752893632e+02 Max:+3.3253815214127339e+03 RMS:+1.7747789889345329e+03
-air_temperature                              | Min:+1.9401980349230789e+02 Max:+3.1646209701364154e+02 RMS:+2.5844850082975267e+02
-air_temperature_at_2m                        | Min:+2.7126944394609632e+02 Max:+3.1680856307809466e+02 RMS:+2.9475440586448099e+02
+air_pressure_at_surface                      | Min:+6.6067611265473737e+04 Max:+1.0238089685959565e+05 RMS:+9.6269100091642205e+04
+air_pressure_thickness                       | Min:+1.4048437134324610e+02 Max:+3.3257884766521888e+03 RMS:+1.7748663485419481e+03
+air_temperature                              | Min:+1.9401965161921100e+02 Max:+3.1653623103076637e+02 RMS:+2.5844983945832251e+02
+air_temperature_at_2m                        | Min:+2.7126998079913221e+02 Max:+3.1688269709521950e+02 RMS:+2.9476237389749485e+02
 cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+1.5055759360000000e+09 RMS:+2.0745188331041779e+07
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
-cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263384e-06
+cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
-eastward_wind                                | Min:-2.7020201819662667e+01 Max:+5.2720726406520185e+01 RMS:+1.3257449600059024e+01
-eastward_wind_at_surface                     | Min:-1.3228949589467366e+01 Max:+1.2346056976849811e+01 RMS:+3.4907679909679641e+00
+eastward_wind                                | Min:-2.7020006017994834e+01 Max:+5.2722369860251398e+01 RMS:+1.3256304757432380e+01
+eastward_wind_at_surface                     | Min:-1.2695811432842323e+01 Max:+1.2349605471597853e+01 RMS:+3.4839453721056661e+00
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586809e+00
-geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223766e+03
+geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223757e+03
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
-northward_wind                               | Min:-4.0078438075466146e+01 Max:+3.8601890555671638e+01 RMS:+6.3803849268339841e+00
-northward_wind_at_surface                    | Min:-1.3141648950176414e+01 Max:+1.1267184850005062e+01 RMS:+3.5787930923762730e+00
+northward_wind                               | Min:-4.0071085298968370e+01 Max:+3.8603953359575151e+01 RMS:+6.3872884925847417e+00
+northward_wind_at_surface                    | Min:-1.3529088433789223e+01 Max:+1.1469431083617142e+01 RMS:+3.6157901025273320e+00
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
-rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806409e+03
+rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 sheleg                                       | Min:+0.0000000000000000e+00 Max:+1.6966506958007812e+01 RMS:+2.0734254733790997e-01
-skin_temperature_at_surface                  | Min:+2.7119995117187500e+02 Max:+3.2296466064453125e+02 RMS:+2.9475363971841756e+02
+skin_temperature_at_surface                  | Min:+2.7119995117187500e+02 Max:+3.2296466064453125e+02 RMS:+2.9475363971841750e+02
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
@@ -57,60 +57,60 @@ tslb                                         | Min:+2.6350683593750000e+02 Max:+
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 vtype                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+01 RMS:+7.1648734770793263e+00
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.3836142327084617e-02 RMS:+5.7291639388871779e-03
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+0.0000000000000000e+00 Max:+2.5345266151273745e-02 RMS:+1.1839394377687723e-02
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.3829227110798070e-02 RMS:+5.7003075999781539e-03
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+0.0000000000000000e+00 Max:+2.5342611613883837e-02 RMS:+1.1744194405384998e-02
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 580.453739343651, nobs = 551, Jo/n = 1.053455062329675, err = 0.7527999877929688
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 15.39239941721667, nobs = 218, Jo/n = 0.07060733677622323, err = 4740998230.350175
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 1145.376609183813, nobs = 2048, Jo/n = 0.5592659224530336, err = 1.129250049591064
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 208.4991091257527, nobs = 562, Jo/n = 0.3709948560956454, err = 0.002411889398854826
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 58.87802830589253, nobs = 215, Jo/n = 0.2738512944460118, err = 0.002582168883354586
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 952.6398885434696, nobs = 2059, Jo/n = 0.4626711454800727, err = 0.003755441913178962
-CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 392.6560362115845, nobs = 562, Jo/n = 0.6986762210170542, err = 76.83292428321245
-CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 1016.445572827914, nobs = 2138, Jo/n = 0.4754188834555257, err = 61.00751505809844
-CostJo   : Nonlinear Jo(adpsfc_winds_281) = 520.928438362953, nobs = 1082, Jo/n = 0.4814495733483854, err = 2.052070608022017
-CostJo   : Nonlinear Jo(adpsfc_winds_284) = 162.2799317168592, nobs = 418, Jo/n = 0.3882295017149742, err = 2.389662265250861
-CostJo   : Nonlinear Jo(adpsfc_winds_287) = 1868.138617559783, nobs = 4038, Jo/n = 0.4626395783951914, err = 1.831580075501386
-CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 856.2373167266801, nobs = 21341, Jo/n = 0.04012170548365494, err = 4577659806.921542
-CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 9393.687289758935, nobs = 19879, Jo/n = 0.4725432511574493, err = 0.005160472983565587
-CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 36989.03957475174, nobs = 19628, Jo/n = 1.884503748458923, err = 70.1204137881226
-CostJo   : Nonlinear Jo(msonet_winds_288) = 1208.365423674192, nobs = 6164, Jo/n = 0.1960359220756314, err = 3.371246373937797
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 84.15786290485924, nobs = 490, Jo/n = 0.1717507406221617, err = 1749635530.559413
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 581.168771600304, nobs = 560, Jo/n = 1.037801377857686, err = 0.7527999877929688
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 15.34228090878478, nobs = 218, Jo/n = 0.07037743536139805, err = 4740998230.350175
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 1139.181678883367, nobs = 2048, Jo/n = 0.5562410541422691, err = 1.129250049591064
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 216.4442319421182, nobs = 570, Jo/n = 0.3797267227054706, err = 0.002508106183910733
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 58.35439899275995, nobs = 215, Jo/n = 0.2714158092686509, err = 0.002582168883354586
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 948.904273613787, nobs = 2059, Jo/n = 0.4608568594530292, err = 0.003755441913178962
+CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 415.2426285228508, nobs = 570, Jo/n = 0.7284958395137733, err = 76.63036458910742
+CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 1003.081960216273, nobs = 2138, Jo/n = 0.4691683630571903, err = 61.00751505809844
+CostJo   : Nonlinear Jo(adpsfc_winds_281) = 527.8155803393132, nobs = 1100, Jo/n = 0.479832345763012, err = 2.051971008479105
+CostJo   : Nonlinear Jo(adpsfc_winds_284) = 161.7013696638858, nobs = 418, Jo/n = 0.3868453819710186, err = 2.389662265250861
+CostJo   : Nonlinear Jo(adpsfc_winds_287) = 1882.080950977399, nobs = 4040, Jo/n = 0.4658616215290592, err = 1.83147725301929
+CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 860.8600862265178, nobs = 21341, Jo/n = 0.04033831995813306, err = 4577659806.921542
+CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 9390.543293548955, nobs = 19879, Jo/n = 0.4723850944991677, err = 0.005160472983565587
+CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 36884.95627748308, nobs = 19627, Jo/n = 1.879296697278396, err = 70.1181989063623
+CostJo   : Nonlinear Jo(msonet_winds_288) = 1192.798277761262, nobs = 6164, Jo/n = 0.1935104279301204, err = 3.371246373937797
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 46.70120221263277, nobs = 266, Jo/n = 0.1755684293707999, err = 2123976976.214366
 CostJo   : Nonlinear Jo(sfcshp_airTemperature_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 8.130420534219162, nobs = 44, Jo/n = 0.1847822848686173, err = 3370999312.31621
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 95.11391211079045, nobs = 416, Jo/n = 0.2286392118047847, err = 0.00124627547718944
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 5.16275222094087, nobs = 28, Jo/n = 0.1843840078907454, err = 3273268353.539886
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 75.92353403942263, nobs = 214, Jo/n = 0.3547828693430964, err = 0.001351204507360681
 CostJo   : Nonlinear Jo(sfcshp_specificHumidity_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 2.313334019256688, nobs = 9, Jo/n = 0.2570371132507432, err = 0.00132439934435662
-CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 2283.215412060962, nobs = 1211, Jo/n = 1.88539670690418, err = 39.70642087671248
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 3.59503277801645, nobs = 9, Jo/n = 0.3994480864462722, err = 0.00132439934435662
+CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 1440.472422524329, nobs = 499, Jo/n = 2.886718281611882, err = 39.70019911262604
 CostJo   : Nonlinear Jo(sfcshp_stationPressure_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_winds_280) = 293.9348280235245, nobs = 1764, Jo/n = 0.1666297211017712, err = 2.694602820739344
-CostJo   : Nonlinear Jo(sfcshp_winds_282) = 20.98504069412895, nobs = 18, Jo/n = 1.165835594118275, err = 1.106441246672606
-CostJo   : Nonlinear Jo(sfcshp_winds_284) = 141.4939020975243, nobs = 124, Jo/n = 1.141079855625196, err = 1.314810726708362
-CostFunction: Nonlinear J = 58298.36268795571
-DRPCGMinimizer: reduction in residual norm = 0.0009423138085230272
+CostJo   : Nonlinear Jo(sfcshp_winds_280) = 145.5787612864556, nobs = 710, Jo/n = 0.2050405088541629, err = 2.715379692126758
+CostJo   : Nonlinear Jo(sfcshp_winds_282) = 21.23356376945124, nobs = 18, Jo/n = 1.17964243163618, err = 1.106441246672606
+CostJo   : Nonlinear Jo(sfcshp_winds_284) = 46.04846169098383, nobs = 54, Jo/n = 0.8527492905737746, err = 1.314298441422557
+CostFunction: Nonlinear J = 57063.19179120288
+DRPCGMinimizer: reduction in residual norm = 0.0008529430894101886
 CostFunction::addIncrement: Analysis: 
 ----------------------------------------------------------------------------------------------------
 State print | number of fields = 30 | cube sphere face size: C420
-air_pressure_at_surface                      | Min:+6.6067993261775715e+04 Max:+1.0237013862325788e+05 RMS:+9.6265366779644421e+04
-air_pressure_thickness                       | Min:+1.4048518361854093e+02 Max:+3.3253681759748088e+03 RMS:+1.7747905407453800e+03
-air_temperature                              | Min:+1.9401973354399090e+02 Max:+3.1646860927149646e+02 RMS:+2.5844920079708572e+02
-air_temperature_at_2m                        | Min:+2.7127710464338321e+02 Max:+3.1681507533594959e+02 RMS:+2.9475513725098568e+02
+air_pressure_at_surface                      | Min:+6.6067999773858319e+04 Max:+1.0238097200578284e+05 RMS:+9.6269685176885454e+04
+air_pressure_thickness                       | Min:+1.4048519746580541e+02 Max:+3.3257914124487620e+03 RMS:+1.7748780041715518e+03
+air_temperature                              | Min:+1.9401960070484481e+02 Max:+3.1655247054583083e+02 RMS:+2.5845079447769666e+02
+air_temperature_at_2m                        | Min:+2.7127703734241783e+02 Max:+3.1689893661028395e+02 RMS:+2.9476450120663787e+02
 cloud_droplet_number_concentration           | Min:+0.0000000000000000e+00 Max:+1.5055759360000000e+09 RMS:+2.0745188331041779e+07
 cloud_ice_number_concentration               | Min:+0.0000000000000000e+00 Max:+5.0166070000000000e+06 RMS:+2.8482317076120715e+04
-cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263384e-06
+cloud_liquid_ice                             | Min:+0.0000000000000000e+00 Max:+3.5491219023242593e-04 RMS:+2.6466693180263379e-06
 cloud_liquid_water                           | Min:+0.0000000000000000e+00 Max:+1.4309773687273264e-03 RMS:+1.9256935244694531e-05
-eastward_wind                                | Min:-2.7020205377183999e+01 Max:+5.2720269723100508e+01 RMS:+1.3257499480455444e+01
-eastward_wind_at_surface                     | Min:-1.3578746391654928e+01 Max:+1.2349135320127507e+01 RMS:+3.4941094347888129e+00
+eastward_wind                                | Min:-2.7020022006279145e+01 Max:+5.2722260076922957e+01 RMS:+1.3255902324824456e+01
+eastward_wind_at_surface                     | Min:-1.2509842761469210e+01 Max:+1.2350234300283594e+01 RMS:+3.4814684311186941e+00
 f10m                                         | Min:+1.0004938840866089e+00 Max:+1.0948654413223267e+00 RMS:+1.0188698647586809e+00
-geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223766e+03
+geopotential_height_times_gravity_at_surface | Min:+0.0000000000000000e+00 Max:+3.5301851562500000e+04 RMS:+7.8466628379223757e+03
 graupel                                      | Min:+0.0000000000000000e+00 Max:+6.5326219191774726e-04 RMS:+3.0288534886145319e-06
-northward_wind                               | Min:-4.0078185665407403e+01 Max:+3.8601040519354804e+01 RMS:+6.3814373161622937e+00
-northward_wind_at_surface                    | Min:-1.3137481178590665e+01 Max:+1.1110245113001820e+01 RMS:+3.5818961636854953e+00
+northward_wind                               | Min:-4.0071147927978160e+01 Max:+3.8603052710687741e+01 RMS:+6.3875674624660226e+00
+northward_wind_at_surface                    | Min:-1.3518185866853509e+01 Max:+1.1345459088628690e+01 RMS:+3.6152528676815017e+00
 ozone_mass_mixing_ratio                      | Min:+4.4753472039360531e-09 Max:+1.6040661648730747e-05 RMS:+4.4486309455750947e-06
-rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806409e+03
+rain_number_concentration                    | Min:+0.0000000000000000e+00 Max:+8.6749025000000000e+05 RMS:+2.1760084842806414e+03
 rain_water                                   | Min:+0.0000000000000000e+00 Max:+1.7932932823896408e-03 RMS:+1.6047798774338737e-05
 sheleg                                       | Min:+0.0000000000000000e+00 Max:+1.6966506958007812e+01 RMS:+2.0734254733790997e-01
-skin_temperature_at_surface                  | Min:+2.7119995117187500e+02 Max:+3.2296466064453125e+02 RMS:+2.9475363971841756e+02
+skin_temperature_at_surface                  | Min:+2.7119995117187500e+02 Max:+3.2296466064453125e+02 RMS:+2.9475363971841750e+02
 slmsk                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+00 RMS:+7.8767192390790086e-01
 smois                                        | Min:+1.4970073476433754e-02 Max:+1.0000000000000000e+00 RMS:+6.4129001953741271e-01
 snow_water                                   | Min:+0.0000000000000000e+00 Max:+5.0736027769744396e-03 RMS:+4.4287745731177579e-05
@@ -119,33 +119,33 @@ tslb                                         | Min:+2.6350683593750000e+02 Max:+
 upward_air_velocity                          | Min:-9.9441605806350708e-01 Max:+2.9850695133209229e+00 RMS:+5.5847735613424890e-02
 vfrac                                        | Min:+0.0000000000000000e+00 Max:+9.9000000953674316e-01 RMS:+4.4064937959870992e-01
 vtype                                        | Min:+0.0000000000000000e+00 Max:+2.0000000000000000e+01 RMS:+7.1648734770793263e+00
-water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.3834229041695180e-02 RMS:+5.7299637375035290e-03
-water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+0.0000000000000000e+00 Max:+2.5338902044743646e-02 RMS:+1.1837031141379170e-02
+water_vapor_mixing_ratio_wrt_moist_air       | Min:+0.0000000000000000e+00 Max:+2.3834477430799562e-02 RMS:+5.7021406671902541e-03
+water_vapor_mixing_ratio_wrt_moist_air_at_2m | Min:+0.0000000000000000e+00 Max:+2.5338721467678779e-02 RMS:+1.1744459186538268e-02
 ----------------------------------------------------------------------------------------------------
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 580.6127088661092, nobs = 551, Jo/n = 1.053743573259726, err = 0.7527999877929688
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 15.42963663339243, nobs = 218, Jo/n = 0.07077814969446071, err = 4740998230.350175
-CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 1145.706746159938, nobs = 2048, Jo/n = 0.5594271221484073, err = 1.129250049591064
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 208.3875662747223, nobs = 562, Jo/n = 0.3707963812717479, err = 0.002411889398854826
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 58.74000897170578, nobs = 215, Jo/n = 0.2732093440544455, err = 0.002582168883354586
-CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 953.9393186635671, nobs = 2059, Jo/n = 0.4633022431586047, err = 0.003755441913178962
-CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 393.0953790101408, nobs = 562, Jo/n = 0.6994579697689339, err = 76.83292428321245
-CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 1016.225945142347, nobs = 2138, Jo/n = 0.4753161576905273, err = 61.00751505809844
-CostJo   : Nonlinear Jo(adpsfc_winds_281) = 521.9535563454119, nobs = 1082, Jo/n = 0.4823970021676635, err = 2.052070608022017
-CostJo   : Nonlinear Jo(adpsfc_winds_284) = 162.7275881203338, nobs = 418, Jo/n = 0.3893004500486454, err = 2.389662265250861
-CostJo   : Nonlinear Jo(adpsfc_winds_287) = 1867.651955456488, nobs = 4038, Jo/n = 0.4625190578148806, err = 1.831580075501386
-CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 855.5763073774755, nobs = 21341, Jo/n = 0.04009073180157797, err = 4577659806.921542
-CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 9392.038032796674, nobs = 19879, Jo/n = 0.4724602863723866, err = 0.005160472983565587
-CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 36935.80738983226, nobs = 19628, Jo/n = 1.881791695018966, err = 70.1204137881226
-CostJo   : Nonlinear Jo(msonet_winds_288) = 1211.953901004282, nobs = 6164, Jo/n = 0.1966180890662365, err = 3.371246373937797
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 84.26808809613752, nobs = 490, Jo/n = 0.1719756899921174, err = 1749635530.559413
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_181) = 580.9966746198374, nobs = 560, Jo/n = 1.037494061821138, err = 0.7527999877929688
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_183) = 15.37787953516676, nobs = 218, Jo/n = 0.07054073181269158, err = 4740998230.350175
+CostJo   : Nonlinear Jo(adpsfc_airTemperature_187) = 1139.659800587752, nobs = 2048, Jo/n = 0.5564745120057384, err = 1.129250049591064
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_181) = 216.4405477821376, nobs = 570, Jo/n = 0.3797202592669081, err = 0.002508106183910733
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_183) = 58.24274411573992, nobs = 215, Jo/n = 0.2708964842592554, err = 0.002582168883354586
+CostJo   : Nonlinear Jo(adpsfc_specificHumidity_187) = 950.3732517756921, nobs = 2059, Jo/n = 0.4615703019794522, err = 0.003755441913178962
+CostJo   : Nonlinear Jo(adpsfc_stationPressure_181) = 415.8568778401548, nobs = 570, Jo/n = 0.7295734698950084, err = 76.63036458910742
+CostJo   : Nonlinear Jo(adpsfc_stationPressure_187) = 1002.576760538389, nobs = 2138, Jo/n = 0.4689320676044852, err = 61.00751505809844
+CostJo   : Nonlinear Jo(adpsfc_winds_281) = 527.7936869757125, nobs = 1100, Jo/n = 0.4798124427051932, err = 2.051971008479105
+CostJo   : Nonlinear Jo(adpsfc_winds_284) = 161.9827670941551, nobs = 418, Jo/n = 0.3875185815649643, err = 2.389662265250861
+CostJo   : Nonlinear Jo(adpsfc_winds_287) = 1882.075941784989, nobs = 4040, Jo/n = 0.4658603816299476, err = 1.83147725301929
+CostJo   : Nonlinear Jo(msonet_airTemperature_188) = 860.2478193654056, nobs = 21341, Jo/n = 0.04030963025937892, err = 4577659806.921542
+CostJo   : Nonlinear Jo(msonet_specificHumidity_188) = 9388.753129481265, nobs = 19879, Jo/n = 0.4722950414749869, err = 0.005160472983565587
+CostJo   : Nonlinear Jo(msonet_stationPressure_188) = 36831.55611725252, nobs = 19627, Jo/n = 1.876575947279387, err = 70.1181989063623
+CostJo   : Nonlinear Jo(msonet_winds_288) = 1191.975301211793, nobs = 6164, Jo/n = 0.1933769145379288, err = 3.371246373937797
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_180) = 46.67909639928193, nobs = 266, Jo/n = 0.1754853248093306, err = 2123976976.214366
 CostJo   : Nonlinear Jo(sfcshp_airTemperature_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 8.137526743981862, nobs = 44, Jo/n = 0.1849437896359514, err = 3370999312.31621
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 95.30946752183394, nobs = 416, Jo/n = 0.2291092969274854, err = 0.00124627547718944
+CostJo   : Nonlinear Jo(sfcshp_airTemperature_183) = 5.1583489981012, nobs = 28, Jo/n = 0.1842267499321857, err = 3273268353.539886
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_180) = 75.85180945301155, nobs = 214, Jo/n = 0.3544477077243531, err = 0.001351204507360681
 CostJo   : Nonlinear Jo(sfcshp_specificHumidity_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 2.316931074480798, nobs = 9, Jo/n = 0.257436786053422, err = 0.00132439934435662
-CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 2279.625947498581, nobs = 1211, Jo/n = 1.882432656893956, err = 39.70642087671248
+CostJo   : Nonlinear Jo(sfcshp_specificHumidity_183) = 3.599077537349551, nobs = 9, Jo/n = 0.3998975041499502, err = 0.00132439934435662
+CostJo   : Nonlinear Jo(sfcshp_stationPressure_180) = 1437.852466840711, nobs = 499, Jo/n = 2.881467869420263, err = 39.70019911262604
 CostJo   : Nonlinear Jo(sfcshp_stationPressure_182) = 0 --- No Observations
-CostJo   : Nonlinear Jo(sfcshp_winds_280) = 294.725000132735, nobs = 1764, Jo/n = 0.1670776644743396, err = 2.694602820739344
-CostJo   : Nonlinear Jo(sfcshp_winds_282) = 21.02255767512631, nobs = 18, Jo/n = 1.16791987084035, err = 1.106441246672606
-CostJo   : Nonlinear Jo(sfcshp_winds_284) = 132.2114599366158, nobs = 124, Jo/n = 1.06622145110174, err = 1.314810726708362
-CostFunction: Nonlinear J = 58237.46301933433
+CostJo   : Nonlinear Jo(sfcshp_winds_280) = 145.7398211369503, nobs = 710, Jo/n = 0.2052673537140145, err = 2.715379692126758
+CostJo   : Nonlinear Jo(sfcshp_winds_282) = 21.27962990545547, nobs = 18, Jo/n = 1.182201661414193, err = 1.106441246672606
+CostJo   : Nonlinear Jo(sfcshp_winds_284) = 45.69579404274567, nobs = 54, Jo/n = 0.846218408198994, err = 1.314298441422557
+CostFunction: Nonlinear J = 57005.76534427431


### PR DESCRIPTION
## Description
This PR

- Changes all the category grouping variables for all surface types to `longitude_latitude`. This includes those that were already set to `stationIdentifier`. This is for consistency across all surface types while also ensuring that moving station types (ships) are handled correctly.
- Changes the operator for sfcshp data to the sfcCorrected operator.
- Adds the ability to add the needed metadata in offline_ioda_patch tool.

## Dependencies (if applicable)
- [x] Need to update the following ctest obs files to include `MetaData/longitude_latitude`
  - ioda_adpsfc.nc
  - ioda_sfcshp.nc

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [x] Unit tests added/updated (if applicable).
