### PR TITLE
Add field IO names to ensemble mean output 

### DIFF
--- a/parm/jcb-rdas/model/fv3/atmosphere/atmosphere_output_mean_prior.yaml.j2
+++ b/parm/jcb-rdas/model/fv3/atmosphere/atmosphere_output_mean_prior.yaml.j2
@@ -1,3 +1,24 @@
   filetype: fms restart
   datapath: ./
   prefix: letkf-meanprior-fv3_lam-C775
+  field io names:
+    eastward_wind: {{eastward_wind}}
+    northward_wind: {{northward_wind}}
+    air_temperature: {{air_temperature}}
+    air_pressure_at_surface: {{air_pressure_at_surface}}
+    air_pressure_thickness: {{air_pressure_thickness}}
+    water_vapor_mixing_ratio_wrt_moist_air: {{water_vapor_mixing_ratio_wrt_moist_air}}
+    cloud_liquid_ice: {{cloud_liquid_ice}}
+    cloud_liquid_water: {{cloud_liquid_water}}
+    ozone_mass_mixing_ratio: {{ozone_mass_mixing_ratio}}
+    geopotential_height_times_gravity_at_surface: {{geopotential_height_times_gravity_at_surface}}
+    skin_temperature_at_surface: {{skin_temperature_at_surface}}
+    tslb: {{tslb}}
+    smois: {{smois}}
+    eastward_wind_at_surface: {{eastward_wind_at_surface}}
+    northward_wind_at_surface: {{northward_wind_at_surface}}
+    rain_water: {{rain_water}}
+    snow_water: {{snow_water}}
+    graupel: {{graupel}}
+    upward_air_velocity: {{upward_air_velocity}}
+    equivalent_reflectivity_factor: {{equivalent_reflectivity_factor}}

--- a/parm/jcb-rdas/model/fv3/atmosphere/atmosphere_posterior_output.yaml.j2
+++ b/parm/jcb-rdas/model/fv3/atmosphere/atmosphere_posterior_output.yaml.j2
@@ -1,3 +1,24 @@
   filetype: fms restart
   datapath: ./
   prefix: letkf-meanposterior-fv3_lam-C775
+  field io names:
+    eastward_wind: {{eastward_wind}}
+    northward_wind: {{northward_wind}}
+    air_temperature: {{air_temperature}}
+    air_pressure_at_surface: {{air_pressure_at_surface}}
+    air_pressure_thickness: {{air_pressure_thickness}}
+    water_vapor_mixing_ratio_wrt_moist_air: {{water_vapor_mixing_ratio_wrt_moist_air}}
+    cloud_liquid_ice: {{cloud_liquid_ice}}
+    cloud_liquid_water: {{cloud_liquid_water}}
+    ozone_mass_mixing_ratio: {{ozone_mass_mixing_ratio}}
+    geopotential_height_times_gravity_at_surface: {{geopotential_height_times_gravity_at_surface}}
+    skin_temperature_at_surface: {{skin_temperature_at_surface}}
+    tslb: {{tslb}}
+    smois: {{smois}}
+    eastward_wind_at_surface: {{eastward_wind_at_surface}}
+    northward_wind_at_surface: {{northward_wind_at_surface}}
+    rain_water: {{rain_water}}
+    snow_water: {{snow_water}}
+    graupel: {{graupel}}
+    upward_air_velocity: {{upward_air_velocity}}
+    equivalent_reflectivity_factor: {{equivalent_reflectivity_factor}}


### PR DESCRIPTION

## Description

Very small PR here to add the field IO names when outputting the ensemble mean prior and posterior. This way these files are output with the FV3 variable names instead of the generic JEDI names (e.g., use `T` instead of `air_temperature`). 

This change is needed for running the GSI observer with the JEDI analyses to generate o-a diagnostics and comparing against the real-time RRFS. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
