### PR TITLE
allow generic building when users provide their own build environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ install*/
 expr
 fix/INIT_DONE
 fix/.agent
+modulefiles/RDAS/hostgeneric.intel.lua
 
 # Ignore the rrfs-test ctest yamls since they are build with RDASApp
 rrfs-test/testinput/rrfs_fv3jedi_2024052700_3dvar*.yaml

--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ START=$(date +%s)
 dir_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 source $dir_root/ush/detect_machine.sh
-source $dir_root/ush/init.sh
+$dir_root/ush/init.sh
 
 # ==============================================================================
 usage() {
@@ -119,7 +119,7 @@ while getopts "p:c:m:j:t:b:r:w:hvfsxd" opt; do
 done
 
 case ${BUILD_TARGET} in
-  hera | orion | hercules | jet | gaeac? | wcoss2 | ursa | derecho)
+  hera | orion | hercules | jet | gaeac? | wcoss2 | ursa | derecho | hostgeneric)
     echo "Building RDASApp on $BUILD_TARGET"
     echo "  Build initiated `date`"
     if [[ "${BUILD_TARGET}" != *gaea* ]] &&  [[ "${BUILD_TARGET}" != *derecho* ]]; then

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -9,7 +9,7 @@
 # Thank you for your contribution
 
 # First detect w/ hostname
-if [[ "${MACHINE}" == "hostgeneric" ]]; then
+if [[ "${MACHINE:-''}" == "hostgeneric" ]]; then
   MACHINE_ID="hostgeneric"
   return 0
 fi

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -9,6 +9,10 @@
 # Thank you for your contribution
 
 # First detect w/ hostname
+if [[ "${MACHINE}" == "hostgeneric" ]]; then
+  MACHINE_ID="hostgeneric"
+  return 0
+fi
 case $(hostname -f) in
 
   adecflow0[12].acorn.wcoss2.ncep.noaa.gov)  MACHINE_ID=acorn ;; ### acorn

--- a/ush/init.sh
+++ b/ush/init.sh
@@ -32,6 +32,9 @@ case ${MACHINE_ID} in
       echo "unsupported gaea cluster: ${MACHINE_ID}"
     fi
     ;;
+  hostgeneric)
+    exit 0
+    ;;
   *)
     echo "platform not supported: ${MACHINE_ID}"
     ;;

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -115,6 +115,9 @@ elif [[ $MACHINE_ID = discover* ]]; then
     export PATH=$PATH:$SPACK_ROOT/bin
     . $SPACK_ROOT/share/spack/setup-env.sh
 
+elif [[ $MACHINE_ID = hostgeneric ]]; then
+    :  # do nothing
+
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi


### PR DESCRIPTION
## Description
Allow generic building when users provide their own build environments.

This facilitates the ongoing work to port rrfs-workflow(MPAS-JEDI) to generic machines, such as Docker containers, small clusters, personal PCs etc (for example, https://github.com/NOAA-EMC/rrfs-workflow/pull/1473).

## Issue(s) addressed
None

## Dependencies (if applicable)
None