### PR TITLE
Add expanded SATWND AMV converter and JCB support

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_273.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_273.yaml.j2
@@ -1,0 +1,437 @@
+     - obs space:
+         name: satwnd_winds_245_273
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_satwnd.abi_goes-19.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_245_273.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (245)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: {{iuse_satwnd_winds_245_273 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 273
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Online domain check
+         - filter: Bounds Check
+           udescriptor: "online_domain_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0]
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+
+         # Halve the ob error (based on read_satwnd.f90)
+         - filter: Perform Action
+           udescriptor: "ob_error_inflation"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation factor: 0.5
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 90.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with pressure < 150 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 15000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
+           udescriptor: "bounds_check_pressure_over_land"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 85000.
+           - variable: GeoVaLs/land_area_fraction
+             minvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pct1"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/coefficientOfVariation
+           minvalue: 0.04
+           maxvalue: 0.5
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject data over non-water surface type where latitude > 20N
+         - filter: Perform Action
+           udescriptor: "bounds_check_reject_over_nonwater"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/latitude
+             minvalue: 20.
+           - variable: GeoVaLs/water_area_fraction
+             maxvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # AMV expected error norm check
+         - filter: Perform Action
+           udescriptor: "amv_experr_norm_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             minvalue: 0.1
+           - variable: MetaData/exp_err_norm
+             minvalue: 0.9
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject when pressure between 399 and 801 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 39901.
+             maxvalue: 80099.
+           - variable: ObsType/windEastward
+             is_in: 245
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 245 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 245 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_273.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_273.yaml.j2
@@ -1,0 +1,403 @@
+     - obs space:
+         name: satwnd_winds_246_273
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_satwnd.abi_goes-19.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_246_273.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (246)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: {{iuse_satwnd_winds_246_273 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 273
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Online domain check
+         - filter: Bounds Check
+           udescriptor: "online_domain_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0]
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+
+         # Halve the ob error (based on read_satwnd.f90)
+         - filter: Perform Action
+           udescriptor: "ob_error_inflation"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation factor: 0.5
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 90.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with pressure < 150 mb and  > 300 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 15000.
+           maxvalue: 30000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
+           udescriptor: "bounds_check_pressure_over_land"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 85000.
+           - variable: GeoVaLs/land_area_fraction
+             minvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pct1"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/coefficientOfVariation
+           minvalue: 0.04
+           maxvalue: 0.5
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # AMV expected error norm check
+         - filter: Perform Action
+           udescriptor: "amv_experr_norm_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             minvalue: 0.1
+           - variable: MetaData/exp_err_norm
+             minvalue: 0.9
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 246 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 246 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_273.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_273.yaml.j2
@@ -1,0 +1,406 @@
+     - obs space:
+         name: satwnd_winds_247_273
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_satwnd.abi_goes-19.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_247_273.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (247)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: {{iuse_satwnd_winds_247_273 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 273
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Online domain check
+         - filter: Bounds Check
+           udescriptor: "online_domain_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0]
+                 #errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0]
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+
+         # Halve the ob error (based on read_satwnd.f90)
+         - filter: Perform Action
+           udescriptor: "ob_error_inflation"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: inflate error
+             inflation factor: 0.5
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 90.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with pressure < 150 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 15000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
+           udescriptor: "bounds_check_pressure_over_land"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 85000.
+           - variable: GeoVaLs/land_area_fraction
+             minvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # AMV expected error norm check
+         - filter: Perform Action
+           udescriptor: "amv_experr_norm_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             minvalue: 0.1
+           - variable: MetaData/exp_err_norm
+             minvalue: 0.9
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs within 110 mb of surface pressure over non-water surface
+         - filter: Difference Check
+           udescriptor: "difference_check_surface_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable:
+               name: GeoVaLs/water_area_fraction
+             maxvalue: 0.99
+           - variable:
+               name: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -11000.                   # within 110 hPa above surface pressure, negative p-diff
+           action:
+             name: reject
+
+         # Reject when difference of wind direction between obs and background is more than 50 degrees
+         - filter: Bounds Check
+           udescriptor: "wind_direction_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: ObsFunction/WindDirAngleDiff
+           maxvalue: 50.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 247
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 247 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 247 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_250_174.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_250_174.yaml.j2
@@ -1,0 +1,404 @@
+     - obs space:
+         name: satwnd_winds_250_174
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_satwnd.ahi_h9.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_250_174.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (250)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: {{iuse_satwnd_winds_250_174 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 174
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Online domain check
+         - filter: Bounds Check
+           udescriptor: "online_domain_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0, 1000000000.0]
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+
+         # Halve the ob error (based on read_satwnd.f90)
+         - filter: Perform Action
+           udescriptor: "ob_error_inflation"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: inflate error
+             inflation factor: 0.5
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 90.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with pressure < 150 mb and  > 300 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 15000.
+           #maxvalue: 30000.
+           maxvalue: 40000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
+           udescriptor: "bounds_check_pressure_over_land"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 85000.
+           - variable: GeoVaLs/land_area_fraction
+             minvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pct1"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/coefficientOfVariation
+           minvalue: 0.04
+           maxvalue: 0.5
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         ## AMV expected error norm check
+         #- filter: Perform Action
+         #  udescriptor: "amv_experr_norm_check"
+         #  filter variables:
+         #  - name: windEastward
+         #  - name: windNorthward
+         #  where:
+         #  - variable: ObsFunction/Velocity
+         #    minvalue: 0.1
+         #  - variable: MetaData/exp_err_norm
+         #    minvalue: 0.9
+         #  - variable: ObsType/windEastward
+         #    is_in: 250
+         #  - variable: MetaData/satelliteIdentifier
+         #    is_in: 174
+         #  action:
+         #    name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 250 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 250 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_252_174.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_252_174.yaml.j2
@@ -1,0 +1,437 @@
+     - obs space:
+         name: satwnd_winds_252_174
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_satwnd.ahi_h9.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_252_174.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (252)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: {{iuse_satwnd_winds_252_174 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 174
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Online domain check
+         - filter: Bounds Check
+           udescriptor: "online_domain_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0]
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+
+         # Halve the ob error (based on read_satwnd.f90)
+         - filter: Perform Action
+           udescriptor: "ob_error_inflation"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: inflate error
+             inflation factor: 0.5
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 90.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with pressure < 150 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 15000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
+           udescriptor: "bounds_check_pressure_over_land"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 85000.
+           - variable: GeoVaLs/land_area_fraction
+             minvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pct1"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/coefficientOfVariation
+           minvalue: 0.04
+           maxvalue: 0.5
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject data over non-water surface type where latitude > 20N
+         - filter: Perform Action
+           udescriptor: "bounds_check_reject_over_nonwater"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/latitude
+             minvalue: 20.
+           - variable: GeoVaLs/water_area_fraction
+             maxvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         ## AMV expected error norm check
+         #- filter: Perform Action
+         #  udescriptor: "amv_experr_norm_check"
+         #  filter variables:
+         #  - name: windEastward
+         #  - name: windNorthward
+         #  where:
+         #  - variable: ObsFunction/Velocity
+         #    minvalue: 0.1
+         #  - variable: MetaData/exp_err_norm
+         #    minvalue: 0.9
+         #  - variable: ObsType/windEastward
+         #    is_in: 252
+         #  - variable: MetaData/satelliteIdentifier
+         #    is_in: 174
+         #  action:
+         #    name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject when pressure between 399 and 801 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 39901.
+             maxvalue: 80099.
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 252 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 252 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_56.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_56.yaml.j2
@@ -1,0 +1,437 @@
+     - obs space:
+         name: satwnd_winds_253_56
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_satwnd.seviri_m9.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_253_56.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (253)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: {{iuse_satwnd_winds_253_56 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 56
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reduce obs space
+
+         # Online domain check
+         - filter: Bounds Check
+           udescriptor: "online_domain_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0] 
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+
+         # Halve the ob error (based on read_satwnd.f90)
+         - filter: Perform Action
+           udescriptor: "ob_error_inflation"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: inflate error
+             inflation factor: 0.5
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 90.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject obs with pressure < 150 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 15000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
+           udescriptor: "bounds_check_pressure_over_land"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 85000.
+           - variable: GeoVaLs/land_area_fraction
+             minvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pct1"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/coefficientOfVariation
+           minvalue: 0.04
+           maxvalue: 0.5
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject data over non-water surface type where latitude > 20N
+         - filter: Perform Action
+           udescriptor: "bounds_check_reject_over_nonwater"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/latitude
+             minvalue: 20.
+           - variable: GeoVaLs/water_area_fraction
+             maxvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         ## AMV expected error norm check
+         #- filter: Perform Action
+         #  udescriptor: "amv_experr_norm_check"
+         #  filter variables:
+         #  - name: windEastward
+         #  - name: windNorthward
+         #  where:
+         #  - variable: ObsFunction/Velocity
+         #    minvalue: 0.1
+         #  - variable: MetaData/exp_err_norm
+         #    minvalue: 0.9
+         #  - variable: ObsType/windEastward
+         #    is_in: 253
+         #  - variable: MetaData/satelliteIdentifier
+         #    is_in: 56
+         #  action:
+         #    name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject when pressure between 399 and 801 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 39901.
+             maxvalue: 80099.
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 253 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 253 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_57.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_57.yaml.j2
@@ -1,0 +1,437 @@
+     - obs space:
+         name: satwnd_winds_253_57
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_satwnd.seviri_m10.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_253_57.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (253)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: {{iuse_satwnd_winds_253_57 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 57
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reduce obs space
+
+         # Online domain check
+         - filter: Bounds Check
+           udescriptor: "online_domain_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name:  GeoVaLs/observable_domain_mask
+           minvalue: 0.0
+           maxvalue: 0.5
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0] 
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+
+         # Halve the ob error (based on read_satwnd.f90)
+         - filter: Perform Action
+           udescriptor: "ob_error_inflation"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: inflate error
+             inflation factor: 0.5
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 90.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject obs with pressure < 150 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 15000.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject obs over land (isli=1) where pressure > 850 mb
+         - filter: Perform Action
+           udescriptor: "bounds_check_pressure_over_land"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 85000.
+           - variable: GeoVaLs/land_area_fraction
+             minvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pct1"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/coefficientOfVariation
+           minvalue: 0.04
+           maxvalue: 0.5
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject data over non-water surface type where latitude > 20N
+         - filter: Perform Action
+           udescriptor: "bounds_check_reject_over_nonwater"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/latitude
+             minvalue: 20.
+           - variable: GeoVaLs/water_area_fraction
+             maxvalue: 0.99
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Low wind speed check
+         - filter: Perform Action
+           udescriptor: "reject_low_speed_amv"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsFunction/Velocity
+             maxvalue: 0.1
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         ## AMV expected error norm check
+         #- filter: Perform Action
+         #  udescriptor: "amv_experr_norm_check"
+         #  filter variables:
+         #  - name: windEastward
+         #  - name: windNorthward
+         #  where:
+         #  - variable: ObsFunction/Velocity
+         #    minvalue: 0.1
+         #  - variable: MetaData/exp_err_norm
+         #    minvalue: 0.9
+         #  - variable: ObsType/windEastward
+         #    is_in: 253
+         #  - variable: MetaData/satelliteIdentifier
+         #    is_in: 57
+         #  action:
+         #    name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject when pressure between 399 and 801 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 39901.
+             maxvalue: 80099.
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 253 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 253 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_ahi.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_ahi.json
@@ -1,0 +1,15 @@
+{
+  "data_format"      : "bufr_d",
+  "data_type"        : "satwnd",
+  "cycle_datetime"   : "{{ current_cycle | to_YMDH }}",
+  "dump_directory"   : "./",
+  "ioda_directory"   : "./",
+  "subsets"          : [ "NC005044", "NC005045", "NC005046" ],
+  "data_description" : "NC005044 JMA SATWIND, AHI HIMAWARI IR(LW)/VIS/WV-CT/WV-CS;  NC005045 JMA SATWIND, AHI HIMAWARI IR(LW)/VIS/WV-CT/WV-CS; NC005046 JMA SATWIND, AHI HIMAWARI IR(LW)/VIS/WV-CT/WV-CS",
+  "data_provider"    : "JMA",
+  "sensor_info"      : { "sensor_name": "AHI",  "sensor_full_name": "Advanced Himawari Imager",  "sensor_id": 999 },
+  "satellite_info"   : [
+                          { "satellite_name": "H8", "satellite_full_name": "Himawari-8", "satellite_id": 173, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "H9", "satellite_full_name": "Himawari-9", "satellite_id": 174, "launch time": "YYYYMMDD" }
+                       ]
+}

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_ahi.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_ahi.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+import numpy.ma as ma
+from pyiodaconv import bufr
+import calendar
+import json
+import time
+import math
+import datetime
+import os
+from datetime import datetime, timezone
+from pyioda import ioda_obs_space as ioda_ospace
+from wxflow import Logger
+
+# ====================================================================
+# Satellite Winds (AMV) BUFR dump file for AHI/Himawari
+# ====================================================================
+# All subsets contain all spectral bands: NC005044 NC005045 NC005046
+# ====================================================================
+# Spectral Band                 | Code (002023) | ObsType
+# --------------------------------------------------------------------
+# IRLW  (Freq < 5E+13)          |    Method 1   | 252
+# VIS                           |    Method 2   | 242
+# WV Cloud Top                  |    Method 3   | 250
+# WV Clear Sky/ Deep Layer      |    Method 5   | 250
+# ====================================================================
+
+# Define and initialize  global variables
+global float32_fill_value
+global int32_fill_value
+global int64_fill_value
+
+float32_fill_value = np.float32(0)
+int32_fill_value = np.int32(0)
+int64_fill_value = np.int64(0)
+
+
+def Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd):
+
+    uob = (-wspd * np.sin(np.radians(wdir))).astype(np.float32)
+    vob = (-wspd * np.cos(np.radians(wdir))).astype(np.float32)
+
+    return uob, vob
+
+
+def Get_ObsType(swcm, chanfreq):
+
+    obstype = swcm.copy()
+
+    # Use numpy vectorized operations
+    obstype = np.where(swcm == 5, 250, obstype)  # WVCA/DL
+    obstype = np.where(swcm == 3, 250, obstype)  # WVCT
+    obstype = np.where(swcm == 2, 242, obstype)  # VIS
+    obstype = np.where(swcm == 1, 252, obstype)  # IRLW
+
+    if not np.any(np.isin(obstype, [242, 250, 252])):
+        raise ValueError("Error: Unassigned ObsType found ... ")
+
+    return obstype
+
+
+def bufr_to_ioda(config, logger):
+
+    subsets = config["subsets"]
+    logger.debug(f"Checking subsets = {subsets}")
+
+    # Get parameters from configuration
+    subsets = config["subsets"]
+    data_format = config["data_format"]
+    data_type = config["data_type"]
+    data_description = config["data_description"]
+    data_provider = config["data_provider"]
+    #cycle_type = config["cycle_type"]
+    dump_dir = config["dump_directory"]
+    ioda_dir = config["ioda_directory"]
+    cycle = config["cycle_datetime"]
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+
+    satellite_info_array = config["satellite_info"]
+    sensor_name = config["sensor_info"]["sensor_name"]
+    sensor_full_name = config["sensor_info"]["sensor_full_name"]
+    sensor_id = config["sensor_info"]["sensor_id"]
+
+    # Get derived parameters
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+    reference_time = datetime.strptime(cycle, "%Y%m%d%H")
+    reference_time = reference_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # General informaton
+    converter = 'BUFR to IODA Converter'
+    process_level = 'Level-2'
+    platform_description = 'Himawari-8'
+    sensor_description = 'Advanced Himawari Imager'
+
+    logger.info(f'sensor_name = {sensor_name}')
+    logger.info(f'sensor_full_name = {sensor_full_name}')
+    logger.info(f'sensor_id = {sensor_id}')
+    logger.info(f'reference_time = {reference_time}')
+
+    bufrfile = "satwndbufr"
+    DATA_PATH = os.path.join(dump_dir, bufrfile)
+    if not os.path.isfile(DATA_PATH):
+        logger.info(f"DATA_PATH {DATA_PATH} does not exist")
+        return
+    logger.debug(f"The DATA_PATH is: {DATA_PATH}")
+
+    # ============================================
+    # Make the QuerySet for all the data we want
+    # ============================================
+    start_time = time.time()
+
+    logger.info('Making QuerySet')
+    q = bufr.QuerySet(subsets)
+
+    # MetaData
+    q.add('latitude', '*/CLAT')
+    q.add('longitude', '*/CLON')
+    q.add('satelliteId', '*/SAID')
+    q.add('year', '*/YEAR')
+    q.add('month', '*/MNTH')
+    q.add('day', '*/DAYS')
+    q.add('hour', '*/HOUR')
+    q.add('minute', '*/MINU')
+    q.add('second', '*/SECO')
+    q.add('satelliteZenithAngle', '*/SAZA')
+    q.add('sensorCentralFrequency', '*/SCCF')
+    q.add('pressure', '*/PRLC')
+
+    # Processing Center
+    q.add('dataProviderOrigin', '*/OGCE')
+    q.add('windGeneratingApplication', '*/QCPRMS[1]/GNAP')
+
+#   # Quality Infomation (Quality Indicator w/o forecast)
+    q.add('qualityInformationWithoutForecast', '*/QCPRMS[1]/PCCF')
+
+    # Wind Retrieval Method Information
+    q.add('windComputationMethod', '*/SWCM')
+
+    # ObsValue
+    q.add('windDirection', '*/WDIR')
+    q.add('windSpeed', '*/WSPD')
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.debug(f'Processing time for making QuerySet : {running_time} seconds')
+
+    # ==============================================================
+    # Open the BUFR file and execute the QuerySet to get ResultSet
+    # Use the ResultSet returned to get numpy arrays of the data
+    # ==============================================================
+    start_time = time.time()
+
+    logger.info('Executing QuerySet to get ResultSet')
+    with bufr.File(DATA_PATH) as f:
+        try:
+            r = f.execute(q)
+        except Exception as err:
+            logger.info(f'Return with {err}')
+            return
+
+    # MetaData
+    satid = r.get('satelliteId')
+    year = r.get('year')
+    month = r.get('month')
+    day = r.get('day')
+    hour = r.get('hour')
+    minute = r.get('minute')
+    second = r.get('second')
+    lat = r.get('latitude')
+    lon = r.get('longitude')
+    satzenang = r.get('satelliteZenithAngle')
+    pressure = r.get('pressure', type='float')
+    chanfreq = r.get('sensorCentralFrequency', type='float')
+
+    # Processing Center
+    ogce = r.get('dataProviderOrigin')
+    ga = r.get('windGeneratingApplication')
+
+    # Quality Information
+    qi = r.get('qualityInformationWithoutForecast', type='float')
+    # For AHI/Himawari data, qi w/o forecast (qifn) is packaged in same
+    # vector where ga == 102. Must conduct a search and extract the
+    # correct vector for gnap and qi
+    # 1. Find dimension-sizes of ga and qi (should be the same!)
+    gDim1, gDim2 = np.shape(ga)
+    qDim1, qDim2 = np.shape(qi)
+    logger.info(f'Generating Application and Quality Information SEARCH:')
+    logger.info(f'Dimension size of GNAP ({gDim1},{gDim2})')
+    logger.info(f'Dimension size of PCCF ({qDim1},{qDim2})')
+    # 2. Initialize gnap and qifn as None, and search for dimension of
+    #    ga with values of 102. If the same column exists for qi, assign
+    #    gnap to ga[:,i] and qifn to qi[:,i], else raise warning that no
+    #    appropriate GNAP/PCCF combination was found
+    gnap = None
+    qifn = None
+    for i in range(gDim2):
+        if np.unique(ga[:, i].squeeze()) == 102:
+            if i <= qDim2:
+                logger.info(f'GNAP/PCCF found for column {i}')
+                gnap = ga[:, i].squeeze()
+                qifn = qi[:, i].squeeze()
+            else:
+                logger.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')
+    if (gnap is None) & (qifn is None):
+        logger.info(f'ERROR: GNAP == 102 NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
+
+    # Wind Retrieval Method Information
+    swcm = r.get('windComputationMethod')
+
+    # ObsValue
+    # Wind direction and Speed
+    wdir = r.get('windDirection', type='float')
+    wspd = r.get('windSpeed')
+
+    # DateTime: seconds since Epoch time
+    # IODA has no support for numpy datetime arrays dtype=datetime64[s]
+    timestamp = r.get_datetime('year', 'month', 'day', 'hour', 'minute', 'second').astype(np.int64)
+
+    ref_dt  = datetime.fromisoformat(reference_time.replace("Z", "+00:00"))
+    ref_sec = ref_dt.replace(tzinfo=timezone.utc).timestamp()
+    toff = ma.MaskedArray((timestamp.data - ref_sec).astype(np.float32), mask=timestamp.mask)
+    # Check BUFR variable generic dimension and type
+
+    # Global variables declaration
+    # Set global fill values
+    float32_fill_value = satzenang.fill_value
+    int32_fill_value = satid.fill_value
+    int64_fill_value = timestamp.fill_value.astype(np.int64)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for executing QuerySet to get ResultSet : {running_time} seconds')
+
+    # =========================
+    # Create derived variables
+    # =========================
+    start_time = time.time()
+
+    logger.info('Creating derived variables')
+    logger.debug('Creating derived variables - wind components (uob and vob)')
+
+    uob, vob = Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd)
+
+    logger.debug(f'   uob min/max = {uob.min()} {uob.max()}')
+    logger.debug(f'   vob min/max = {vob.min()} {vob.max()}')
+
+    obstype = Get_ObsType(swcm, chanfreq)
+
+    height = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+    stnelev = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for creating derived variables : {running_time} seconds')
+
+    # =====================================
+    # Split output based on satellite id
+    # Create IODA ObsSpace
+    # Write IODA output
+    # =====================================
+    logger.info('Create IODA ObsSpace and Write IODA output based on satellite ID')
+
+    # Find unique satellite identifiers in data to process
+    unique_satids = np.unique(satid)
+    logger.info(f'Number of Unique satellite identifiers: {len(unique_satids)}')
+    logger.info(f'Unique satellite identifiers: {unique_satids}')
+
+    logger.debug(f'Loop through unique satellite identifier {unique_satids}')
+    total_ob_processed = 0
+    for sat in unique_satids.tolist():
+        start_time = time.time()
+
+        matched = False
+        for satellite_info in satellite_info_array:
+            if (satellite_info["satellite_id"] == sat):
+                matched = True
+                satellite_id = satellite_info["satellite_id"]
+                satellite_name = satellite_info["satellite_name"]
+                satinst = sensor_name.lower()+'_'+satellite_name.lower()
+                logger.debug(f'Split data for {satinst} satid = {sat}')
+
+        if matched:
+
+            # Define a boolean mask to subset data from the original data object
+            mask = satid == sat
+            # MetaData
+            lon2 = lon[mask]
+            lat2 = lat[mask]
+            timestamp2 = timestamp[mask]
+            satid2 = satid[mask]
+            satzenang2 = satzenang[mask]
+            chanfreq2 = chanfreq[mask]
+            obstype2 = obstype[mask]
+            pressure2 = pressure[mask]
+            height2 = height[mask]
+            stnelev2 = stnelev[mask]
+
+            # Processing Center
+            ogce2 = ogce[mask]
+
+            # QC Info
+            qifn2 = qifn[mask]
+
+            # Method
+            swcm2 = swcm[mask]
+
+            # ObsValue
+            wdir2 = wdir[mask]
+            wspd2 = wspd[mask]
+            uob2 = uob[mask]
+            vob2 = vob[mask]
+
+            # Timestamp Range
+            timestamp2_min = datetime.fromtimestamp(timestamp2.min())
+            timestamp2_max = datetime.fromtimestamp(timestamp2.max())
+
+            # Check unique observation time
+            unique_timestamp2 = np.unique(timestamp2)
+            logger.debug(f'Processing output for satid {sat}')
+
+            # Create the dimensions
+            dims = {
+                'Location': np.arange(0, wdir2.shape[0])
+            }
+
+            # Create IODA ObsSpace
+            iodafile = f"ioda_{data_type}.{satinst}.nc"
+            OUTPUT_PATH = os.path.join(ioda_dir, iodafile)
+            logger.info(f'Create output file : {OUTPUT_PATH}')
+            obsspace = ioda_ospace.ObsSpace(OUTPUT_PATH, mode='w', dim_dict=dims)
+
+            # Create Global attributes
+            logger.debug('Write global attributes')
+            obsspace.write_attr('Converter', converter)
+            obsspace.write_attr('sourceFiles', bufrfile)
+            obsspace.write_attr('dataProviderOrigin', data_provider)
+            obsspace.write_attr('description', data_description)
+            obsspace.write_attr('datetimeReference', reference_time)
+            obsspace.write_attr('datetimeRange', [str(timestamp2_min), str(timestamp2_max)])
+            obsspace.write_attr('sensor', sensor_id)
+            obsspace.write_attr('platform', satellite_id)
+            obsspace.write_attr('platformCommonName', satellite_name)
+            obsspace.write_attr('sensorCommonName', sensor_name)
+            obsspace.write_attr('processingLevel', process_level)
+            obsspace.write_attr('platformLongDescription', platform_description)
+            obsspace.write_attr('sensorLongDescription', sensor_description)
+
+            # Create IODA variables
+            logger.debug('Write variables: name, type, units, and attributes')
+            # Longitude
+            obsspace.create_var('MetaData/longitude', dtype=lon2.dtype, fillval=lon2.fill_value) \
+                .write_attr('units', 'degrees_east') \
+                .write_attr('valid_range', np.array([-180, 180], dtype=np.float32)) \
+                .write_attr('long_name', 'Longitude') \
+                .write_data(lon2)
+
+            # Latitude
+            obsspace.create_var('MetaData/latitude', dtype=lat.dtype, fillval=lat2.fill_value) \
+                .write_attr('units', 'degrees_north') \
+                .write_attr('valid_range', np.array([-90, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Latitude') \
+                .write_data(lat2)
+
+            # Datetime
+            obsspace.create_var('MetaData/dateTime', dtype=np.int64, fillval=int64_fill_value) \
+                .write_attr('units', 'seconds since 1970-01-01T00:00:00Z') \
+                .write_attr('long_name', 'Datetime') \
+                .write_data(timestamp2)
+
+            # Time variable
+            obsspace.create_var('MetaData/timeOffset', dtype=toff.dtype, fillval=toff.fill_value) \
+                .write_attr('units', 's') \
+                .write_attr('long_name', 'Observation Time Minus Reference Time') \
+                .write_data(toff)
+
+            # Satellite Identifier
+            obsspace.create_var('MetaData/satelliteIdentifier', dtype=satid2.dtype, fillval=satid2.fill_value) \
+                .write_attr('long_name', 'Satellite Identifier') \
+                .write_data(satid2)
+
+            # Sensor Zenith Angle
+            obsspace.create_var('MetaData/satelliteZenithAngle', dtype=satzenang2.dtype, fillval=satzenang2.fill_value) \
+                .write_attr('units', 'degree') \
+                .write_attr('valid_range', np.array([0, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Satellite Zenith Angle') \
+                .write_data(satzenang2)
+
+            # Sensor Centrall Frequency
+            obsspace.create_var('MetaData/sensorCentralFrequency', dtype=chanfreq2.dtype, fillval=chanfreq2.fill_value) \
+                .write_attr('units', 'Hz') \
+                .write_attr('long_name', 'Satellite Channel Center Frequency') \
+                .write_data(chanfreq2)
+
+            # Data Provider
+            obsspace.create_var('MetaData/dataProviderOrigin', dtype=ogce2.dtype, fillval=ogce2.fill_value) \
+                .write_attr('long_name', 'Identification of Originating/Generating Center') \
+                .write_data(ogce2)
+
+            # Quality: Percent Confidence - Quality Information Without Forecast
+            obsspace.create_var('MetaData/qiWithoutForecast', dtype=qifn2.dtype, fillval=qifn2.fill_value) \
+                .write_attr('long_name', 'QI Without Forecast') \
+                .write_data(qifn2)
+
+            # Wind Computation Method
+            obsspace.create_var('MetaData/windComputationMethod', dtype=swcm2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Satellite-derived Wind Computation Method') \
+                .write_data(swcm2)
+
+            # Pressure
+            obsspace.create_var('MetaData/pressure', dtype=pressure2.dtype, fillval=pressure2.fill_value) \
+                .write_attr('units', 'pa') \
+                .write_attr('long_name', 'Pressure') \
+                .write_data(pressure2)
+
+            # Height (mimic prepbufr)
+            obsspace.create_var('MetaData/height', dtype=height2.dtype, fillval=height2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Height of Observation') \
+                .write_data(height2)
+
+            # Station Elevation (mimic prepbufr)
+            obsspace.create_var('MetaData/stationElevation', dtype=stnelev2.dtype, fillval=stnelev2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Station Elevation') \
+                .write_data(stnelev2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windEastward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windNorthward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # U-Wind Component
+            obsspace.create_var('ObsValue/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Eastward Wind Component') \
+                .write_data(uob2)
+
+            # V-Wind Component
+            obsspace.create_var('ObsValue/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Northward Wind Component') \
+                .write_data(vob2)
+
+            end_time = time.time()
+            running_time = end_time - start_time
+            total_ob_processed += len(satid2)
+            logger.debug(f'Number of observation processed : {len(satid2)}')
+            logger.debug(f'Processing time for splitting and output IODA for {satinst} : {running_time} seconds')
+
+        else:
+            logger.info(f"Do not find this satellite id in the configuration: satid = {sat}")
+
+    logger.info("All Done!")
+    logger.info(f'Total number of observation processed : {total_ob_processed}')
+
+
+if __name__ == '__main__':
+
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, help='Input JSON configuration', required=True)
+    parser.add_argument('-v', '--verbose', help='print debug logging information',
+                        action='store_true')
+    args = parser.parse_args()
+
+    log_level = 'DEBUG' if args.verbose else 'INFO'
+    logger = Logger('BUFR2IODA_satwind_amv_ahi.py', level=log_level, colored_log=True)
+
+    with open(args.config, "r") as json_file:
+        config = json.load(json_file)
+
+    bufr_to_ioda(config, logger)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Total running time: {running_time} seconds")

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_avhrr.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_avhrr.json
@@ -1,0 +1,16 @@
+{
+  "data_format"      : "bufr_d",
+  "data_type"        : "satwnd",
+  "cycle_datetime"   : "{{ current_cycle | to_YMDH }}",
+  "dump_directory"   : "./",
+  "ioda_directory"   : "./",
+  "subsets"          : [ "NC005080" ],
+  "data_description" : "AVHRR NOAA-15/18/19 IR(LW)",
+  "data_provider"    : "U.S. NOAA/NESDIS",
+  "sensor_info"      : { "sensor_name": "AVHRR",  "sensor_full_name": "Advanced Very High Resolution Radiometer",  "sensor_id": 999 },
+  "satellite_info"   : [
+                          { "satellite_name": "n15", "satellite_full_name": "NOAA-15", "satellite_id": 206, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "n18", "satellite_full_name": "NOAA-18", "satellite_id": 209, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "n19", "satellite_full_name": "NOAA-19", "satellite_id": 223, "launch time": "YYYYMMDD" }
+                      ]
+}

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_avhrr.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_avhrr.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+import numpy.ma as ma
+from pyiodaconv import bufr
+import calendar
+import json
+import time
+import math
+import datetime
+import os
+from datetime import datetime, timezone
+from pyioda import ioda_obs_space as ioda_ospace
+from wxflow import Logger
+
+# ====================================================================
+# Satellite Winds (AMV) BUFR dump file for AVHRR
+# ====================================================================
+# Subset    |  Spectral Band              |  Code (002023) |  ObsType
+# --------------------------------------------------------------------
+# NC005080  |    IRLW  (Freq < 5E+13)     |    Method 1    |   244
+# ====================================================================
+
+# Define and initialize  global variables
+global float32_fill_value
+global int32_fill_value
+global int64_fill_value
+
+float32_fill_value = np.float32(0)
+int32_fill_value = np.int32(0)
+int64_fill_value = np.int64(0)
+
+
+def Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd):
+
+    uob = (-wspd * np.sin(np.radians(wdir))).astype(np.float32)
+    vob = (-wspd * np.cos(np.radians(wdir))).astype(np.float32)
+
+    return uob, vob
+
+
+def Get_ObsType(swcm, chanfreq):
+
+    obstype = swcm.copy()
+
+    # Use numpy vectorized operations
+    obstype = np.where(swcm == 1, 244, obstype)  # IRLW
+
+    if not np.any(np.isin(obstype, [244])):
+        raise ValueError("Error: Unassigned ObsType found ... ")
+
+    return obstype
+
+
+def bufr_to_ioda(config, logger):
+
+    subsets = config["subsets"]
+    logger.debug(f"Checking subsets = {subsets}")
+
+    # Get parameters from configuration
+    subsets = config["subsets"]
+    data_format = config["data_format"]
+    data_type = config["data_type"]
+    data_description = config["data_description"]
+    data_provider = config["data_provider"]
+    #cycle_type = config["cycle_type"]
+    dump_dir = config["dump_directory"]
+    ioda_dir = config["ioda_directory"]
+    cycle = config["cycle_datetime"]
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+
+    satellite_info_array = config["satellite_info"]
+    sensor_name = config["sensor_info"]["sensor_name"]
+    sensor_full_name = config["sensor_info"]["sensor_full_name"]
+    sensor_id = config["sensor_info"]["sensor_id"]
+
+    # Get derived parameters
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+    reference_time = datetime.strptime(cycle, "%Y%m%d%H")
+    reference_time = reference_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # General informaton
+    converter = 'BUFR to IODA Converter'
+    process_level = 'Level-2'
+    platform_description = 'NOAA-15/18/19'
+    sensor_description = 'Advanced Very High Resolution Radiometer'
+
+    logger.info(f'sensor_name = {sensor_name}')
+    logger.info(f'sensor_full_name = {sensor_full_name}')
+    logger.info(f'sensor_id = {sensor_id}')
+    logger.info(f'reference_time = {reference_time}')
+
+    bufrfile = "satwndbufr"
+    DATA_PATH = os.path.join(dump_dir, bufrfile)
+    if not os.path.isfile(DATA_PATH):
+        logger.info(f"DATA_PATH {DATA_PATH} does not exist")
+        return
+    logger.debug(f"The DATA_PATH is: {DATA_PATH}")
+
+    # ============================================
+    # Make the QuerySet for all the data we want
+    # ============================================
+    start_time = time.time()
+
+    logger.info('Making QuerySet')
+    q = bufr.QuerySet(subsets)
+
+    # MetaData
+    q.add('latitude', '*/CLAT')
+    q.add('longitude', '*/CLON')
+    q.add('satelliteId', '*/SAID')
+    q.add('year', '*/YEAR')
+    q.add('month', '*/MNTH')
+    q.add('day', '*/DAYS')
+    q.add('hour', '*/HOUR')
+    q.add('minute', '*/MINU')
+    q.add('second', '*/SECO')
+    q.add('satelliteZenithAngle', '*/SAZA')
+    q.add('sensorCentralFrequency', '*/SCCF')
+    q.add('pressure', '*/PRLC')
+
+    # Processing Center
+    q.add('dataProviderOrigin', '*/OGCE')
+    q.add('windGeneratingApplication', '*/GQCPRMS[1]/GNAP')
+
+#   # Quality Infomation (Quality Indicator w/o forecast)
+    q.add('qualityInformationWithoutForecast', '*/GQCPRMS[1]/PCCF')
+
+    # Wind Retrieval Method Information
+    q.add('windComputationMethod', '*/SWCM')
+
+    # ObsValue
+    q.add('windDirection', '*/WDIR')
+    q.add('windSpeed', '*/WSPD')
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.debug(f'Processing time for making QuerySet : {running_time} seconds')
+
+    # ==============================================================
+    # Open the BUFR file and execute the QuerySet to get ResultSet
+    # Use the ResultSet returned to get numpy arrays of the data
+    # ==============================================================
+    start_time = time.time()
+
+    logger.info('Executing QuerySet to get ResultSet')
+    with bufr.File(DATA_PATH) as f:
+        try:
+            r = f.execute(q)
+        except Exception as err:
+            logger.info(f'Return with {err}')
+            return
+
+    # MetaData
+    satid = r.get('satelliteId')
+    year = r.get('year')
+    month = r.get('month')
+    day = r.get('day')
+    hour = r.get('hour')
+    minute = r.get('minute')
+    second = r.get('second')
+    lat = r.get('latitude')
+    lon = r.get('longitude')
+    satzenang = r.get('satelliteZenithAngle')
+    pressure = r.get('pressure', type='float')
+    chanfreq = r.get('sensorCentralFrequency', type='float')
+
+    # Processing Center
+    ogce = r.get('dataProviderOrigin')
+    ga = r.get('windGeneratingApplication')
+
+    # Quality Information
+    qi = r.get('qualityInformationWithoutForecast', type='float')
+    # For NOAA-15/18/19 AVHRR data, qi w/o forecast (qifn) is packaged in same
+    # vector of qi with ga = 1 (EUMETSAT QI without forecast), and EE is
+    # packaged in same vector of qi with ga=4 (Estimated Error (EE) in m/s
+    # converted to a percent confidence)shape (4,nobs). Must conduct a
+    # search and extract the correct vector for gnap and qi
+    # 1. Find dimension-sizes of ga and qi (should be the same!)
+    gDim1, gDim2 = np.shape(ga)
+    qDim1, qDim2 = np.shape(qi)
+    logger.info(f'Generating Application and Quality Information SEARCH:')
+    logger.info(f'Dimension size of GNAP ({gDim1},{gDim2})')
+    logger.info(f'Dimension size of PCCF ({qDim1},{qDim2})')
+    # 2. Initialize gnap and qifn as None, and search for dimension of
+    #    ga with values of 1. If the same column exists for qi, assign
+    #    gnap to ga[:,i] and qifn to qi[:,i], else raise warning that no
+    #    appropriate GNAP/PCCF combination was found
+    gnap = None
+    qifn = None
+    for i in range(gDim2):
+        if np.unique(ga[:, i].squeeze()) == 1:
+            if i <= qDim2:
+                logger.info(f'GNAP/PCCF found for column {i}')
+                gnap = ga[:, i].squeeze()
+                qifn = qi[:, i].squeeze()
+            else:
+                logger.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')
+    if (gnap is None) & (qifn is None):
+        logger.info(f'ERROR: GNAP == 1 NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
+    # If EE is needed, key search on np.unique(ga[:,i].squeeze()) == 4 instead
+
+    # Wind Retrieval Method Information
+    swcm = r.get('windComputationMethod')
+
+    # ObsValue
+    # Wind direction and Speed
+    wdir = r.get('windDirection', type='float')
+    wspd = r.get('windSpeed')
+
+    # DateTime: seconds since Epoch time
+    # IODA has no support for numpy datetime arrays dtype=datetime64[s]
+    timestamp = r.get_datetime('year', 'month', 'day', 'hour', 'minute', 'second').astype(np.int64)
+
+    ref_dt  = datetime.fromisoformat(reference_time.replace("Z", "+00:00"))
+    ref_sec = ref_dt.replace(tzinfo=timezone.utc).timestamp()
+    toff = ma.MaskedArray((timestamp.data - ref_sec).astype(np.float32), mask=timestamp.mask)
+    # Check BUFR variable generic dimension and type
+
+    # Global variables declaration
+    # Set global fill values
+    float32_fill_value = satzenang.fill_value
+    int32_fill_value = satid.fill_value
+    int64_fill_value = timestamp.fill_value.astype(np.int64)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for executing QuerySet to get ResultSet : {running_time} seconds')
+
+    # =========================
+    # Create derived variables
+    # =========================
+    start_time = time.time()
+
+    logger.info('Creating derived variables')
+    logger.debug('Creating derived variables - wind components (uob and vob)')
+
+    uob, vob = Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd)
+
+    logger.debug(f'   uob min/max = {uob.min()} {uob.max()}')
+    logger.debug(f'   vob min/max = {vob.min()} {vob.max()}')
+
+    obstype = Get_ObsType(swcm, chanfreq)
+
+    height = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+    stnelev = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for creating derived variables : {running_time} seconds')
+
+    # =====================================
+    # Split output based on satellite id
+    # Create IODA ObsSpace
+    # Write IODA output
+    # =====================================
+    logger.info('Create IODA ObsSpace and Write IODA output based on satellite ID')
+
+    # Find unique satellite identifiers in data to process
+    unique_satids = np.unique(satid)
+    logger.info(f'Number of Unique satellite identifiers: {len(unique_satids)}')
+    logger.info(f'Unique satellite identifiers: {unique_satids}')
+
+    logger.debug(f'Loop through unique satellite identifier {unique_satids}')
+    total_ob_processed = 0
+    for sat in unique_satids.tolist():
+        start_time = time.time()
+
+        matched = False
+        for satellite_info in satellite_info_array:
+            if (satellite_info["satellite_id"] == sat):
+                matched = True
+                satellite_id = satellite_info["satellite_id"]
+                satellite_name = satellite_info["satellite_name"]
+                satinst = sensor_name.lower()+'_'+satellite_name.lower()
+                logger.debug(f'Split data for {satinst} satid = {sat}')
+
+        if matched:
+
+            # Define a boolean mask to subset data from the original data object
+            mask = satid == sat
+            # MetaData
+            lon2 = lon[mask]
+            lat2 = lat[mask]
+            timestamp2 = timestamp[mask]
+            satid2 = satid[mask]
+            satzenang2 = satzenang[mask]
+            chanfreq2 = chanfreq[mask]
+            obstype2 = obstype[mask]
+            pressure2 = pressure[mask]
+            height2 = height[mask]
+            stnelev2 = stnelev[mask]
+
+            # Processing Center
+            ogce2 = ogce[mask]
+
+            # QC Info
+            qifn2 = qifn[mask]
+
+            # Method
+            swcm2 = swcm[mask]
+
+            # ObsValue
+            wdir2 = wdir[mask]
+            wspd2 = wspd[mask]
+            uob2 = uob[mask]
+            vob2 = vob[mask]
+
+            # Timestamp Range
+            timestamp2_min = datetime.fromtimestamp(timestamp2.min())
+            timestamp2_max = datetime.fromtimestamp(timestamp2.max())
+
+            # Check unique observation time
+            unique_timestamp2 = np.unique(timestamp2)
+            logger.debug(f'Processing output for satid {sat}')
+
+            # Create the dimensions
+            dims = {
+                'Location': np.arange(0, wdir2.shape[0])
+            }
+
+            # Create IODA ObsSpace
+            iodafile = f"ioda_{data_type}.{satinst}.nc"
+            OUTPUT_PATH = os.path.join(ioda_dir, iodafile)
+            logger.info(f'Create output file : {OUTPUT_PATH}')
+            obsspace = ioda_ospace.ObsSpace(OUTPUT_PATH, mode='w', dim_dict=dims)
+
+            # Create Global attributes
+            logger.debug('Write global attributes')
+            obsspace.write_attr('Converter', converter)
+            obsspace.write_attr('sourceFiles', bufrfile)
+            obsspace.write_attr('dataProviderOrigin', data_provider)
+            obsspace.write_attr('description', data_description)
+            obsspace.write_attr('datetimeReference', reference_time)
+            obsspace.write_attr('datetimeRange', [str(timestamp2_min), str(timestamp2_max)])
+            obsspace.write_attr('sensor', sensor_id)
+            obsspace.write_attr('platform', satellite_id)
+            obsspace.write_attr('platformCommonName', satellite_name)
+            obsspace.write_attr('sensorCommonName', sensor_name)
+            obsspace.write_attr('processingLevel', process_level)
+            obsspace.write_attr('platformLongDescription', platform_description)
+            obsspace.write_attr('sensorLongDescription', sensor_description)
+
+            # Create IODA variables
+            logger.debug('Write variables: name, type, units, and attributes')
+            # Longitude
+            obsspace.create_var('MetaData/longitude', dtype=lon2.dtype, fillval=lon2.fill_value) \
+                .write_attr('units', 'degrees_east') \
+                .write_attr('valid_range', np.array([-180, 180], dtype=np.float32)) \
+                .write_attr('long_name', 'Longitude') \
+                .write_data(lon2)
+
+            # Latitude
+            obsspace.create_var('MetaData/latitude', dtype=lat.dtype, fillval=lat2.fill_value) \
+                .write_attr('units', 'degrees_north') \
+                .write_attr('valid_range', np.array([-90, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Latitude') \
+                .write_data(lat2)
+
+            # Datetime
+            obsspace.create_var('MetaData/dateTime', dtype=np.int64, fillval=int64_fill_value) \
+                .write_attr('units', 'seconds since 1970-01-01T00:00:00Z') \
+                .write_attr('long_name', 'Datetime') \
+                .write_data(timestamp2)
+
+            # Time variable
+            obsspace.create_var('MetaData/timeOffset', dtype=toff.dtype, fillval=toff.fill_value) \
+                .write_attr('units', 's') \
+                .write_attr('long_name', 'Observation Time Minus Reference Time') \
+                .write_data(toff)
+
+            # Satellite Identifier
+            obsspace.create_var('MetaData/satelliteIdentifier', dtype=satid2.dtype, fillval=satid2.fill_value) \
+                .write_attr('long_name', 'Satellite Identifier') \
+                .write_data(satid2)
+
+            # Sensor Zenith Angle
+            obsspace.create_var('MetaData/satelliteZenithAngle', dtype=satzenang2.dtype, fillval=satzenang2.fill_value) \
+                .write_attr('units', 'degree') \
+                .write_attr('valid_range', np.array([0, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Satellite Zenith Angle') \
+                .write_data(satzenang2)
+
+            # Sensor Centrall Frequency
+            obsspace.create_var('MetaData/sensorCentralFrequency', dtype=chanfreq2.dtype, fillval=chanfreq2.fill_value) \
+                .write_attr('units', 'Hz') \
+                .write_attr('long_name', 'Satellite Channel Center Frequency') \
+                .write_data(chanfreq2)
+
+            # Data Provider
+            obsspace.create_var('MetaData/dataProviderOrigin', dtype=ogce2.dtype, fillval=ogce2.fill_value) \
+                .write_attr('long_name', 'Identification of Originating/Generating Center') \
+                .write_data(ogce2)
+
+            # Quality: Percent Confidence - Quality Information Without Forecast
+            obsspace.create_var('MetaData/qiWithoutForecast', dtype=qifn2.dtype, fillval=qifn2.fill_value) \
+                .write_attr('long_name', 'QI Without Forecast') \
+                .write_data(qifn2)
+
+            # Wind Computation Method
+            obsspace.create_var('MetaData/windComputationMethod', dtype=swcm2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Satellite-derived Wind Computation Method') \
+                .write_data(swcm2)
+
+            # Pressure
+            obsspace.create_var('MetaData/pressure', dtype=pressure2.dtype, fillval=pressure2.fill_value) \
+                .write_attr('units', 'pa') \
+                .write_attr('long_name', 'Pressure') \
+                .write_data(pressure2)
+
+            # Height (mimic prepbufr)
+            obsspace.create_var('MetaData/height', dtype=height2.dtype, fillval=height2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Height of Observation') \
+                .write_data(height2)
+
+            # Station Elevation (mimic prepbufr)
+            obsspace.create_var('MetaData/stationElevation', dtype=stnelev2.dtype, fillval=stnelev2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Station Elevation') \
+                .write_data(stnelev2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windEastward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windNorthward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # U-Wind Component
+            obsspace.create_var('ObsValue/windEastward', dtype=uob2.dtype, fillval=uob2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Eastward Wind Component') \
+                .write_data(uob2)
+
+            # V-Wind Component
+            obsspace.create_var('ObsValue/windNorthward', dtype=vob2.dtype, fillval=vob2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Northward Wind Component') \
+                .write_data(vob2)
+
+            end_time = time.time()
+            running_time = end_time - start_time
+            total_ob_processed += len(satid2)
+            logger.debug(f'Number of observation processed : {len(satid2)}')
+            logger.debug(f'Processing time for splitting and output IODA for {satinst} : {running_time} seconds')
+
+        else:
+            logger.info(f"Do not find this satellite id in the configuration: satid = {sat}")
+
+    logger.info("All Done!")
+    logger.info(f'Total number of observation processed : {total_ob_processed}')
+
+
+if __name__ == '__main__':
+
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, help='Input JSON configuration', required=True)
+    parser.add_argument('-v', '--verbose', help='print debug logging information',
+                        action='store_true')
+    args = parser.parse_args()
+
+    log_level = 'DEBUG' if args.verbose else 'INFO'
+    logger = Logger('BUFR2IODA_satwind_amv_ahi.py', level=log_level, colored_log=True)
+
+    with open(args.config, "r") as json_file:
+        config = json.load(json_file)
+
+    bufr_to_ioda(config, logger)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Total running time: {running_time} seconds")

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_goes.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_goes.json
@@ -11,6 +11,7 @@
   "satellite_info"   : [
                           { "satellite_name": "GOES-16", "satellite_full_name": "Geostationary Operational Satellite - 16", "satellite_id": 270, "launch time": "20161119" },
                           { "satellite_name": "GOES-17", "satellite_full_name": "Geostationary Operational Satellite - 17", "satellite_id": 271, "launch time": "20180301" },
-                          { "satellite_name": "GOES-18", "satellite_full_name": "Geostationary Operational Satellite - 18", "satellite_id": 272, "launch time": "20220301" }
+                          { "satellite_name": "GOES-18", "satellite_full_name": "Geostationary Operational Satellite - 18", "satellite_id": 272, "launch time": "20220301" },
+                          { "satellite_name": "GOES-19", "satellite_full_name": "Geostationary Operational Satellite - 19", "satellite_id": 273, "launch time": "20240625" }
                        ]
 }

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_leogeo.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_leogeo.json
@@ -1,0 +1,14 @@
+{
+  "data_format"      : "bufr_d",
+  "data_type"        : "satwnd",
+  "cycle_datetime"   : "{{ current_cycle | to_YMDH }}",
+  "dump_directory"   : "./",
+  "ioda_directory"   : "./",
+  "subsets"          : [ "NC005072" ],
+  "data_description" : "NC005072 LEOGEO SATWIND IR(LW)",
+  "data_provider"    : "U.S. NOAA/NESDIS",
+  "sensor_info"      : { "sensor_name": "LEOGEO",  "sensor_full_name": "Combined Platform LEO/GEO",  "sensor_id": 999 },
+  "satellite_info"   : [
+                          { "satellite_name": "multi", "satellite_full_name": "MULTIPLE-SATS", "satellite_id": 854, "launch time": "YYYYMMDD" }
+                      ]
+}

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_leogeo.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_leogeo.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+import numpy.ma as ma
+from pyiodaconv import bufr
+import calendar
+import json
+import time
+import math
+import datetime
+import os
+from datetime import datetime, timezone
+from pyioda import ioda_obs_space as ioda_ospace
+from wxflow import Logger
+
+# ====================================================================
+# Satellite Winds (AMV) BUFR dump file for multi-satellite LEOGEO
+# ====================================================================
+# Subset    |  Spectral Band              |  Code (002023) |  ObsType
+# --------------------------------------------------------------------
+# NC005072  |    IRLW  (Freq < 5E+13)     |    Method 1    |   255
+# ====================================================================
+
+# Define and initialize  global variables
+global float32_fill_value
+global int32_fill_value
+global int64_fill_value
+
+float32_fill_value = np.float32(0)
+int32_fill_value = np.int32(0)
+int64_fill_value = np.int64(0)
+
+
+def Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd):
+
+    uob = (-wspd * np.sin(np.radians(wdir))).astype(np.float32)
+    vob = (-wspd * np.cos(np.radians(wdir))).astype(np.float32)
+
+    return uob, vob
+
+
+def Get_ObsType(swcm, chanfreq):
+
+    obstype = swcm.copy()
+
+    # Use numpy vectorized operations
+    obstype = np.where(swcm == 1, 255, obstype)  # IRLW
+
+    if not np.any(np.isin(obstype, [255])):
+        raise ValueError("Error: Unassigned ObsType found ... ")
+
+    return obstype
+
+
+def bufr_to_ioda(config, logger):
+
+    subsets = config["subsets"]
+    logger.debug(f"Checking subsets = {subsets}")
+
+    # Get parameters from configuration
+    subsets = config["subsets"]
+    data_format = config["data_format"]
+    data_type = config["data_type"]
+    data_description = config["data_description"]
+    data_provider = config["data_provider"]
+    #cycle_type = config["cycle_type"]
+    dump_dir = config["dump_directory"]
+    ioda_dir = config["ioda_directory"]
+    cycle = config["cycle_datetime"]
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+
+    satellite_info_array = config["satellite_info"]
+    sensor_name = config["sensor_info"]["sensor_name"]
+    sensor_full_name = config["sensor_info"]["sensor_full_name"]
+    sensor_id = config["sensor_info"]["sensor_id"]
+
+    # Get derived parameters
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+    reference_time = datetime.strptime(cycle, "%Y%m%d%H")
+    reference_time = reference_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # General informaton
+    converter = 'BUFR to IODA Converter'
+    process_level = 'Level-2'
+    platform_description = 'TERRA/AQUA'
+    sensor_description = 'Moderate Resolution Imaging Spectroradiometer'
+
+    logger.info(f'sensor_name = {sensor_name}')
+    logger.info(f'sensor_full_name = {sensor_full_name}')
+    logger.info(f'sensor_id = {sensor_id}')
+    logger.info(f'reference_time = {reference_time}')
+
+    bufrfile = "satwndbufr"
+    DATA_PATH = os.path.join(dump_dir, bufrfile)
+    if not os.path.isfile(DATA_PATH):
+        logger.info(f"DATA_PATH {DATA_PATH} does not exist")
+        return
+    logger.debug(f"The DATA_PATH is: {DATA_PATH}")
+
+    # ============================================
+    # Make the QuerySet for all the data we want
+    # ============================================
+    start_time = time.time()
+
+    logger.info('Making QuerySet')
+    q = bufr.QuerySet(subsets)
+
+    # MetaData
+    q.add('latitude', '*/CLATH')
+    q.add('longitude', '*/CLONH')
+    q.add('satelliteId', '*/SAID')
+    q.add('year', '*/YEAR')
+    q.add('month', '*/MNTH')
+    q.add('day', '*/DAYS')
+    q.add('hour', '*/HOUR')
+    q.add('minute', '*/MINU')
+    q.add('second', '*/SECO')
+    q.add('satelliteZenithAngle', '*/SAZA')
+    q.add('sensorCentralFrequency', '*/SCCF')
+    q.add('pressure', '*/PRLC[1]')
+
+    # Processing Center
+    # GCLONG takes place of OGCE in this subset
+    q.add('dataProviderOrigin', '*/GCLONG')
+    # There are 3 replications of GNAP, GNAP[1] appears to have values of 1 == EUMETSAT QI without forecast
+    q.add('windGeneratingApplication', 'GNAP[1]')
+
+    # Quality Infomation (Quality Indicator w/o forecast)
+    # There are 3 replications of PCCF, PCCF[1] corresponds to GNAP[1] == EUMETSAT QI without forecast
+    q.add('qualityInformationWithoutForecast', '*/LGRSQ4[1]/PCCF')
+
+    # Wind Retrieval Method Information
+    q.add('windComputationMethod', '*/SWCM')
+
+    # ObsValue
+    q.add('windDirection', '*/WDIR')
+    q.add('windSpeed', '*/WSPD')
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.debug(f'Processing time for making QuerySet : {running_time} seconds')
+
+    # ==============================================================
+    # Open the BUFR file and execute the QuerySet to get ResultSet
+    # Use the ResultSet returned to get numpy arrays of the data
+    # ==============================================================
+    start_time = time.time()
+
+    logger.info('Executing QuerySet to get ResultSet')
+    with bufr.File(DATA_PATH) as f:
+        try:
+            r = f.execute(q)
+        except Exception as err:
+            logger.info(f'Return with {err}')
+            return
+
+    # MetaData
+    satid = r.get('satelliteId')
+    year = r.get('year')
+    month = r.get('month')
+    day = r.get('day')
+    hour = r.get('hour')
+    minute = r.get('minute')
+    second = r.get('second')
+    lat = r.get('latitude')
+    lon = r.get('longitude')
+    satzenang = r.get('satelliteZenithAngle')
+    pressure = r.get('pressure', type='float')
+    chanfreq = r.get('sensorCentralFrequency', type='float')
+
+    # Processing Center
+    ogce = r.get('dataProviderOrigin')  # drawn from GLONGC mnemonic, but OGCE == GLONGC
+    gnap = r.get('windGeneratingApplication')
+
+    # Quality Information
+    qifn = r.get('qualityInformationWithoutForecast', type='float')
+
+    # Wind Retrieval Method Information
+    swcm = r.get('windComputationMethod')
+
+    # ObsValue
+    # Wind direction and Speed
+    wdir = r.get('windDirection', type='float')
+    wspd = r.get('windSpeed')
+
+    # DateTime: seconds since Epoch time
+    # IODA has no support for numpy datetime arrays dtype=datetime64[s]
+    timestamp = r.get_datetime('year', 'month', 'day', 'hour', 'minute', 'second').astype(np.int64)
+
+    # Check BUFR variable generic dimension and type
+
+    # Global variables declaration
+    # Set global fill values
+    float32_fill_value = satzenang.fill_value
+    int32_fill_value = satid.fill_value
+    int64_fill_value = timestamp.fill_value.astype(np.int64)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for executing QuerySet to get ResultSet : {running_time} seconds')
+
+    # =========================
+    # Create derived variables
+    # =========================
+    start_time = time.time()
+
+    logger.info('Creating derived variables')
+    logger.debug('Creating derived variables - wind components (uob and vob)')
+
+    uob, vob = Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd)
+
+    logger.debug(f'   uob min/max = {uob.min()} {uob.max()}')
+    logger.debug(f'   vob min/max = {vob.min()} {vob.max()}')
+
+    obstype = Get_ObsType(swcm, chanfreq)
+
+    height = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+    stnelev = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for creating derived variables : {running_time} seconds')
+
+    # =====================================
+    # Split output based on satellite id
+    # Create IODA ObsSpace
+    # Write IODA output
+    # =====================================
+    logger.info('Create IODA ObsSpace and Write IODA output based on satellite ID')
+
+    # Find unique satellite identifiers in data to process
+    unique_satids = np.unique(satid)
+    logger.info(f'Number of Unique satellite identifiers: {len(unique_satids)}')
+    logger.info(f'Unique satellite identifiers: {unique_satids}')
+
+    logger.debug(f'Loop through unique satellite identifier {unique_satids}')
+    total_ob_processed = 0
+    for sat in unique_satids.tolist():
+        start_time = time.time()
+
+        matched = False
+        for satellite_info in satellite_info_array:
+            if (satellite_info["satellite_id"] == sat):
+                matched = True
+                satellite_id = satellite_info["satellite_id"]
+                satellite_name = satellite_info["satellite_name"]
+                satinst = sensor_name.lower()+'_'+satellite_name.lower()
+                logger.debug(f'Split data for {satinst} satid = {sat}')
+
+        if matched:
+
+            # Define a boolean mask to subset data from the original data object
+            mask = satid == sat
+            # MetaData
+            lon2 = lon[mask]
+            lat2 = lat[mask]
+            timestamp2 = timestamp[mask]
+            satid2 = satid[mask]
+            satzenang2 = satzenang[mask]
+            chanfreq2 = chanfreq[mask]
+            obstype2 = obstype[mask]
+            pressure2 = pressure[mask]
+            height2 = height[mask]
+            stnelev2 = stnelev[mask]
+
+            # Processing Center
+            ogce2 = ogce[mask]
+
+            # QC Info
+            qifn2 = qifn[mask]
+
+            # Method
+            swcm2 = swcm[mask]
+
+            # ObsValue
+            wdir2 = wdir[mask]
+            wspd2 = wspd[mask]
+            uob2 = uob[mask]
+            vob2 = vob[mask]
+
+            # Timestamp Range
+            timestamp2_min = datetime.fromtimestamp(timestamp2.min())
+            timestamp2_max = datetime.fromtimestamp(timestamp2.max())
+
+            # Check unique observation time
+            unique_timestamp2 = np.unique(timestamp2)
+            logger.debug(f'Processing output for satid {sat}')
+
+            # Create the dimensions
+            dims = {
+                'Location': np.arange(0, wdir2.shape[0])
+            }
+
+            # Create IODA ObsSpace
+            iodafile = f"ioda_{data_type}.{satinst}.nc"
+            OUTPUT_PATH = os.path.join(ioda_dir, iodafile)
+            logger.info(f'Create output file : {OUTPUT_PATH}')
+            obsspace = ioda_ospace.ObsSpace(OUTPUT_PATH, mode='w', dim_dict=dims)
+
+            # Create Global attributes
+            logger.debug('Write global attributes')
+            obsspace.write_attr('Converter', converter)
+            obsspace.write_attr('sourceFiles', bufrfile)
+            obsspace.write_attr('dataProviderOrigin', data_provider)
+            obsspace.write_attr('description', data_description)
+            obsspace.write_attr('datetimeReference', reference_time)
+            obsspace.write_attr('datetimeRange', [str(timestamp2_min), str(timestamp2_max)])
+            obsspace.write_attr('sensor', sensor_id)
+            obsspace.write_attr('platform', satellite_id)
+            obsspace.write_attr('platformCommonName', satellite_name)
+            obsspace.write_attr('sensorCommonName', sensor_name)
+            obsspace.write_attr('processingLevel', process_level)
+            obsspace.write_attr('platformLongDescription', platform_description)
+            obsspace.write_attr('sensorLongDescription', sensor_description)
+
+            # Create IODA variables
+            logger.debug('Write variables: name, type, units, and attributes')
+            # Longitude
+            obsspace.create_var('MetaData/longitude', dtype=lon2.dtype, fillval=lon2.fill_value) \
+                .write_attr('units', 'degrees_east') \
+                .write_attr('valid_range', np.array([-180, 180], dtype=np.float32)) \
+                .write_attr('long_name', 'Longitude') \
+                .write_data(lon2)
+
+            # Latitude
+            obsspace.create_var('MetaData/latitude', dtype=lat.dtype, fillval=lat2.fill_value) \
+                .write_attr('units', 'degrees_north') \
+                .write_attr('valid_range', np.array([-90, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Latitude') \
+                .write_data(lat2)
+
+            # Datetime
+            obsspace.create_var('MetaData/dateTime', dtype=np.int64, fillval=int64_fill_value) \
+                .write_attr('units', 'seconds since 1970-01-01T00:00:00Z') \
+                .write_attr('long_name', 'Datetime') \
+                .write_data(timestamp2)
+
+            # Time variable
+            obsspace.create_var('MetaData/timeOffset', dtype=toff.dtype, fillval=toff.fill_value) \
+                .write_attr('units', 's') \
+                .write_attr('long_name', 'Observation Time Minus Reference Time') \
+                .write_data(toff)
+
+            # Satellite Identifier
+            obsspace.create_var('MetaData/satelliteIdentifier', dtype=satid2.dtype, fillval=satid2.fill_value) \
+                .write_attr('long_name', 'Satellite Identifier') \
+                .write_data(satid2)
+
+            # Sensor Zenith Angle
+            obsspace.create_var('MetaData/satelliteZenithAngle', dtype=satzenang2.dtype, fillval=satzenang2.fill_value) \
+                .write_attr('units', 'degree') \
+                .write_attr('valid_range', np.array([0, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Satellite Zenith Angle') \
+                .write_data(satzenang2)
+
+            # Sensor Centrall Frequency
+            obsspace.create_var('MetaData/sensorCentralFrequency', dtype=chanfreq2.dtype, fillval=chanfreq2.fill_value) \
+                .write_attr('units', 'Hz') \
+                .write_attr('long_name', 'Satellite Channel Center Frequency') \
+                .write_data(chanfreq2)
+
+            # Data Provider
+            obsspace.create_var('MetaData/dataProviderOrigin', dtype=ogce2.dtype, fillval=ogce2.fill_value) \
+                .write_attr('long_name', 'Identification of Originating/Generating Center') \
+                .write_data(ogce2)
+
+            # Quality: Percent Confidence - Quality Information Without Forecast
+            obsspace.create_var('MetaData/qiWithoutForecast', dtype=qifn2.dtype, fillval=qifn2.fill_value) \
+                .write_attr('long_name', 'Quality Information Without Forecast') \
+                .write_data(qifn2)
+
+            # Wind Computation Method
+            obsspace.create_var('MetaData/windComputationMethod', dtype=swcm2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Satellite-derived Wind Computation Method') \
+                .write_data(swcm2)
+
+            # Pressure
+            obsspace.create_var('MetaData/pressure', dtype=pressure2.dtype, fillval=pressure2.fill_value) \
+                .write_attr('units', 'pa') \
+                .write_attr('long_name', 'Pressure') \
+                .write_data(pressure2)
+
+            # Height (mimic prepbufr)
+            obsspace.create_var('MetaData/height', dtype=height2.dtype, fillval=height2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Height of Observation') \
+                .write_data(height2)
+
+            # Station Elevation (mimic prepbufr)
+            obsspace.create_var('MetaData/stationElevation', dtype=stnelev2.dtype, fillval=stnelev2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Station Elevation') \
+                .write_data(stnelev2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windEastward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windNorthward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # U-Wind Component
+            obsspace.create_var('ObsValue/windEastward', dtype=uob2.dtype, fillval=uob2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Eastward Wind Component') \
+                .write_data(uob2)
+
+            # V-Wind Component
+            obsspace.create_var('ObsValue/windNorthward', dtype=vob2.dtype, fillval=vob2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Northward Wind Component') \
+                .write_data(vob2)
+
+            end_time = time.time()
+            running_time = end_time - start_time
+            total_ob_processed += len(satid2)
+            logger.debug(f'Number of observation processed : {len(satid2)}')
+            logger.debug(f'Processing time for splitting and output IODA for {satinst} : {running_time} seconds')
+
+        else:
+            logger.info(f"Do not find this satellite id in the configuration: satid = {sat}")
+
+    logger.info("All Done!")
+    logger.info(f'Total number of observation processed : {total_ob_processed}')
+
+
+if __name__ == '__main__':
+
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, help='Input JSON configuration', required=True)
+    parser.add_argument('-v', '--verbose', help='print debug logging information',
+                        action='store_true')
+    args = parser.parse_args()
+
+    log_level = 'DEBUG' if args.verbose else 'INFO'
+    logger = Logger('BUFR2IODA_satwind_amv_ahi.py', level=log_level, colored_log=True)
+
+    with open(args.config, "r") as json_file:
+        config = json.load(json_file)
+
+    bufr_to_ioda(config, logger)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Total running time: {running_time} seconds")

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_modis.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_modis.json
@@ -1,0 +1,15 @@
+{
+  "data_format"      : "bufr_d",
+  "data_type"        : "satwnd",
+  "cycle_datetime"   : "{{ current_cycle | to_YMDH }}",
+  "dump_directory"   : "./",
+  "ioda_directory"   : "./",
+  "subsets"          : [ "NC005070", "NC005071" ],
+  "data_description" : "NC005070 AQUA/TERRA SATWIND MODIS IR(LW); NC005071 AQUA/TERRA SATWIND MODIS WVCT, WVDL",
+  "data_provider"    : "U.S. NOAA/NESDIS",
+  "sensor_info"      : { "sensor_name": "MODIS",  "sensor_full_name": "Moderate Resolution Imaging Spectroradiometer",  "sensor_id": 999 },
+  "satellite_info"   : [
+                          { "satellite_name": "terra", "satellite_full_name": "TERRA", "satellite_id": 783, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "aqua", "satellite_full_name": "AQUA", "satellite_id": 784, "launch time": "YYYYMMDD" }
+                      ]
+}

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_modis.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_modis.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+import numpy.ma as ma
+from pyiodaconv import bufr
+import calendar
+import json
+import time
+import math
+import datetime
+import os
+from datetime import datetime, timezone
+from pyioda import ioda_obs_space as ioda_ospace
+from wxflow import Logger
+
+# ====================================================================
+# Satellite Winds (AMV) BUFR dump file for MODIS/TERRA,AQUA
+# ====================================================================
+# Subset    |  Spectral Band              |  Code (002023) |  ObsType
+# --------------------------------------------------------------------
+# NC005070  |    IRLW  (Freq < 5E+13)     |    Method 1    |   257
+# NC005071  |    WV Cloud Top             |    Method 3    |   258
+#           |    WV Clear Sky/ Deep Layer |    Method 5    |   259
+# ====================================================================
+
+# Define and initialize  global variables
+global float32_fill_value
+global int32_fill_value
+global int64_fill_value
+
+float32_fill_value = np.float32(0)
+int32_fill_value = np.int32(0)
+int64_fill_value = np.int64(0)
+
+
+def Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd):
+
+    uob = (-wspd * np.sin(np.radians(wdir))).astype(np.float32)
+    vob = (-wspd * np.cos(np.radians(wdir))).astype(np.float32)
+
+    return uob, vob
+
+
+def Get_ObsType(swcm, chanfreq):
+
+    obstype = swcm.copy()
+
+    # Use numpy vectorized operations
+    obstype = np.where(swcm == 1, 257, obstype)  # IRLW
+    obstype = np.where(swcm == 3, 258, obstype)  # WVCT
+    obstype = np.where(swcm >= 4, 259, obstype)  # WVDL
+
+    if not np.any(np.isin(obstype, [257, 258, 259])):
+        raise ValueError("Error: Unassigned ObsType found ... ")
+
+    return obstype
+
+
+def bufr_to_ioda(config, logger):
+
+    subsets = config["subsets"]
+    logger.debug(f"Checking subsets = {subsets}")
+
+    # Get parameters from configuration
+    subsets = config["subsets"]
+    data_format = config["data_format"]
+    data_type = config["data_type"]
+    data_description = config["data_description"]
+    data_provider = config["data_provider"]
+    #cycle_type = config["cycle_type"]
+    dump_dir = config["dump_directory"]
+    ioda_dir = config["ioda_directory"]
+    cycle = config["cycle_datetime"]
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+
+    satellite_info_array = config["satellite_info"]
+    sensor_name = config["sensor_info"]["sensor_name"]
+    sensor_full_name = config["sensor_info"]["sensor_full_name"]
+    sensor_id = config["sensor_info"]["sensor_id"]
+
+    # Get derived parameters
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+    reference_time = datetime.strptime(cycle, "%Y%m%d%H")
+    reference_time = reference_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # General informaton
+    converter = 'BUFR to IODA Converter'
+    process_level = 'Level-2'
+    platform_description = 'TERRA/AQUA'
+    sensor_description = 'Moderate Resolution Imaging Spectroradiometer'
+
+    logger.info(f'sensor_name = {sensor_name}')
+    logger.info(f'sensor_full_name = {sensor_full_name}')
+    logger.info(f'sensor_id = {sensor_id}')
+    logger.info(f'reference_time = {reference_time}')
+
+    bufrfile = "satwndbufr"
+    DATA_PATH = os.path.join(dump_dir, bufrfile)
+    if not os.path.isfile(DATA_PATH):
+        logger.info(f"DATA_PATH {DATA_PATH} does not exist")
+        return
+    logger.debug(f"The DATA_PATH is: {DATA_PATH}")
+
+    # ============================================
+    # Make the QuerySet for all the data we want
+    # ============================================
+    start_time = time.time()
+
+    logger.info('Making QuerySet')
+    q = bufr.QuerySet(subsets)
+
+    # MetaData
+    q.add('latitude', '*/CLAT')
+    q.add('longitude', '*/CLON')
+    q.add('satelliteId', '*/SAID')
+    q.add('year', '*/YEAR')
+    q.add('month', '*/MNTH')
+    q.add('day', '*/DAYS')
+    q.add('hour', '*/HOUR')
+    q.add('minute', '*/MINU')
+    q.add('second', '*/SECO')
+    q.add('satelliteZenithAngle', '*/SAZA')
+    q.add('sensorCentralFrequency', '*/SCCF')
+    q.add('pressure', '*/PRLC')
+
+    # Processing Center
+    q.add('dataProviderOrigin', '*/OGCE')
+    q.add('windGeneratingApplication', '*/GQCPRMS[1]/GNAP')
+
+#   # Quality Infomation (Quality Indicator w/o forecast)
+    q.add('qualityInformationWithoutForecast', '*/GQCPRMS[1]/PCCF')
+
+    # Wind Retrieval Method Information
+    q.add('windComputationMethod', '*/SWCM')
+
+    # ObsValue
+    q.add('windDirection', '*/WDIR')
+    q.add('windSpeed', '*/WSPD')
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.debug(f'Processing time for making QuerySet : {running_time} seconds')
+
+    # ==============================================================
+    # Open the BUFR file and execute the QuerySet to get ResultSet
+    # Use the ResultSet returned to get numpy arrays of the data
+    # ==============================================================
+    start_time = time.time()
+
+    logger.info('Executing QuerySet to get ResultSet')
+    with bufr.File(DATA_PATH) as f:
+        try:
+            r = f.execute(q)
+        except Exception as err:
+            logger.info(f'Return with {err}')
+            return
+
+    # MetaData
+    satid = r.get('satelliteId')
+    year = r.get('year')
+    month = r.get('month')
+    day = r.get('day')
+    hour = r.get('hour')
+    minute = r.get('minute')
+    second = r.get('second')
+    lat = r.get('latitude')
+    lon = r.get('longitude')
+    satzenang = r.get('satelliteZenithAngle')
+    pressure = r.get('pressure', type='float')
+    chanfreq = r.get('sensorCentralFrequency', type='float')
+
+    # Processing Center
+    ogce = r.get('dataProviderOrigin')
+    ga = r.get('windGeneratingApplication')
+
+    # Quality Information
+    qi = r.get('qualityInformationWithoutForecast', type='float')
+    # For TERRA/AQUA MODIS data, qi w/o forecast (qifn) is packaged in same
+    # vector of qi with ga = 1 (EUMETSAT QI without forecast), and EE is
+    # packaged in same vector of qi with ga=4 (Estimated Error (EE) in m/s
+    # converted to a percent confidence)shape (4,nobs). Must conduct a
+    # search and extract the correct vector for gnap and qi
+    # 1. Find dimension-sizes of ga and qi (should be the same!)
+    gDim1, gDim2 = np.shape(ga)
+    qDim1, qDim2 = np.shape(qi)
+    logger.info(f'Generating Application and Quality Information SEARCH:')
+    logger.info(f'Dimension size of GNAP ({gDim1},{gDim2})')
+    logger.info(f'Dimension size of PCCF ({qDim1},{qDim2})')
+    # 2. Initialize gnap and qifn as None, and search for dimension of
+    #    ga with values of 1. If the same column exists for qi, assign
+    #    gnap to ga[:,i] and qifn to qi[:,i], else raise warning that no
+    #    appropriate GNAP/PCCF combination was found
+    gnap = None
+    qifn = None
+    for i in range(gDim2):
+        if np.unique(ga[:, i].squeeze()) == 1:
+            if i <= qDim2:
+                logger.info(f'GNAP/PCCF found for column {i}')
+                gnap = ga[:, i].squeeze()
+                qifn = qi[:, i].squeeze()
+            else:
+                logger.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')
+    if (gnap is None) & (qifn is None):
+        logger.info(f'ERROR: GNAP == 1 NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
+    # If EE is needed, key search on np.unique(ga[:,i].squeeze()) == 4 instead
+
+    # Wind Retrieval Method Information
+    swcm = r.get('windComputationMethod')
+
+    # ObsValue
+    # Wind direction and Speed
+    wdir = r.get('windDirection', type='float')
+    wspd = r.get('windSpeed')
+
+    # DateTime: seconds since Epoch time
+    # IODA has no support for numpy datetime arrays dtype=datetime64[s]
+    timestamp = r.get_datetime('year', 'month', 'day', 'hour', 'minute', 'second').astype(np.int64)
+
+    ref_dt  = datetime.fromisoformat(reference_time.replace("Z", "+00:00"))
+    ref_sec = ref_dt.replace(tzinfo=timezone.utc).timestamp()
+    toff = ma.MaskedArray((timestamp.data - ref_sec).astype(np.float32), mask=timestamp.mask)
+    # Check BUFR variable generic dimension and type
+
+    # Global variables declaration
+    # Set global fill values
+    float32_fill_value = satzenang.fill_value
+    int32_fill_value = satid.fill_value
+    int64_fill_value = timestamp.fill_value.astype(np.int64)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for executing QuerySet to get ResultSet : {running_time} seconds')
+
+    # =========================
+    # Create derived variables
+    # =========================
+    start_time = time.time()
+
+    logger.info('Creating derived variables')
+    logger.debug('Creating derived variables - wind components (uob and vob)')
+
+    uob, vob = Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd)
+
+    logger.debug(f'   uob min/max = {uob.min()} {uob.max()}')
+    logger.debug(f'   vob min/max = {vob.min()} {vob.max()}')
+
+    obstype = Get_ObsType(swcm, chanfreq)
+
+    height = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+    stnelev = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for creating derived variables : {running_time} seconds')
+
+    # =====================================
+    # Split output based on satellite id
+    # Create IODA ObsSpace
+    # Write IODA output
+    # =====================================
+    logger.info('Create IODA ObsSpace and Write IODA output based on satellite ID')
+
+    # Find unique satellite identifiers in data to process
+    unique_satids = np.unique(satid)
+    logger.info(f'Number of Unique satellite identifiers: {len(unique_satids)}')
+    logger.info(f'Unique satellite identifiers: {unique_satids}')
+
+    logger.debug(f'Loop through unique satellite identifier {unique_satids}')
+    total_ob_processed = 0
+    for sat in unique_satids.tolist():
+        start_time = time.time()
+
+        matched = False
+        for satellite_info in satellite_info_array:
+            if (satellite_info["satellite_id"] == sat):
+                matched = True
+                satellite_id = satellite_info["satellite_id"]
+                satellite_name = satellite_info["satellite_name"]
+                satinst = sensor_name.lower()+'_'+satellite_name.lower()
+                logger.debug(f'Split data for {satinst} satid = {sat}')
+
+        if matched:
+
+            # Define a boolean mask to subset data from the original data object
+            mask = satid == sat
+            # MetaData
+            lon2 = lon[mask]
+            lat2 = lat[mask]
+            timestamp2 = timestamp[mask]
+            satid2 = satid[mask]
+            satzenang2 = satzenang[mask]
+            chanfreq2 = chanfreq[mask]
+            obstype2 = obstype[mask]
+            pressure2 = pressure[mask]
+            height2 = height[mask]
+            stnelev2 = stnelev[mask]
+
+            # Processing Center
+            ogce2 = ogce[mask]
+
+            # QC Info
+            qifn2 = qifn[mask]
+
+            # Method
+            swcm2 = swcm[mask]
+
+            # ObsValue
+            wdir2 = wdir[mask]
+            wspd2 = wspd[mask]
+            uob2 = uob[mask]
+            vob2 = vob[mask]
+
+            # Timestamp Range
+            timestamp2_min = datetime.fromtimestamp(timestamp2.min())
+            timestamp2_max = datetime.fromtimestamp(timestamp2.max())
+
+            # Check unique observation time
+            unique_timestamp2 = np.unique(timestamp2)
+            logger.debug(f'Processing output for satid {sat}')
+
+            # Create the dimensions
+            dims = {
+                'Location': np.arange(0, wdir2.shape[0])
+            }
+
+            # Create IODA ObsSpace
+            iodafile = f"ioda_{data_type}.{satinst}.nc"
+            OUTPUT_PATH = os.path.join(ioda_dir, iodafile)
+            logger.info(f'Create output file : {OUTPUT_PATH}')
+            obsspace = ioda_ospace.ObsSpace(OUTPUT_PATH, mode='w', dim_dict=dims)
+
+            # Create Global attributes
+            logger.debug('Write global attributes')
+            obsspace.write_attr('Converter', converter)
+            obsspace.write_attr('sourceFiles', bufrfile)
+            obsspace.write_attr('dataProviderOrigin', data_provider)
+            obsspace.write_attr('description', data_description)
+            obsspace.write_attr('datetimeReference', reference_time)
+            obsspace.write_attr('datetimeRange', [str(timestamp2_min), str(timestamp2_max)])
+            obsspace.write_attr('sensor', sensor_id)
+            obsspace.write_attr('platform', satellite_id)
+            obsspace.write_attr('platformCommonName', satellite_name)
+            obsspace.write_attr('sensorCommonName', sensor_name)
+            obsspace.write_attr('processingLevel', process_level)
+            obsspace.write_attr('platformLongDescription', platform_description)
+            obsspace.write_attr('sensorLongDescription', sensor_description)
+
+            # Create IODA variables
+            logger.debug('Write variables: name, type, units, and attributes')
+            # Longitude
+            obsspace.create_var('MetaData/longitude', dtype=lon2.dtype, fillval=lon2.fill_value) \
+                .write_attr('units', 'degrees_east') \
+                .write_attr('valid_range', np.array([-180, 180], dtype=np.float32)) \
+                .write_attr('long_name', 'Longitude') \
+                .write_data(lon2)
+
+            # Latitude
+            obsspace.create_var('MetaData/latitude', dtype=lat.dtype, fillval=lat2.fill_value) \
+                .write_attr('units', 'degrees_north') \
+                .write_attr('valid_range', np.array([-90, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Latitude') \
+                .write_data(lat2)
+
+            # Datetime
+            obsspace.create_var('MetaData/dateTime', dtype=np.int64, fillval=int64_fill_value) \
+                .write_attr('units', 'seconds since 1970-01-01T00:00:00Z') \
+                .write_attr('long_name', 'Datetime') \
+                .write_data(timestamp2)
+
+            # Time variable
+            obsspace.create_var('MetaData/timeOffset', dtype=toff.dtype, fillval=toff.fill_value) \
+                .write_attr('units', 's') \
+                .write_attr('long_name', 'Observation Time Minus Reference Time') \
+                .write_data(toff)
+
+            # Satellite Identifier
+            obsspace.create_var('MetaData/satelliteIdentifier', dtype=satid2.dtype, fillval=satid2.fill_value) \
+                .write_attr('long_name', 'Satellite Identifier') \
+                .write_data(satid2)
+
+            # Sensor Zenith Angle
+            obsspace.create_var('MetaData/satelliteZenithAngle', dtype=satzenang2.dtype, fillval=satzenang2.fill_value) \
+                .write_attr('units', 'degree') \
+                .write_attr('valid_range', np.array([0, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Satellite Zenith Angle') \
+                .write_data(satzenang2)
+
+            # Sensor Centrall Frequency
+            obsspace.create_var('MetaData/sensorCentralFrequency', dtype=chanfreq2.dtype, fillval=chanfreq2.fill_value) \
+                .write_attr('units', 'Hz') \
+                .write_attr('long_name', 'Satellite Channel Center Frequency') \
+                .write_data(chanfreq2)
+
+            # Data Provider
+            obsspace.create_var('MetaData/dataProviderOrigin', dtype=ogce2.dtype, fillval=ogce2.fill_value) \
+                .write_attr('long_name', 'Identification of Originating/Generating Center') \
+                .write_data(ogce2)
+
+            # Quality: Percent Confidence - Quality Information Without Forecast
+            obsspace.create_var('MetaData/qiWithoutForecast', dtype=qifn2.dtype, fillval=qifn2.fill_value) \
+                .write_attr('long_name', 'QI Without Forecast') \
+                .write_data(qifn2)
+
+            # Wind Computation Method
+            obsspace.create_var('MetaData/windComputationMethod', dtype=swcm2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Satellite-derived Wind Computation Method') \
+                .write_data(swcm2)
+
+            # Pressure
+            obsspace.create_var('MetaData/pressure', dtype=pressure2.dtype, fillval=pressure2.fill_value) \
+                .write_attr('units', 'pa') \
+                .write_attr('long_name', 'Pressure') \
+                .write_data(pressure2)
+
+            # Height (mimic prepbufr)
+            obsspace.create_var('MetaData/height', dtype=height2.dtype, fillval=height2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Height of Observation') \
+                .write_data(height2)
+
+            # Station Elevation (mimic prepbufr)
+            obsspace.create_var('MetaData/stationElevation', dtype=stnelev2.dtype, fillval=stnelev2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Station Elevation') \
+                .write_data(stnelev2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windEastward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windNorthward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # U-Wind Component
+            obsspace.create_var('ObsValue/windEastward', dtype=uob2.dtype, fillval=uob2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Eastward Wind Component') \
+                .write_data(uob2)
+
+            # V-Wind Component
+            obsspace.create_var('ObsValue/windNorthward', dtype=vob2.dtype, fillval=vob2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Northward Wind Component') \
+                .write_data(vob2)
+
+            end_time = time.time()
+            running_time = end_time - start_time
+            total_ob_processed += len(satid2)
+            logger.debug(f'Number of observation processed : {len(satid2)}')
+            logger.debug(f'Processing time for splitting and output IODA for {satinst} : {running_time} seconds')
+
+        else:
+            logger.info(f"Do not find this satellite id in the configuration: satid = {sat}")
+
+    logger.info("All Done!")
+    logger.info(f'Total number of observation processed : {total_ob_processed}')
+
+
+if __name__ == '__main__':
+
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, help='Input JSON configuration', required=True)
+    parser.add_argument('-v', '--verbose', help='print debug logging information',
+                        action='store_true')
+    args = parser.parse_args()
+
+    log_level = 'DEBUG' if args.verbose else 'INFO'
+    logger = Logger('BUFR2IODA_satwind_amv_ahi.py', level=log_level, colored_log=True)
+
+    with open(args.config, "r") as json_file:
+        config = json.load(json_file)
+
+    bufr_to_ioda(config, logger)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Total running time: {running_time} seconds")

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_seviri.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_seviri.json
@@ -1,0 +1,17 @@
+{
+  "data_format"      : "bufr_d",
+  "data_type"        : "satwnd",
+  "cycle_datetime"   : "{{ current_cycle | to_YMDH }}",
+  "dump_directory"   : "./",
+  "ioda_directory"   : "./",
+  "subsets"          : [ "NC005067", "NC005068", "NC005069" ],
+  "data_description" : "EUMETSAT SATWIND, SEVIRI IR(LW);  EUMETSAT SATWIND, SEVIRI WV-IMG/DL; EUMETSAT SATWIND, SEVIRI VIS",
+  "data_provider"    : "EUMETSAT",
+  "sensor_info"      : { "sensor_name": "SEVIRI",  "sensor_full_name": "Spinning Enhanced Visible and InfraRed Imager",  "sensor_id": 999 },
+  "satellite_info"   : [
+                          { "satellite_name": "M8", "satellite_full_name": "METEOSAT-8", "satellite_id": 55, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "M9", "satellite_full_name": "METEOSAT-9", "satellite_id": 56, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "M10", "satellite_full_name": "METEOSAT-10", "satellite_id": 57, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "M11", "satellite_full_name": "METEOSAT-11", "satellite_id": 70, "launch time": "YYYYMMDD" }
+                       ]
+}

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_seviri.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_seviri.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+import numpy.ma as ma
+from pyiodaconv import bufr
+import calendar
+import json
+import time
+import math
+import datetime
+import os
+from datetime import datetime, timezone
+from pyioda import ioda_obs_space as ioda_ospace
+from wxflow import Logger
+
+# ====================================================================
+# Satellite Winds (AMV) BUFR dump file for SEVIRI/METEOSAT
+# ====================================================================
+# All subsets contain all spectral bands: NC005067 NC005068 NC005069
+# ====================================================================
+# Spectral Band                 | Code (002023) | ObsType
+# --------------------------------------------------------------------
+# IRLW  (Freq < 5E+13)          |    Method 1   | 253
+# VIS                           |    Method 2   | 243
+# WV Cloud Top                  |    Method 3   | 254
+# WV Clear Sky/ Deep Layer      |    Method 5   | 254
+# ====================================================================
+
+# Define and initialize  global variables
+global float32_fill_value
+global int32_fill_value
+global int64_fill_value
+
+float32_fill_value = np.float32(0)
+int32_fill_value = np.int32(0)
+int64_fill_value = np.int64(0)
+
+
+def Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd):
+
+    uob = (-wspd * np.sin(np.radians(wdir))).astype(np.float32)
+    vob = (-wspd * np.cos(np.radians(wdir))).astype(np.float32)
+
+    return uob, vob
+
+
+def Get_ObsType(swcm, chanfreq):
+
+    obstype = swcm.copy()
+
+    # Use numpy vectorized operations
+    obstype = np.where(swcm == 5, 254, obstype)  # WVCA/DL
+    obstype = np.where(swcm == 3, 254, obstype)  # WVCT
+    obstype = np.where(swcm == 2, 243, obstype)  # VIS
+    obstype = np.where(swcm == 1, 253, obstype)  # IRLW
+
+    if not np.any(np.isin(obstype, [243, 253, 254])):
+        raise ValueError("Error: Unassigned ObsType found ... ")
+
+    return obstype
+
+
+def bufr_to_ioda(config, logger):
+
+    subsets = config["subsets"]
+    logger.debug(f"Checking subsets = {subsets}")
+
+    # Get parameters from configuration
+    subsets = config["subsets"]
+    data_format = config["data_format"]
+    data_type = config["data_type"]
+    data_description = config["data_description"]
+    data_provider = config["data_provider"]
+    #cycle_type = config["cycle_type"]
+    dump_dir = config["dump_directory"]
+    ioda_dir = config["ioda_directory"]
+    cycle = config["cycle_datetime"]
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+
+    satellite_info_array = config["satellite_info"]
+    sensor_name = config["sensor_info"]["sensor_name"]
+    sensor_full_name = config["sensor_info"]["sensor_full_name"]
+    sensor_id = config["sensor_info"]["sensor_id"]
+
+    # Get derived parameters
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+    reference_time = datetime.strptime(cycle, "%Y%m%d%H")
+    reference_time = reference_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # General informaton
+    converter = 'BUFR to IODA Converter'
+    process_level = 'Level-2'
+    platform_description = 'METEOSAT-8'
+    sensor_description = 'Spinning Enhanced Visible and InfraRed Imager'
+
+    logger.info(f'sensor_name = {sensor_name}')
+    logger.info(f'sensor_full_name = {sensor_full_name}')
+    logger.info(f'sensor_id = {sensor_id}')
+    logger.info(f'reference_time = {reference_time}')
+
+    bufrfile = "satwndbufr"
+    DATA_PATH = os.path.join(dump_dir, bufrfile)
+    if not os.path.isfile(DATA_PATH):
+        logger.info(f"DATA_PATH {DATA_PATH} does not exist")
+        return
+    logger.debug(f"The DATA_PATH is: {DATA_PATH}")
+
+    # ============================================
+    # Make the QuerySet for all the data we want
+    # ============================================
+    start_time = time.time()
+
+    logger.info('Making QuerySet')
+    q = bufr.QuerySet(subsets)
+
+    # MetaData
+    q.add('latitude', '*/CLATH')
+    q.add('longitude', '*/CLONH')
+    q.add('satelliteId', '*/SAID')
+    q.add('year', '*/YEAR')
+    q.add('month', '*/MNTH')
+    q.add('day', '*/DAYS')
+    q.add('hour', '*/HOUR')
+    q.add('minute', '*/MINU')
+    q.add('second', '*/SECO')
+    q.add('satelliteZenithAngle', '*/SAZA')
+    q.add('sensorCentralFrequency', '*/SCCF')
+    q.add('pressure', '*/PRLC[1]')
+
+    # Processing Center
+    q.add('dataProviderOrigin', '*/OGCE')
+
+#   # Quality Infomation (Quality Indicator w/o forecast)
+    q.add('qualityInformationWithoutForecast', '*/AMVQIC{2}/PCCF')
+
+    # Wind Retrieval Method Information
+    q.add('windComputationMethod', '*/SWCM')
+
+    # ObsValue
+    q.add('windDirection', '*/WDIR')
+    q.add('windSpeed', '*/WSPD')
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.debug(f'Processing time for making QuerySet : {running_time} seconds')
+
+    # ==============================================================
+    # Open the BUFR file and execute the QuerySet to get ResultSet
+    # Use the ResultSet returned to get numpy arrays of the data
+    # ==============================================================
+    start_time = time.time()
+
+    logger.info('Executing QuerySet to get ResultSet')
+    with bufr.File(DATA_PATH) as f:
+        try:
+            r = f.execute(q)
+        except Exception as err:
+            logger.info(f'Return with {err}')
+            return
+
+    # MetaData
+    satid = r.get('satelliteId')
+    year = r.get('year')
+    month = r.get('month')
+    day = r.get('day')
+    hour = r.get('hour')
+    minute = r.get('minute')
+    second = r.get('second')
+    lat = r.get('latitude')
+    lon = r.get('longitude')
+    satzenang = r.get('satelliteZenithAngle')
+    pressure = r.get('pressure', type='float')
+    chanfreq = r.get('sensorCentralFrequency', type='float')
+
+    # Processing Center
+    ogce = r.get('dataProviderOrigin')
+
+    # Quality Information
+    qifn = r.get('qualityInformationWithoutForecast', type='float')
+
+    # Wind Retrieval Method Information
+    swcm = r.get('windComputationMethod')
+
+    # ObsValue
+    # Wind direction and Speed
+    wdir = r.get('windDirection', type='float')
+    wspd = r.get('windSpeed')
+
+    # DateTime: seconds since Epoch time
+    # IODA has no support for numpy datetime arrays dtype=datetime64[s]
+    timestamp = r.get_datetime('year', 'month', 'day', 'hour', 'minute', 'second').astype(np.int64)
+
+    ref_dt  = datetime.fromisoformat(reference_time.replace("Z", "+00:00"))
+    ref_sec = ref_dt.replace(tzinfo=timezone.utc).timestamp()
+    toff = ma.MaskedArray((timestamp.data - ref_sec).astype(np.float32), mask=timestamp.mask)
+    # Check BUFR variable generic dimension and type
+
+    # Global variables declaration
+    # Set global fill values
+    float32_fill_value = satzenang.fill_value
+    int32_fill_value = satid.fill_value
+    int64_fill_value = timestamp.fill_value.astype(np.int64)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for executing QuerySet to get ResultSet : {running_time} seconds')
+
+    # =========================
+    # Create derived variables
+    # =========================
+    start_time = time.time()
+
+    logger.info('Creating derived variables')
+    logger.debug('Creating derived variables - wind components (uob and vob)')
+
+    uob, vob = Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd)
+
+    logger.debug(f'   uob min/max = {uob.min()} {uob.max()}')
+    logger.debug(f'   vob min/max = {vob.min()} {vob.max()}')
+
+    obstype = Get_ObsType(swcm, chanfreq)
+
+    height = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+    stnelev = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for creating derived variables : {running_time} seconds')
+
+    # =====================================
+    # Split output based on satellite id
+    # Create IODA ObsSpace
+    # Write IODA output
+    # =====================================
+    logger.info('Create IODA ObsSpace and Write IODA output based on satellite ID')
+
+    # Find unique satellite identifiers in data to process
+    unique_satids = np.unique(satid)
+    logger.info(f'Number of Unique satellite identifiers: {len(unique_satids)}')
+    logger.info(f'Unique satellite identifiers: {unique_satids}')
+
+    logger.debug(f'Loop through unique satellite identifier {unique_satids}')
+    total_ob_processed = 0
+    for sat in unique_satids.tolist():
+        start_time = time.time()
+
+        matched = False
+        for satellite_info in satellite_info_array:
+            if (satellite_info["satellite_id"] == sat):
+                matched = True
+                satellite_id = satellite_info["satellite_id"]
+                satellite_name = satellite_info["satellite_name"]
+                satinst = sensor_name.lower()+'_'+satellite_name.lower()
+                logger.debug(f'Split data for {satinst} satid = {sat}')
+
+        if matched:
+
+            # Define a boolean mask to subset data from the original data object
+            mask = satid == sat
+            # MetaData
+            lon2 = lon[mask]
+            lat2 = lat[mask]
+            timestamp2 = timestamp[mask]
+            satid2 = satid[mask]
+            satzenang2 = satzenang[mask]
+            chanfreq2 = chanfreq[mask]
+            obstype2 = obstype[mask]
+            pressure2 = pressure[mask]
+            height2 = height[mask]
+            stnelev2 = stnelev[mask]
+
+            # Processing Center
+            ogce2 = ogce[mask]
+
+            # QC Info
+            qifn2 = qifn[mask]
+
+            # Method
+            swcm2 = swcm[mask]
+
+            # ObsValue
+            wdir2 = wdir[mask]
+            wspd2 = wspd[mask]
+            uob2 = uob[mask]
+            vob2 = vob[mask]
+
+            # Timestamp Range
+            timestamp2_min = datetime.fromtimestamp(timestamp2.min())
+            timestamp2_max = datetime.fromtimestamp(timestamp2.max())
+
+            # Check unique observation time
+            unique_timestamp2 = np.unique(timestamp2)
+            logger.debug(f'Processing output for satid {sat}')
+
+            # Create the dimensions
+            dims = {
+                'Location': np.arange(0, wdir2.shape[0])
+            }
+
+            # Create IODA ObsSpace
+            iodafile = f"ioda_{data_type}.{satinst}.nc"
+            OUTPUT_PATH = os.path.join(ioda_dir, iodafile)
+            logger.info(f'Create output file : {OUTPUT_PATH}')
+            obsspace = ioda_ospace.ObsSpace(OUTPUT_PATH, mode='w', dim_dict=dims)
+
+            # Create Global attributes
+            logger.debug('Write global attributes')
+            obsspace.write_attr('Converter', converter)
+            obsspace.write_attr('sourceFiles', bufrfile)
+            obsspace.write_attr('dataProviderOrigin', data_provider)
+            obsspace.write_attr('description', data_description)
+            obsspace.write_attr('datetimeReference', reference_time)
+            obsspace.write_attr('datetimeRange', [str(timestamp2_min), str(timestamp2_max)])
+            obsspace.write_attr('sensor', sensor_id)
+            obsspace.write_attr('platform', satellite_id)
+            obsspace.write_attr('platformCommonName', satellite_name)
+            obsspace.write_attr('sensorCommonName', sensor_name)
+            obsspace.write_attr('processingLevel', process_level)
+            obsspace.write_attr('platformLongDescription', platform_description)
+            obsspace.write_attr('sensorLongDescription', sensor_description)
+
+            # Create IODA variables
+            logger.debug('Write variables: name, type, units, and attributes')
+            # Longitude
+            obsspace.create_var('MetaData/longitude', dtype=lon2.dtype, fillval=lon2.fill_value) \
+                .write_attr('units', 'degrees_east') \
+                .write_attr('valid_range', np.array([-180, 180], dtype=np.float32)) \
+                .write_attr('long_name', 'Longitude') \
+                .write_data(lon2)
+
+            # Latitude
+            obsspace.create_var('MetaData/latitude', dtype=lat2.dtype, fillval=lat2.fill_value) \
+                .write_attr('units', 'degrees_north') \
+                .write_attr('valid_range', np.array([-90, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Latitude') \
+                .write_data(lat2)
+
+            # Datetime
+            obsspace.create_var('MetaData/dateTime', dtype=np.int64, fillval=int64_fill_value) \
+                .write_attr('units', 'seconds since 1970-01-01T00:00:00Z') \
+                .write_attr('long_name', 'Datetime') \
+                .write_data(timestamp2)
+
+            # Time variable
+            obsspace.create_var('MetaData/timeOffset', dtype=toff.dtype, fillval=toff.fill_value) \
+                .write_attr('units', 's') \
+                .write_attr('long_name', 'Observation Time Minus Reference Time') \
+                .write_data(toff)
+
+            # Satellite Identifier
+            obsspace.create_var('MetaData/satelliteIdentifier', dtype=satid2.dtype, fillval=satid2.fill_value) \
+                .write_attr('long_name', 'Satellite Identifier') \
+                .write_data(satid2)
+
+            # Sensor Zenith Angle
+            obsspace.create_var('MetaData/satelliteZenithAngle', dtype=satzenang2.dtype, fillval=satzenang2.fill_value) \
+                .write_attr('units', 'degree') \
+                .write_attr('valid_range', np.array([0, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Satellite Zenith Angle') \
+                .write_data(satzenang2)
+
+            # Sensor Centrall Frequency
+            obsspace.create_var('MetaData/sensorCentralFrequency', dtype=chanfreq2.dtype, fillval=chanfreq2.fill_value) \
+                .write_attr('units', 'Hz') \
+                .write_attr('long_name', 'Satellite Channel Center Frequency') \
+                .write_data(chanfreq2)
+
+            # Data Provider
+            obsspace.create_var('MetaData/dataProviderOrigin', dtype=ogce2.dtype, fillval=ogce2.fill_value) \
+                .write_attr('long_name', 'Identification of Originating/Generating Center') \
+                .write_data(ogce2)
+
+            # Quality: Percent Confidence - Quality Information Without Forecast
+            obsspace.create_var('MetaData/qiWithoutForecast', dtype=qifn2.dtype, fillval=qifn2.fill_value) \
+                .write_attr('long_name', 'QI Without Forecast') \
+                .write_data(qifn2)
+
+            # Wind Computation Method
+            obsspace.create_var('MetaData/windComputationMethod', dtype=swcm2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Satellite-derived Wind Computation Method') \
+                .write_data(swcm2)
+
+            # Pressure
+            obsspace.create_var('MetaData/pressure', dtype=pressure2.dtype, fillval=pressure2.fill_value) \
+                .write_attr('units', 'pa') \
+                .write_attr('long_name', 'Pressure') \
+                .write_data(pressure2)
+
+            # Height (mimic prepbufr)
+            obsspace.create_var('MetaData/height', dtype=height2.dtype, fillval=height2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Height of Observation') \
+                .write_data(height2)
+
+            # Station Elevation (mimic prepbufr)
+            obsspace.create_var('MetaData/stationElevation', dtype=stnelev2.dtype, fillval=stnelev2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Station Elevation') \
+                .write_data(stnelev2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windEastward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windNorthward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # U-Wind Component
+            obsspace.create_var('ObsValue/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Eastward Wind Component') \
+                .write_data(uob2)
+
+            # V-Wind Component
+            obsspace.create_var('ObsValue/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Northward Wind Component') \
+                .write_data(vob2)
+
+            end_time = time.time()
+            running_time = end_time - start_time
+            total_ob_processed += len(satid2)
+            logger.debug(f'Number of observation processed : {len(satid2)}')
+            logger.debug(f'Processing time for splitting and output IODA for {satinst} : {running_time} seconds')
+
+        else:
+            logger.info(f"Do not find this satellite id in the configuration: satid = {sat}")
+
+    logger.info("All Done!")
+    logger.info(f'Total number of observation processed : {total_ob_processed}')
+
+
+if __name__ == '__main__':
+
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, help='Input JSON configuration', required=True)
+    parser.add_argument('-v', '--verbose', help='print debug logging information',
+                        action='store_true')
+    args = parser.parse_args()
+
+    log_level = 'DEBUG' if args.verbose else 'INFO'
+    logger = Logger('BUFR2IODA_satwind_amv_ahi.py', level=log_level, colored_log=True)
+
+    with open(args.config, "r") as json_file:
+        config = json.load(json_file)
+
+    bufr_to_ioda(config, logger)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Total running time: {running_time} seconds")

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_viirs.json
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_viirs.json
@@ -1,0 +1,16 @@
+{
+  "data_format"      : "bufr_d",
+  "data_type"        : "satwnd",
+  "cycle_datetime"   : "{{ current_cycle | to_YMDH }}",
+  "dump_directory"   : "./",
+  "ioda_directory"   : "./",
+  "subsets"          : [ "NC005091" ],
+  "data_description" : "NC005091 S-NPP/NOAA-20/NOAA-21 SATWIND VIIRS IR(LW)",
+  "data_provider"    : "U.S. NOAA/NESDIS",
+  "sensor_info"      : { "sensor_name": "VIIRS",  "sensor_full_name": "Visible Infrared Imaging Radiometer Suite",  "sensor_id": 999 },
+  "satellite_info"   : [
+                          { "satellite_name": "npp", "satellite_full_name": "SUOMI-NPP", "satellite_id": 224, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "n20", "satellite_full_name": "NOAA-20", "satellite_id": 225, "launch time": "YYYYMMDD" },
+                          { "satellite_name": "n21", "satellite_full_name": "NOAA-21", "satellite_id": 226, "launch time": "YYYYMMDD" }
+                      ]
+}

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_viirs.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_viirs.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+import numpy.ma as ma
+from pyiodaconv import bufr
+import calendar
+import json
+import time
+import math
+import datetime
+import os
+from datetime import datetime, timezone
+from pyioda import ioda_obs_space as ioda_ospace
+from wxflow import Logger
+
+# ====================================================================
+# Satellite Winds (AMV) BUFR dump file for VIIRS/S-NPP,NOAA-20
+# ====================================================================
+# Subset    |  Spectral Band              |  Code (002023) |  ObsType
+# --------------------------------------------------------------------
+# NC005091  |    IRLW  (Freq < 5E+13)     |    Method 1    |   260
+# ====================================================================
+
+# Define and initialize  global variables
+global float32_fill_value
+global int32_fill_value
+global int64_fill_value
+
+float32_fill_value = np.float32(0)
+int32_fill_value = np.int32(0)
+int64_fill_value = np.int64(0)
+
+
+def Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd):
+
+    uob = (-wspd * np.sin(np.radians(wdir))).astype(np.float32)
+    vob = (-wspd * np.cos(np.radians(wdir))).astype(np.float32)
+
+    return uob, vob
+
+
+def Get_ObsType(swcm, chanfreq):
+
+    obstype = swcm.copy()
+
+    # Use numpy vectorized operations
+    obstype = np.where(swcm == 1, 260, obstype)  # IRLW
+
+    if not np.any(np.isin(obstype, [260])):
+        raise ValueError("Error: Unassigned ObsType found ... ")
+
+    return obstype
+
+
+def bufr_to_ioda(config, logger):
+
+    subsets = config["subsets"]
+    logger.debug(f"Checking subsets = {subsets}")
+
+    # Get parameters from configuration
+    subsets = config["subsets"]
+    data_format = config["data_format"]
+    data_type = config["data_type"]
+    data_description = config["data_description"]
+    data_provider = config["data_provider"]
+    #cycle_type = config["cycle_type"]
+    dump_dir = config["dump_directory"]
+    ioda_dir = config["ioda_directory"]
+    cycle = config["cycle_datetime"]
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+
+    satellite_info_array = config["satellite_info"]
+    sensor_name = config["sensor_info"]["sensor_name"]
+    sensor_full_name = config["sensor_info"]["sensor_full_name"]
+    sensor_id = config["sensor_info"]["sensor_id"]
+
+    # Get derived parameters
+    yyyymmdd = cycle[0:8]
+    hh = cycle[8:10]
+    reference_time = datetime.strptime(cycle, "%Y%m%d%H")
+    reference_time = reference_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # General informaton
+    converter = 'BUFR to IODA Converter'
+    process_level = 'Level-2'
+    platform_description = 'TERRA/AQUA'
+    sensor_description = 'Moderate Resolution Imaging Spectroradiometer'
+
+    logger.info(f'sensor_name = {sensor_name}')
+    logger.info(f'sensor_full_name = {sensor_full_name}')
+    logger.info(f'sensor_id = {sensor_id}')
+    logger.info(f'reference_time = {reference_time}')
+
+    bufrfile = "satwndbufr"
+    DATA_PATH = os.path.join(dump_dir, bufrfile)
+    if not os.path.isfile(DATA_PATH):
+        logger.info(f"DATA_PATH {DATA_PATH} does not exist")
+        return
+    logger.debug(f"The DATA_PATH is: {DATA_PATH}")
+
+    # ============================================
+    # Make the QuerySet for all the data we want
+    # ============================================
+    start_time = time.time()
+
+    logger.info('Making QuerySet')
+    q = bufr.QuerySet(subsets)
+
+    # MetaData
+    q.add('latitude', '*/CLATH')
+    q.add('longitude', '*/CLONH')
+    q.add('satelliteId', '*/SAID')
+    q.add('year', '*/YEAR')
+    q.add('month', '*/MNTH')
+    q.add('day', '*/DAYS')
+    q.add('hour', '*/HOUR')
+    q.add('minute', '*/MINU')
+    q.add('second', '*/SECO')
+    q.add('satelliteZenithAngle', '*/SAZA')
+    q.add('sensorCentralFrequency', '*/SCCF')
+    q.add('pressure', '*/PRLC[1]')
+
+    # Processing Center
+    q.add('dataProviderOrigin', '*/OGCE[1]')
+    q.add('windGeneratingApplication', '*/AMVQIC/GNAPS')
+
+#   # Quality Infomation (Quality Indicator w/o forecast)
+    q.add('qualityInformationWithoutForecast', '*/AMVQIC/PCCF')
+
+    # Wind Retrieval Method Information
+    q.add('windComputationMethod', '*/SWCM')
+
+    # ObsValue
+    q.add('windDirection', '*/WDIR')
+    q.add('windSpeed', '*/WSPD')
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.debug(f'Processing time for making QuerySet : {running_time} seconds')
+
+    # ==============================================================
+    # Open the BUFR file and execute the QuerySet to get ResultSet
+    # Use the ResultSet returned to get numpy arrays of the data
+    # ==============================================================
+    start_time = time.time()
+
+    logger.info('Executing QuerySet to get ResultSet')
+    with bufr.File(DATA_PATH) as f:
+        try:
+            r = f.execute(q)
+        except Exception as err:
+            logger.info(f'Return with {err}')
+            return
+
+    # MetaData
+    satid = r.get('satelliteId')
+    year = r.get('year')
+    month = r.get('month')
+    day = r.get('day')
+    hour = r.get('hour')
+    minute = r.get('minute')
+    second = r.get('second')
+    lat = r.get('latitude')
+    lon = r.get('longitude')
+    satzenang = r.get('satelliteZenithAngle')
+    pressure = r.get('pressure', type='float')
+    chanfreq = r.get('sensorCentralFrequency', type='float')
+
+    # Processing Center
+    ogce = r.get('dataProviderOrigin')
+    ga = r.get('windGeneratingApplication')
+
+    # Quality Information
+    qi = r.get('qualityInformationWithoutForecast', type='float')
+    # For TERRA/AQUA MODIS data, qi w/o forecast (qifn) is packaged in same
+    # vector of qi with ga = 5 (QI without forecast), and EE is
+    # packaged in same vector of qi with ga=7 (Estimated Error (EE) in m/s
+    # converted to a percent confidence)shape (4,nobs). Must conduct a
+    # search and extract the correct vector for gnap and qi
+    # 1. Find dimension-sizes of ga and qi (should be the same!)
+    gDim1, gDim2 = np.shape(ga)
+    qDim1, qDim2 = np.shape(qi)
+    logger.info(f'Generating Application and Quality Information SEARCH:')
+    logger.info(f'Dimension size of GNAP ({gDim1},{gDim2})')
+    logger.info(f'Dimension size of PCCF ({qDim1},{qDim2})')
+    # 2. Initialize gnap and qifn as None, and search for dimension of
+    #    ga with values of 5. If the same column exists for qi, assign
+    #    gnap to ga[:,i] and qifn to qi[:,i], else raise warning that no
+    #    appropriate GNAP/PCCF combination was found
+    gnap = None
+    qifn = None
+    for i in range(gDim2):
+        if np.unique(ga[:, i].squeeze()) == 5:
+            if i <= qDim2:
+                logger.info(f'GNAP/PCCF found for column {i}')
+                gnap = ga[:, i].squeeze()
+                qifn = qi[:, i].squeeze()
+            else:
+                logger.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')
+    if (gnap is None) & (qifn is None):
+        logger.info(f'ERROR: GNAP == 5 NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
+    # If EE is needed, key search on np.unique(ga[:,i].squeeze()) == 7 instead
+
+    # Wind Retrieval Method Information
+    swcm = r.get('windComputationMethod')
+
+    # ObsValue
+    # Wind direction and Speed
+    wdir = r.get('windDirection', type='float')
+    wspd = r.get('windSpeed')
+
+    # DateTime: seconds since Epoch time
+    # IODA has no support for numpy datetime arrays dtype=datetime64[s]
+    timestamp = r.get_datetime('year', 'month', 'day', 'hour', 'minute', 'second').astype(np.int64)
+
+    ref_dt  = datetime.fromisoformat(reference_time.replace("Z", "+00:00"))
+    ref_sec = ref_dt.replace(tzinfo=timezone.utc).timestamp()
+    toff = ma.MaskedArray((timestamp.data - ref_sec).astype(np.float32), mask=timestamp.mask)
+    # Check BUFR variable generic dimension and type
+
+    # Global variables declaration
+    # Set global fill values
+    float32_fill_value = satzenang.fill_value
+    int32_fill_value = satid.fill_value
+    int64_fill_value = timestamp.fill_value.astype(np.int64)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for executing QuerySet to get ResultSet : {running_time} seconds')
+
+    # =========================
+    # Create derived variables
+    # =========================
+    start_time = time.time()
+
+    logger.info('Creating derived variables')
+    logger.debug('Creating derived variables - wind components (uob and vob)')
+
+    uob, vob = Compute_WindComponents_from_WindDirection_and_WindSpeed(wdir, wspd)
+
+    logger.debug(f'   uob min/max = {uob.min()} {uob.max()}')
+    logger.debug(f'   vob min/max = {vob.min()} {vob.max()}')
+
+    obstype = Get_ObsType(swcm, chanfreq)
+
+    height = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+    stnelev = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f'Processing time for creating derived variables : {running_time} seconds')
+
+    # =====================================
+    # Split output based on satellite id
+    # Create IODA ObsSpace
+    # Write IODA output
+    # =====================================
+    logger.info('Create IODA ObsSpace and Write IODA output based on satellite ID')
+
+    # Find unique satellite identifiers in data to process
+    unique_satids = np.unique(satid)
+    logger.info(f'Number of Unique satellite identifiers: {len(unique_satids)}')
+    logger.info(f'Unique satellite identifiers: {unique_satids}')
+
+    logger.debug(f'Loop through unique satellite identifier {unique_satids}')
+    total_ob_processed = 0
+    for sat in unique_satids.tolist():
+        start_time = time.time()
+
+        matched = False
+        for satellite_info in satellite_info_array:
+            if (satellite_info["satellite_id"] == sat):
+                matched = True
+                satellite_id = satellite_info["satellite_id"]
+                satellite_name = satellite_info["satellite_name"]
+                satinst = sensor_name.lower()+'_'+satellite_name.lower()
+                logger.debug(f'Split data for {satinst} satid = {sat}')
+
+        if matched:
+
+            # Define a boolean mask to subset data from the original data object
+            mask = satid == sat
+            # MetaData
+            lon2 = lon[mask]
+            lat2 = lat[mask]
+            timestamp2 = timestamp[mask]
+            satid2 = satid[mask]
+            satzenang2 = satzenang[mask]
+            chanfreq2 = chanfreq[mask]
+            obstype2 = obstype[mask]
+            pressure2 = pressure[mask]
+            height2 = height[mask]
+            stnelev2 = stnelev[mask]
+
+            # Processing Center
+            ogce2 = ogce[mask]
+
+            # QC Info
+            qifn2 = qifn[mask]
+
+            # Method
+            swcm2 = swcm[mask]
+
+            # ObsValue
+            wdir2 = wdir[mask]
+            wspd2 = wspd[mask]
+            uob2 = uob[mask]
+            vob2 = vob[mask]
+
+            # Timestamp Range
+            timestamp2_min = datetime.fromtimestamp(timestamp2.min())
+            timestamp2_max = datetime.fromtimestamp(timestamp2.max())
+
+            # Check unique observation time
+            unique_timestamp2 = np.unique(timestamp2)
+            logger.debug(f'Processing output for satid {sat}')
+
+            # Create the dimensions
+            dims = {
+                'Location': np.arange(0, wdir2.shape[0])
+            }
+
+            # Create IODA ObsSpace
+            iodafile = f"ioda_{data_type}.{satinst}.nc"
+            OUTPUT_PATH = os.path.join(ioda_dir, iodafile)
+            logger.info(f'Create output file : {OUTPUT_PATH}')
+            obsspace = ioda_ospace.ObsSpace(OUTPUT_PATH, mode='w', dim_dict=dims)
+
+            # Create Global attributes
+            logger.debug('Write global attributes')
+            obsspace.write_attr('Converter', converter)
+            obsspace.write_attr('sourceFiles', bufrfile)
+            obsspace.write_attr('dataProviderOrigin', data_provider)
+            obsspace.write_attr('description', data_description)
+            obsspace.write_attr('datetimeReference', reference_time)
+            obsspace.write_attr('datetimeRange', [str(timestamp2_min), str(timestamp2_max)])
+            obsspace.write_attr('sensor', sensor_id)
+            obsspace.write_attr('platform', satellite_id)
+            obsspace.write_attr('platformCommonName', satellite_name)
+            obsspace.write_attr('sensorCommonName', sensor_name)
+            obsspace.write_attr('processingLevel', process_level)
+            obsspace.write_attr('platformLongDescription', platform_description)
+            obsspace.write_attr('sensorLongDescription', sensor_description)
+
+            # Create IODA variables
+            logger.debug('Write variables: name, type, units, and attributes')
+            # Longitude
+            obsspace.create_var('MetaData/longitude', dtype=lon2.dtype, fillval=lon2.fill_value) \
+                .write_attr('units', 'degrees_east') \
+                .write_attr('valid_range', np.array([-180, 180], dtype=np.float32)) \
+                .write_attr('long_name', 'Longitude') \
+                .write_data(lon2)
+
+            # Latitude
+            obsspace.create_var('MetaData/latitude', dtype=lat.dtype, fillval=lat2.fill_value) \
+                .write_attr('units', 'degrees_north') \
+                .write_attr('valid_range', np.array([-90, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Latitude') \
+                .write_data(lat2)
+
+            # Datetime
+            obsspace.create_var('MetaData/dateTime', dtype=np.int64, fillval=int64_fill_value) \
+                .write_attr('units', 'seconds since 1970-01-01T00:00:00Z') \
+                .write_attr('long_name', 'Datetime') \
+                .write_data(timestamp2)
+
+            # Time variable
+            obsspace.create_var('MetaData/timeOffset', dtype=toff.dtype, fillval=toff.fill_value) \
+                .write_attr('units', 's') \
+                .write_attr('long_name', 'Observation Time Minus Reference Time') \
+                .write_data(toff)
+
+            # Satellite Identifier
+            obsspace.create_var('MetaData/satelliteIdentifier', dtype=satid2.dtype, fillval=satid2.fill_value) \
+                .write_attr('long_name', 'Satellite Identifier') \
+                .write_data(satid2)
+
+            # Sensor Zenith Angle
+            obsspace.create_var('MetaData/satelliteZenithAngle', dtype=satzenang2.dtype, fillval=satzenang2.fill_value) \
+                .write_attr('units', 'degree') \
+                .write_attr('valid_range', np.array([0, 90], dtype=np.float32)) \
+                .write_attr('long_name', 'Satellite Zenith Angle') \
+                .write_data(satzenang2)
+
+            # Sensor Centrall Frequency
+            obsspace.create_var('MetaData/sensorCentralFrequency', dtype=chanfreq2.dtype, fillval=chanfreq2.fill_value) \
+                .write_attr('units', 'Hz') \
+                .write_attr('long_name', 'Satellite Channel Center Frequency') \
+                .write_data(chanfreq2)
+
+            # Data Provider
+            obsspace.create_var('MetaData/dataProviderOrigin', dtype=ogce2.dtype, fillval=ogce2.fill_value) \
+                .write_attr('long_name', 'Identification of Originating/Generating Center') \
+                .write_data(ogce2)
+
+            # Quality: Percent Confidence - Quality Information Without Forecast
+            obsspace.create_var('MetaData/qiWithoutForecast', dtype=qifn2.dtype, fillval=qifn2.fill_value) \
+                .write_attr('long_name', 'QI Without Forecast') \
+                .write_data(qifn2)
+
+            # Wind Computation Method
+            obsspace.create_var('MetaData/windComputationMethod', dtype=swcm2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Satellite-derived Wind Computation Method') \
+                .write_data(swcm2)
+
+            # Pressure
+            obsspace.create_var('MetaData/pressure', dtype=pressure2.dtype, fillval=pressure2.fill_value) \
+                .write_attr('units', 'pa') \
+                .write_attr('long_name', 'Pressure') \
+                .write_data(pressure2)
+
+            # Height (mimic prepbufr)
+            obsspace.create_var('MetaData/height', dtype=height2.dtype, fillval=height2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Height of Observation') \
+                .write_data(height2)
+
+            # Station Elevation (mimic prepbufr)
+            obsspace.create_var('MetaData/stationElevation', dtype=stnelev2.dtype, fillval=stnelev2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Station Elevation') \
+                .write_data(stnelev2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windEastward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # ObsType based on computation method/spectral band
+            obsspace.create_var('ObsType/windNorthward', dtype=obstype2.dtype, fillval=swcm2.fill_value) \
+                .write_attr('long_name', 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band') \
+                .write_data(obstype2)
+
+            # U-Wind Component
+            obsspace.create_var('ObsValue/windEastward', dtype=uob2.dtype, fillval=uob2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Eastward Wind Component') \
+                .write_data(uob2)
+
+            # V-Wind Component
+            obsspace.create_var('ObsValue/windNorthward', dtype=vob2.dtype, fillval=vob2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Northward Wind Component') \
+                .write_data(vob2)
+
+            end_time = time.time()
+            running_time = end_time - start_time
+            total_ob_processed += len(satid2)
+            logger.debug(f'Number of observation processed : {len(satid2)}')
+            logger.debug(f'Processing time for splitting and output IODA for {satinst} : {running_time} seconds')
+
+        else:
+            logger.info(f"Do not find this satellite id in the configuration: satid = {sat}")
+
+    logger.info("All Done!")
+    logger.info(f'Total number of observation processed : {total_ob_processed}')
+
+
+if __name__ == '__main__':
+
+    start_time = time.time()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, help='Input JSON configuration', required=True)
+    parser.add_argument('-v', '--verbose', help='print debug logging information',
+                        action='store_true')
+    args = parser.parse_args()
+
+    log_level = 'DEBUG' if args.verbose else 'INFO'
+    logger = Logger('BUFR2IODA_satwind_amv_ahi.py', level=log_level, colored_log=True)
+
+    with open(args.config, "r") as json_file:
+        config = json.load(json_file)
+
+    bufr_to_ioda(config, logger)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logger.info(f"Total running time: {running_time} seconds")


### PR DESCRIPTION
## Description

This PR expands SATWND AMV support by adding new BUFR-to-IODA converter configurations (adapted from GDASApp) and corresponding observation YAMLs (adapted from 245/246 jcb-rdas templates) for additional satellite wind sources from IR and WV channels. Visible channels are not yet addressed.

This expansion is based on observation types noted to have been assimilated in the RRFSv1 real-time system. Some of these sources may have limited utility for a North American regional domain depending on their spatial coverage and data availability, but they are included here to provide a more complete SATWND AMV ingest and configuration baseline for testing.

The main additions include support for:

- GOES-19 ABI SATWND AMVs, satellite ID 273
- Himawari AHI SATWND AMVs, including H8/H9 metadata
- Meteosat SEVIRI SATWND AMVs, including M8/M9/M10/M11 metadata
- AVHRR SATWND AMVs from NOAA-15/18/19
- MODIS SATWND AMVs from Aqua/Terra
- VIIRS SATWND AMVs from S-NPP/NOAA-20/NOAA-21
- LEOGEO combined-platform SATWND AMVs

This also adds JCB observation YAMLs for the newly supported SATWND wind type and satellite ID combinations.

## Changes

- Added new `bufr2ioda_satwnd_amv_*` converter scripts and JSON configuration files for AHI, AVHRR, LEOGEO, MODIS, SEVIRI, and VIIRS.
- Updated the GOES SATWND AMV metadata to include GOES-19 / satellite ID 273.
- Added new SATWND JCB YAML templates for additional wind type and satellite ID combinations:
  - `satwnd_winds_245_273`
  - `satwnd_winds_246_273`
  - `satwnd_winds_247_273`
  - `satwnd_winds_250_174`
  - `satwnd_winds_252_174`
  - `satwnd_winds_253_56`
  - `satwnd_winds_253_57`

## Notes

This PR primarily adds support infrastructure for expanded SATWND AMV ingest and JCB configuration. Not all added sources are expected to have equal value in a North American regional application, and some may provide little or no coverage for a given RRFS domain. The intent is to make the broader SATWND AMV set available so that useful sources can be identified through follow-on domain checks, cycling tests, and forecast-impact validation.

Forecast-impact validation should be handled in follow-on testing experiments.

## Issue(s) addressed
https://github.com/NOAA-EMC/RDASApp/issues/266

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
