### PR TITLE
Add bufr2netcdf yaml file for mtiasi data

### DIFF
--- a/rrfs-test/IODA/yaml/bufr2netcdf_mtiasi.yaml
+++ b/rrfs-test/IODA/yaml/bufr2netcdf_mtiasi.yaml
@@ -1,0 +1,225 @@
+bufr:
+  variables:
+    # MetaData
+    timestamp:
+      datetime:
+        year: "*/YEAR"
+        month: "*/MNTH"
+        day: "*/DAYS"
+        hour: "*/HOUR"
+        minute: "*/MINU"
+        second: "*/SECO"
+
+    latitude:
+      query: "*/CLATH"
+
+    longitude:
+      query: "*/CLONH"
+
+    satelliteId:
+      query: "*/SAID"
+
+    sensorId:
+      query: "*/SIID[1]"
+
+    scanLineNumber:
+      query: "*/SLNM"
+
+    gqisFlagQual:
+      query: "*/QGFQ"
+
+    fieldOfViewNumber:
+      query: "*/FOVN"
+
+    sensorScanPosition:
+      sensorScanPosition:
+        fieldOfViewNumber: "*/FOVN"
+        sensor: iasi
+
+    solarZenithAngle:
+      query: "*/SOZA"
+
+    solarAzimuthAngle:
+      query: "*/SOLAZI"
+
+    sensorZenithAngle:
+      query: "*/SAZA"
+
+    sensorAzimuthAngle:
+      query: "*/BEARAZ"
+
+    stationElevation:
+      query: "*/SELV"
+      type: float
+
+    sensorViewAngle:
+      sensorScanAngle:
+        fieldOfViewNumber: "*/FOVN"
+        scanStart: -48.330
+        scanStep: 3.334
+        scanStepAdjust: 0.625
+        sensor: iasi
+
+    sensorChannelNumber:
+      query: "*/IASICHN/CHNM"
+
+    # ObsValue
+    fractionOfClearPixelsInFOV:
+      query: "*/IASIL1CS{1}/FCPH"
+      type: float
+      transforms:
+        - scale: 0.01
+
+    spectralRadiance:
+      spectralRadiance:
+        sensorChannelNumber: "*/IASICHN/CHNM"
+        startChannel: "*/IASIL1CB/STCH"
+        endChannel: "*/IASIL1CB/ENCH"
+        scaleFactor: "*/IASIL1CB/CHSF"
+        scaledSpectralRadiance: "*/IASICHN/SCRA"
+
+  splits:
+    satId:
+      category:
+        variable: satelliteId
+        map:
+          _3: metop-b
+          _4: metop-a
+          _5: metop-c
+
+encoder:
+  dimensions:
+    - name: Channel
+      source: variables/sensorChannelNumber
+      path: "*/IASICHN"
+
+  globals:
+    - name: "description"
+      type: string
+      value: "IASI Level-1C radiance spectra, calibrated, geolocated, and apodized using the standard Hamming window to suppress spectral sidelobes"
+
+    - name: "platformCommonName"
+      type: string
+      value: "MetOp"
+
+    - name: "platformLongDescription"
+      type: string
+      value: "Meteorological Operational Satellite"
+
+    - name: "sensorCommonName"
+      type: string
+      value: "IASI"
+
+    - name: "sensorLongDescription"
+      type: string
+      value: "Infrared Atmospheric Sounding Interferometer with 8461 channels with one embedded IR imaging channel; corss-track scanning"
+
+    - name: "source"
+      type: string
+      value: "U.S. National Weather Service, National Centres for Environmental Prediction (NCEP))"
+
+    - name: "sourceFiles"
+      type: string
+      value: "NCEP BUFR Dump - mtiasi NC021241 Normal Feed 616 channel subset"
+
+    - name: "processingLevel"
+      type: string
+      value: "Level-1C"
+
+    - name: "converter"
+      type: string
+      value: "bufr-query"
+
+  variables:
+
+    # MetaData
+    - name: "MetaData/dateTime"
+      source: variables/timestamp
+      longName: "Datetime"
+      units: "seconds since 1970-01-01T00:00:00Z"
+
+    - name: "MetaData/latitude"
+      source: variables/latitude
+      longName: "Latitude"
+      units: "degrees_north"
+      range: [ -90, 90 ]
+
+    - name: "MetaData/longitude"
+      source: variables/longitude
+      longName: "Longitude"
+      units: "degrees_east"
+      range: [ -180, 180 ]
+
+    - name: "MetaData/satelliteIdentifier"
+      source: variables/satelliteId
+      longName: "Satellite Identifier"
+
+    - name: "MetaData/instrumentIdentifier"
+      source: variables/sensorId
+      longName: "Satellite Instrument Identifier"
+
+    - name: "MetaData/scanLineNumber"
+      source: variables/scanLineNumber
+      longName: "Scan Line Number"
+
+    - name: "MetaData/qualityFlags"
+      source: variables/gqisFlagQual
+      longName: "Individual IASI-System Quality Flag"
+
+    - name: "MetaData/fieldOfViewNumber"
+      source: variables/fieldOfViewNumber
+      longName: "Field of View Number"
+
+    - name: "MetaData/sensorScanPosition"
+      source: variables/sensorScanPosition
+      longName: "Sensor Scan Position"
+
+    - name: "MetaData/solarZenithAngle"
+      source: variables/solarZenithAngle
+      longName: "Solar Zenith Angle"
+      units: "degree"
+      range: [ 0, 180 ]
+
+    - name: "MetaData/solarAzimuthAngle"
+      source: variables/solarAzimuthAngle
+      longName: "Solar Azimuth Angle"
+      units: "degree"
+      range: [ 0, 360 ]
+
+    - name: "MetaData/sensorZenithAngle"
+      source: variables/sensorZenithAngle
+      longName: "Sensor Zenith Angle"
+      units: "degree"
+      range: [ 0, 90 ]
+
+    - name: "MetaData/sensorAzimuthAngle"
+      source: variables/sensorAzimuthAngle
+      longName: "Sensor Azimuth Angle"
+      units: "degree"
+      range: [ 0, 360 ]
+
+    - name: "MetaData/sensorViewAngle"
+      source: variables/sensorViewAngle
+      longName: "Sensor View Angle"
+      units: "degree"
+
+    - name: "MetaData/stationElevation"
+      source: variables/stationElevation
+      longName: "Altitude of Satellite"
+      units: "m"
+
+    - name: "MetaData/sensorChannelNumber"
+      source: variables/sensorChannelNumber
+      longName: "Sensor Channel Number"
+
+    - name: "ObsValue/cloudFree"
+      source: variables/fractionOfClearPixelsInFOV
+      longName: "Fraction of Clear Pixels in a Field of View"
+      units: "1"
+      range: [ 0, 1 ]
+
+    - name: "ObsValue/spectralRadiance"
+      source: variables/spectralRadiance
+      longName: "IASI Spectral Radiance"
+      units: "W m-2 sr-1 m-1"
+


### PR DESCRIPTION
## Description
Add bufr2netcdf yaml file for mtiasi data
bufr2netcdf_mtiasi.yaml file came from EMC/bufr-query: https://github.com/NOAA-EMC/bufr-query/blob/develop/test/testinput/bufrtest_mtiasi_mapping.yaml
## Issue(s) addressed
Resolves/Results are documented in Issue #

## Dependencies (if applicable)
List the other PRs that this PR is dependent on:
- related PR: https://github.com/NOAA-EMC/rrfs-workflow/pull/1499

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
