### PR TITLE
Output bogus ObsError group for satwnd IODA converters

### DIFF
--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_ahi.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_ahi.py
@@ -449,6 +449,22 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Northward Wind Component') \
                 .write_data(vob2)
 
+            # Placeholder ObsError values needed for later JEDI processing
+            uerr2 = ma.array(np.full_like(uob2, 999.0), mask=ma.getmaskarray(uob2))
+            verr2 = ma.array(np.full_like(vob2, 999.0), mask=ma.getmaskarray(vob2))
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Eastward Wind Component') \
+                .write_data(uerr2)
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Northward Wind Component') \
+                .write_data(verr2)
+
             end_time = time.time()
             running_time = end_time - start_time
             total_ob_processed += len(satid2)

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_avhrr.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_avhrr.py
@@ -444,6 +444,22 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Northward Wind Component') \
                 .write_data(vob2)
 
+            # Placeholder ObsError values needed for later JEDI processing
+            uerr2 = ma.array(np.full_like(uob2, 999.0), mask=ma.getmaskarray(uob2))
+            verr2 = ma.array(np.full_like(vob2, 999.0), mask=ma.getmaskarray(vob2))
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Eastward Wind Component') \
+                .write_data(uerr2)
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Northward Wind Component') \
+                .write_data(verr2)
+
             end_time = time.time()
             running_time = end_time - start_time
             total_ob_processed += len(satid2)

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_goes.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_goes.py
@@ -476,6 +476,22 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Northward Wind Component') \
                 .write_data(vob2)
 
+            # Placeholder ObsError values needed for later JEDI processing
+            uerr2 = ma.array(np.full_like(uob2, 999.0), mask=ma.getmaskarray(uob2))
+            verr2 = ma.array(np.full_like(vob2, 999.0), mask=ma.getmaskarray(vob2))
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Eastward Wind Component') \
+                .write_data(uerr2)
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Northward Wind Component') \
+                .write_data(verr2)
+
             end_time = time.time()
             running_time = end_time - start_time
             total_ob_processed += len(satid2)

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_leogeo.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_leogeo.py
@@ -416,6 +416,22 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Northward Wind Component') \
                 .write_data(vob2)
 
+            # Placeholder ObsError values needed for later JEDI processing
+            uerr2 = ma.array(np.full_like(uob2, 999.0), mask=ma.getmaskarray(uob2))
+            verr2 = ma.array(np.full_like(vob2, 999.0), mask=ma.getmaskarray(vob2))
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Eastward Wind Component') \
+                .write_data(uerr2)
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Northward Wind Component') \
+                .write_data(verr2)
+
             end_time = time.time()
             running_time = end_time - start_time
             total_ob_processed += len(satid2)

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_modis.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_modis.py
@@ -448,6 +448,22 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Northward Wind Component') \
                 .write_data(vob2)
 
+            # Placeholder ObsError values needed for later JEDI processing
+            uerr2 = ma.array(np.full_like(uob2, 999.0), mask=ma.getmaskarray(uob2))
+            verr2 = ma.array(np.full_like(vob2, 999.0), mask=ma.getmaskarray(vob2))
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Eastward Wind Component') \
+                .write_data(uerr2)
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Northward Wind Component') \
+                .write_data(verr2)
+
             end_time = time.time()
             running_time = end_time - start_time
             total_ob_processed += len(satid2)

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_seviri.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_seviri.py
@@ -422,6 +422,22 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Northward Wind Component') \
                 .write_data(vob2)
 
+            # Placeholder ObsError values needed for later JEDI processing
+            uerr2 = ma.array(np.full_like(uob2, 999.0), mask=ma.getmaskarray(uob2))
+            verr2 = ma.array(np.full_like(vob2, 999.0), mask=ma.getmaskarray(vob2))
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Eastward Wind Component') \
+                .write_data(uerr2)
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Northward Wind Component') \
+                .write_data(verr2)
+
             end_time = time.time()
             running_time = end_time - start_time
             total_ob_processed += len(satid2)

--- a/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_viirs.py
+++ b/rrfs-test/IODA/python/bufr2ioda_satwnd_amv_viirs.py
@@ -444,6 +444,22 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Northward Wind Component') \
                 .write_data(vob2)
 
+            # Placeholder ObsError values needed for later JEDI processing
+            uerr2 = ma.array(np.full_like(uob2, 999.0), mask=ma.getmaskarray(uob2))
+            verr2 = ma.array(np.full_like(vob2, 999.0), mask=ma.getmaskarray(vob2))
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Eastward Wind Component') \
+                .write_data(uerr2)
+
+            # Add bogus values for ObsError needed for L/GETKF
+            obsspace.create_var('ObsError/windNorthward', dtype=vob2.dtype, fillval=wspd2.fill_value) \
+                .write_attr('units', 'm s-1') \
+                .write_attr('long_name', 'Error for Northward Wind Component') \
+                .write_data(verr2)
+
             end_time = time.time()
             running_time = end_time - start_time
             total_ob_processed += len(satid2)


### PR DESCRIPTION

## Description

This PR adds an ObsError group and associated variables to the satwnd IODA converters. The ObsError group needs to exist in the IODA files when assimilating any observations in L/GETKF. It can be filled with bogus values (here we use 999) since the UFO filters will later assign the correct values. 

This has been tested to work in the ongoing GETKF parallel. 

## Issue(s) addressed
None

## Dependencies (if applicable)
None

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [x] Unit tests added/updated (if applicable).
