### PR TITLE
Update SATWND yamls

### DIFF
--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_242_174.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_242_174.yaml.j2
@@ -225,6 +225,23 @@
            action:
              name: reject
 
+         # Reject obs with pressure < 125 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 12500.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
          # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
            udescriptor: "difference_check_tropopause_pressure"

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_242_174.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_242_174.yaml.j2
@@ -1,0 +1,312 @@
+     - obs space:
+         name: satwnd_winds_242_174
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: "data/obs/ioda_satwnd.ahi_h9.nc"
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_242_174.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (242)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: {{iuse_satwnd_winds_242_174 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 242
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 174
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0]
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 85. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 85.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with pressure < 700 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 70000.
+           - variable: ObsType/windEastward
+             is_in: 242
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 242 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 242 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_243_56.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_243_56.yaml.j2
@@ -1,0 +1,312 @@
+     - obs space:
+         name: satwnd_winds_243_56
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: '{{ satwnd_winds_243_56_obsfile | default("data/obs/ioda_satwnd.seviri_meteosat-56.nc", true) }}'
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_243_56.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (243)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: {{iuse_satwnd_winds_243_56 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 243
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 56
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reduce obs space
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0]
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 85. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 85.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Reject obs with pressure < 700 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 70000.
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 243 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 243 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_243_56.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_243_56.yaml.j2
@@ -225,6 +225,23 @@
            action:
              name: reject
 
+         # Reject obs with pressure < 125 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 12500.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
          # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
            udescriptor: "difference_check_tropopause_pressure"

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_243_57.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_243_57.yaml.j2
@@ -1,0 +1,312 @@
+     - obs space:
+         name: satwnd_winds_243_57
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: '{{ satwnd_winds_243_57_obsfile | default("data/obs/ioda_satwnd.seviri_meteosat-57.nc", true) }}'
+             missing file action: "warn"
+         obsdataout:
+           empty obs space action: "{{empty_obs_space_action}}"
+           write multiple files: {{write_multiple_files | default(false) }}
+           engine:
+             type: H5File
+             obsfile: jdiag_satwnd_winds_243_57.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{ max_pool_size | default(1) }}
+         observed variables: [windEastward, windNorthward]
+         simulated variables: [windEastward, windNorthward]
+
+       obs operator:
+           name: VertInterp
+           vertical coordinate: air_pressure
+           observation vertical coordinate: pressure
+           observation vertical coordinate group: MetaData
+           interpolation method: log-linear
+           variables:
+           - name: windEastward
+           - name: windNorthward
+
+       linear obs operator:
+         name: VertInterp
+
+       obs error:
+         covariance model: diagonal
+
+       obs filters:
+         # ------------------
+         # wind (243)
+         # ------------------
+         # Accept, reject, or passivate (monitor)
+         - filter: Perform Action
+           udescriptor: "iuse_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: {{iuse_satwnd_winds_243_57 | default("passivate", true)}} # accept, reject, passivate
+
+         # Reject all obs not in type
+         - filter: Perform Action
+           udescriptor: "obs_type_check"
+           where:
+           - variable: ObsValue/windEastward
+             value: is_not_valid
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in kx
+         - filter: Perform Action
+           udescriptor: "obs_kx_check"
+           where:
+           - variable: ObsType/windEastward
+             is_not_in: 243
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
+           - variable: MetaData/satelliteIdentifier
+             is_not_in: 57
+           action:
+             name: reduce obs space
+
+         # Time window filter
+         - filter: Bounds Check
+           udescriptor: "time_window_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/timeOffset
+           minvalue: -5400
+           maxvalue: 5400
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reduce obs space
+
+         # Duplicate Check
+         - filter: Temporal Thinning
+           udescriptor: "duplicate_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           min_spacing: PT90M
+           tolerance: PT0H
+           seed_time: "{{atmosphere_background_time_iso}}"
+           category_variable:
+             name: MetaData/longitude_latitude_pressure
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reduce obs space
+
+         # Initial error assignment
+         - filter: Perform Action
+           udescriptor: "initial_error_assignment"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: assign error
+             error function:
+               name: ObsFunction/ObsErrorModelStepwiseLinear
+               options:
+                 xvar:
+                   name: MetaData/pressure
+                 xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0]
+
+{% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
+         # Error inflation (windEastward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windEastward
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windEastward
+                 inflation factor: 4.0
+
+         # Error inflation (windNorthward) based on pressure check (setupw.f90)
+         - filter: Perform Action
+           udescriptor: "error_inflation_pressure_check"
+           filter variables:
+           - name: windNorthward
+           where:
+           - variable: ObsType/windNorthward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: inflate error
+             inflation variable:
+               name: ObsFunction/ObsErrorFactorPressureCheck
+               options:
+                 variable: windNorthward
+                 inflation factor: 4.0
+{% endif %}  # END use_error_inflation
+
+         # Bounds Check (ObsValue)
+         - filter: Bounds Check
+           udescriptor: "bounds_check_ObsValue"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           minvalue: -200
+           maxvalue: 200
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reduce obs space
+
+         # Reject obs with qiWithoutForecast < 85. OR > 100.
+         - filter: Bounds Check
+           udescriptor: "bounds_check_qifn"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/qiWithoutForecast
+           minvalue: 85.
+           maxvalue: 100.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject obs with satellite zenith angle > 68
+         - filter: Bounds Check
+           udescriptor: "bounds_check_satellite_zenith_angle"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/satelliteZenithAngle
+           maxvalue: 68.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject when pressure is more than 50 mb above tropopause
+         - filter: Difference Check
+           udescriptor: "difference_check_tropopause_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/tropopause_pressure
+           value: MetaData/pressure
+           minvalue: -5000.  # 50 hPa above tropopause level, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject any observation within 100 mb of the surface pressure
+         - filter: Difference Check
+           udescriptor: "difference_check_air_pressure_at_surface"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           reference: GeoVaLs/air_pressure_at_surface
+           value: MetaData/pressure
+           maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Reject obs with pressure < 700 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             maxvalue: 70000.
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
+         # Gross Error Check (windEastward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windEastward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 243 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windEastward
+           action:
+             name: reject
+           defer to post: true
+
+         # Gross Error Check (windNorthward)
+         - filter: Background Check
+           udescriptor: "gross_error_check"
+           apply at iterations: 0,1
+           filter variables:
+           - name: windNorthward
+           function absolute threshold:
+           - name: ObsFunction/WindsSPDBCheck
+             options:
+               wndtype:    [ 243 ]
+               cgross:     [ 2.5 ]
+               error_min:  [ 1.4 ]
+               error_max:  [ 5.0 ]
+               variable: windNorthward
+           action:
+             name: reject
+           defer to post: true

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_243_57.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_243_57.yaml.j2
@@ -225,6 +225,23 @@
            action:
              name: reject
 
+         # Reject obs with pressure < 125 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 12500.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 243
+           - variable: MetaData/satelliteIdentifier
+             is_in: 57
+           action:
+             name: reject
+
          # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
            udescriptor: "difference_check_tropopause_pressure"

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_270.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_270.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 245
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 270
            action:
@@ -107,17 +114,6 @@
              is_in: 270
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -383,7 +379,7 @@
            action:
              name: reject
 
-         # Reject when pressure between 399 and 801 mb.
+         # Reject obs with pressure > 399 mb and < 801 mb.
          - filter: Perform Action
            udescriptor: "pressure_range_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_272.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_272.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 245
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 272
            action:
@@ -107,17 +114,6 @@
              is_in: 272
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -383,7 +379,7 @@
            action:
              name: reject
 
-         # Reject when pressure between 399 and 801 mb.
+         # Reject obs with pressure > 399 mb and < 801 mb.
          - filter: Perform Action
            udescriptor: "pressure_range_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_273.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_245_273.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 245
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 273
            action:
@@ -107,17 +114,6 @@
              is_in: 273
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -383,7 +379,7 @@
            action:
              name: reject
 
-         # Reject when pressure between 399 and 801 mb.
+         # Reject obs with pressure > 399 mb and < 801 mb.
          - filter: Perform Action
            udescriptor: "pressure_range_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_270.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_270.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 246
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 270
            action:
@@ -107,17 +114,6 @@
              is_in: 270
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -244,7 +240,7 @@
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb and  > 300 mb
+         # Reject obs with pressure < 150 mb OR > 300 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
@@ -359,6 +355,22 @@
            value: MetaData/pressure
            maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
            where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 270
+           action:
+             name: reject
+
+         # Reject obs with pressure > 399 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 39901.
            - variable: ObsType/windEastward
              is_in: 246
            - variable: MetaData/satelliteIdentifier

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_272.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_272.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 246
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 272
            action:
@@ -107,17 +114,6 @@
              is_in: 272
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -244,7 +240,7 @@
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb and  > 300 mb
+         # Reject obs with pressure < 150 mb OR > 300 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
@@ -359,6 +355,22 @@
            value: MetaData/pressure
            maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
            where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 272
+           action:
+             name: reject
+
+         # Reject obs with pressure > 399 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 39901.
            - variable: ObsType/windEastward
              is_in: 246
            - variable: MetaData/satelliteIdentifier

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_273.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_246_273.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 246
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 273
            action:
@@ -107,17 +114,6 @@
              is_in: 273
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -244,7 +240,7 @@
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb and  > 300 mb
+         # Reject obs with pressure < 150 mb OR > 300 mb
          - filter: Bounds Check
            udescriptor: "bounds_check_pressure"
            filter variables:
@@ -359,6 +355,22 @@
            value: MetaData/pressure
            maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
            where:
+           - variable: ObsType/windEastward
+             is_in: 246
+           - variable: MetaData/satelliteIdentifier
+             is_in: 273
+           action:
+             name: reject
+
+         # Reject obs with pressure > 399 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 39901.
            - variable: ObsType/windEastward
              is_in: 246
            - variable: MetaData/satelliteIdentifier

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_270.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_270.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 247
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 270
            action:
@@ -107,17 +114,6 @@
              is_in: 270
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -333,7 +329,7 @@
 
          # Reject obs within 110 mb of surface pressure over non-water surface
          - filter: Difference Check
-           udescriptor: "difference_check_surface_pressure"
+           udescriptor: "difference_check_air_pressure_at_surface"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -348,11 +344,11 @@
              is_in: 270
            reference: GeoVaLs/air_pressure_at_surface
            value: MetaData/pressure
-           maxvalue: -11000.                   # within 110 hPa above surface pressure, negative p-diff
+           maxvalue: -11000.  # within 110 hPa above surface pressure, negative p-diff
            action:
              name: reject
 
-         # Reject when difference of wind direction between obs and background is more than 50 degrees
+         # Reject when wind direction o-b is more than 50 degrees
          - filter: Bounds Check
            udescriptor: "wind_direction_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_272.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_272.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 247
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 272
            action:
@@ -107,17 +114,6 @@
              is_in: 272
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -333,7 +329,7 @@
 
          # Reject obs within 110 mb of surface pressure over non-water surface
          - filter: Difference Check
-           udescriptor: "difference_check_surface_pressure"
+           udescriptor: "difference_check_air_pressure_at_surface"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -348,11 +344,11 @@
              is_in: 272
            reference: GeoVaLs/air_pressure_at_surface
            value: MetaData/pressure
-           maxvalue: -11000.                   # within 110 hPa above surface pressure, negative p-diff
+           maxvalue: -11000.  # within 110 hPa above surface pressure, negative p-diff
            action:
              name: reject
 
-         # Reject when difference of wind direction between obs and background is more than 50 degrees
+         # Reject when wind direction o-b is more than 50 degrees
          - filter: Bounds Check
            udescriptor: "wind_direction_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_273.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_247_273.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 247
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 273
            action:
@@ -107,17 +114,6 @@
              is_in: 273
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -333,7 +329,7 @@
 
          # Reject obs within 110 mb of surface pressure over non-water surface
          - filter: Difference Check
-           udescriptor: "difference_check_surface_pressure"
+           udescriptor: "difference_check_air_pressure_at_surface"
            filter variables:
            - name: windEastward
            - name: windNorthward
@@ -348,11 +344,11 @@
              is_in: 273
            reference: GeoVaLs/air_pressure_at_surface
            value: MetaData/pressure
-           maxvalue: -11000.                   # within 110 hPa above surface pressure, negative p-diff
+           maxvalue: -11000.  # within 110 hPa above surface pressure, negative p-diff
            action:
              name: reject
 
-         # Reject when difference of wind direction between obs and background is more than 50 degrees
+         # Reject when wind direction o-b is more than 50 degrees
          - filter: Bounds Check
            udescriptor: "wind_direction_check"
            filter variables:

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_250_174.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_250_174.yaml.j2
@@ -225,6 +225,23 @@
            action:
              name: reject
 
+         # Reject obs with pressure < 125 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 12500.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
          # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
            udescriptor: "difference_check_tropopause_pressure"

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_250_174.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_250_174.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 250
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 174
            action:
@@ -107,17 +114,6 @@
              is_in: 174
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -176,21 +172,6 @@
                options:
                  variable: windNorthward
                  inflation factor: 4.0
-
-         # Halve the ob error (based on read_satwnd.f90)
-         - filter: Perform Action
-           udescriptor: "ob_error_inflation"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsType/windEastward
-             is_in: 250
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: inflate error
-             inflation factor: 0.5
 {% endif %}  # END use_error_inflation
 
          # Bounds Check (ObsValue)
@@ -209,7 +190,7 @@
            action:
              name: reduce obs space
 
-         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         # Reject obs with qiWithoutForecast < 85. OR > 100.
          - filter: Bounds Check
            udescriptor: "bounds_check_qifn"
            filter variables:
@@ -217,7 +198,7 @@
            - name: windNorthward
            test variables:
            - name: MetaData/qiWithoutForecast
-           minvalue: 90.
+           minvalue: 85.
            maxvalue: 100.
            where:
            - variable: ObsType/windEastward
@@ -243,95 +224,6 @@
              is_in: 174
            action:
              name: reject
-
-         # Reject obs with pressure < 150 mb and  > 300 mb
-         - filter: Bounds Check
-           udescriptor: "bounds_check_pressure"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/pressure
-           minvalue: 15000.
-           #maxvalue: 30000.
-           maxvalue: 40000.
-           where:
-           - variable: ObsType/windEastward
-             is_in: 250
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: reject
-
-         # Reject obs over land (isli=1) where pressure > 850 mb
-         - filter: Perform Action
-           udescriptor: "bounds_check_pressure_over_land"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: MetaData/pressure
-             minvalue: 85000.
-           - variable: GeoVaLs/land_area_fraction
-             minvalue: 0.99
-           - variable: ObsType/windEastward
-             is_in: 250
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: reject
-
-         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
-         - filter: Bounds Check
-           udescriptor: "bounds_check_pct1"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/coefficientOfVariation
-           minvalue: 0.04
-           maxvalue: 0.5
-           where:
-           - variable: ObsType/windEastward
-             is_in: 250
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: reject
-
-         # Low wind speed check
-         - filter: Perform Action
-           udescriptor: "reject_low_speed_amv"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             maxvalue: 0.1
-           - variable: ObsType/windEastward
-             is_in: 250
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: reject
-
-         ## AMV expected error norm check
-         #- filter: Perform Action
-         #  udescriptor: "amv_experr_norm_check"
-         #  filter variables:
-         #  - name: windEastward
-         #  - name: windNorthward
-         #  where:
-         #  - variable: ObsFunction/Velocity
-         #    minvalue: 0.1
-         #  - variable: MetaData/exp_err_norm
-         #    minvalue: 0.9
-         #  - variable: ObsType/windEastward
-         #    is_in: 250
-         #  - variable: MetaData/satelliteIdentifier
-         #    is_in: 174
-         #  action:
-         #    name: reject
 
          # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
@@ -360,6 +252,22 @@
            value: MetaData/pressure
            maxvalue: -10000.  # within 100 hPa above surface pressure, negative p-diff
            where:
+           - variable: ObsType/windEastward
+             is_in: 250
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
+         # Reject obs with pressure > 399 mb.
+         - filter: Perform Action
+           udescriptor: "pressure_range_check"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           where:
+           - variable: MetaData/pressure
+             minvalue: 39901.
            - variable: ObsType/windEastward
              is_in: 250
            - variable: MetaData/satelliteIdentifier

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_252_174.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_252_174.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 252
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 174
            action:
@@ -107,17 +114,6 @@
              is_in: 174
            action:
              name: reduce obs space
-
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
 
          # Initial error assignment
          - filter: Perform Action
@@ -176,21 +172,6 @@
                options:
                  variable: windNorthward
                  inflation factor: 4.0
-
-         # Halve the ob error (based on read_satwnd.f90)
-         - filter: Perform Action
-           udescriptor: "ob_error_inflation"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsType/windEastward
-             is_in: 252
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: inflate error
-             inflation factor: 0.5
 {% endif %}  # END use_error_inflation
 
          # Bounds Check (ObsValue)
@@ -209,7 +190,7 @@
            action:
              name: reduce obs space
 
-         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         # Reject obs with qiWithoutForecast < 85. OR > 100.
          - filter: Bounds Check
            udescriptor: "bounds_check_qifn"
            filter variables:
@@ -217,7 +198,7 @@
            - name: windNorthward
            test variables:
            - name: MetaData/qiWithoutForecast
-           minvalue: 90.
+           minvalue: 85.
            maxvalue: 100.
            where:
            - variable: ObsType/windEastward
@@ -244,59 +225,6 @@
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb
-         - filter: Bounds Check
-           udescriptor: "bounds_check_pressure"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/pressure
-           minvalue: 15000.
-           where:
-           - variable: ObsType/windEastward
-             is_in: 252
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: reject
-
-         # Reject obs over land (isli=1) where pressure > 850 mb
-         - filter: Perform Action
-           udescriptor: "bounds_check_pressure_over_land"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: MetaData/pressure
-             minvalue: 85000.
-           - variable: GeoVaLs/land_area_fraction
-             minvalue: 0.99
-           - variable: ObsType/windEastward
-             is_in: 252
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: reject
-
-         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
-         - filter: Bounds Check
-           udescriptor: "bounds_check_pct1"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/coefficientOfVariation
-           minvalue: 0.04
-           maxvalue: 0.5
-           where:
-           - variable: ObsType/windEastward
-             is_in: 252
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: reject
-
          # Reject data over non-water surface type where latitude > 20N
          - filter: Perform Action
            udescriptor: "bounds_check_reject_over_nonwater"
@@ -314,40 +242,6 @@
              is_in: 174
            action:
              name: reject
-
-         # Low wind speed check
-         - filter: Perform Action
-           udescriptor: "reject_low_speed_amv"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             maxvalue: 0.1
-           - variable: ObsType/windEastward
-             is_in: 252
-           - variable: MetaData/satelliteIdentifier
-             is_in: 174
-           action:
-             name: reject
-
-         ## AMV expected error norm check
-         #- filter: Perform Action
-         #  udescriptor: "amv_experr_norm_check"
-         #  filter variables:
-         #  - name: windEastward
-         #  - name: windNorthward
-         #  where:
-         #  - variable: ObsFunction/Velocity
-         #    minvalue: 0.1
-         #  - variable: MetaData/exp_err_norm
-         #    minvalue: 0.9
-         #  - variable: ObsType/windEastward
-         #    is_in: 252
-         #  - variable: MetaData/satelliteIdentifier
-         #    is_in: 174
-         #  action:
-         #    name: reject
 
          # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
@@ -383,7 +277,7 @@
            action:
              name: reject
 
-         # Reject when pressure between 399 and 801 mb.
+         # Reject obs with pressure > 499 mb and < 801 mb.
          - filter: Perform Action
            udescriptor: "pressure_range_check"
            filter variables:
@@ -391,7 +285,7 @@
            - name: windNorthward
            where:
            - variable: MetaData/pressure
-             minvalue: 39901.
+             minvalue: 49901.
              maxvalue: 80099.
            - variable: ObsType/windEastward
              is_in: 252

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_252_174.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_252_174.yaml.j2
@@ -225,6 +225,23 @@
            action:
              name: reject
 
+         # Reject obs with pressure < 125 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 12500.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 252
+           - variable: MetaData/satelliteIdentifier
+             is_in: 174
+           action:
+             name: reject
+
          # Reject data over non-water surface type where latitude > 20N
          - filter: Perform Action
            udescriptor: "bounds_check_reject_over_nonwater"

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_56.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_56.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 253
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 56
            action:
@@ -108,17 +115,6 @@
            action:
              name: reduce obs space
 
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
-
          # Initial error assignment
          - filter: Perform Action
            udescriptor: "initial_error_assignment"
@@ -138,7 +134,7 @@
                  xvar:
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
-                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0] 
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0]
 
 {% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
          # Error inflation (windEastward) based on pressure check (setupw.f90)
@@ -176,21 +172,6 @@
                options:
                  variable: windNorthward
                  inflation factor: 4.0
-
-         # Halve the ob error (based on read_satwnd.f90)
-         - filter: Perform Action
-           udescriptor: "ob_error_inflation"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 56
-           action:
-             name: inflate error
-             inflation factor: 0.5
 {% endif %}  # END use_error_inflation
 
          # Bounds Check (ObsValue)
@@ -209,7 +190,7 @@
            action:
              name: reduce obs space
 
-         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         # Reject obs with qiWithoutForecast < 85. OR > 100.
          - filter: Bounds Check
            udescriptor: "bounds_check_qifn"
            filter variables:
@@ -217,7 +198,7 @@
            - name: windNorthward
            test variables:
            - name: MetaData/qiWithoutForecast
-           minvalue: 90.
+           minvalue: 85.
            maxvalue: 100.
            where:
            - variable: ObsType/windEastward
@@ -244,59 +225,6 @@
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb
-         - filter: Bounds Check
-           udescriptor: "bounds_check_pressure"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/pressure
-           minvalue: 15000.
-           where:
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 56
-           action:
-             name: reject
-
-         # Reject obs over land (isli=1) where pressure > 850 mb
-         - filter: Perform Action
-           udescriptor: "bounds_check_pressure_over_land"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: MetaData/pressure
-             minvalue: 85000.
-           - variable: GeoVaLs/land_area_fraction
-             minvalue: 0.99
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 56
-           action:
-             name: reject
-
-         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
-         - filter: Bounds Check
-           udescriptor: "bounds_check_pct1"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/coefficientOfVariation
-           minvalue: 0.04
-           maxvalue: 0.5
-           where:
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 56
-           action:
-             name: reject
-
          # Reject data over non-water surface type where latitude > 20N
          - filter: Perform Action
            udescriptor: "bounds_check_reject_over_nonwater"
@@ -314,40 +242,6 @@
              is_in: 56
            action:
              name: reject
-
-         # Low wind speed check
-         - filter: Perform Action
-           udescriptor: "reject_low_speed_amv"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             maxvalue: 0.1
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 56
-           action:
-             name: reject
-
-         ## AMV expected error norm check
-         #- filter: Perform Action
-         #  udescriptor: "amv_experr_norm_check"
-         #  filter variables:
-         #  - name: windEastward
-         #  - name: windNorthward
-         #  where:
-         #  - variable: ObsFunction/Velocity
-         #    minvalue: 0.1
-         #  - variable: MetaData/exp_err_norm
-         #    minvalue: 0.9
-         #  - variable: ObsType/windEastward
-         #    is_in: 253
-         #  - variable: MetaData/satelliteIdentifier
-         #    is_in: 56
-         #  action:
-         #    name: reject
 
          # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
@@ -383,7 +277,7 @@
            action:
              name: reject
 
-         # Reject when pressure between 399 and 801 mb.
+         # Reject obs with pressure > 401 mb and < 801 mb.
          - filter: Perform Action
            udescriptor: "pressure_range_check"
            filter variables:
@@ -391,7 +285,7 @@
            - name: windNorthward
            where:
            - variable: MetaData/pressure
-             minvalue: 39901.
+             minvalue: 40101.
              maxvalue: 80099.
            - variable: ObsType/windEastward
              is_in: 253

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_56.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_56.yaml.j2
@@ -225,6 +225,23 @@
            action:
              name: reject
 
+         # Reject obs with pressure < 125 mb
+         - filter: Bounds Check
+           udescriptor: "bounds_check_pressure"
+           filter variables:
+           - name: windEastward
+           - name: windNorthward
+           test variables:
+           - name: MetaData/pressure
+           minvalue: 12500.
+           where:
+           - variable: ObsType/windEastward
+             is_in: 253
+           - variable: MetaData/satelliteIdentifier
+             is_in: 56
+           action:
+             name: reject
+
          # Reject data over non-water surface type where latitude > 20N
          - filter: Perform Action
            udescriptor: "bounds_check_reject_over_nonwater"

--- a/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_57.yaml.j2
+++ b/parm/jcb-rdas/observations/atmosphere/satwnd_winds_253_57.yaml.j2
@@ -66,6 +66,13 @@
            where:
            - variable: ObsType/windEastward
              is_not_in: 253
+           action:
+             name: reduce obs space
+
+         # Reject all obs not in subtype
+         - filter: Perform Action
+           udescriptor: "obs_subtype_check"
+           where:
            - variable: MetaData/satelliteIdentifier
              is_not_in: 57
            action:
@@ -108,17 +115,6 @@
            action:
              name: reduce obs space
 
-         # Online domain check
-         - filter: Bounds Check
-           udescriptor: "online_domain_check"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name:  GeoVaLs/observable_domain_mask
-           minvalue: 0.0
-           maxvalue: 0.5
-
          # Initial error assignment
          - filter: Perform Action
            udescriptor: "initial_error_assignment"
@@ -138,7 +134,7 @@
                  xvar:
                    name: MetaData/pressure
                  xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
-                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0] 
+                 errors: [3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.8, 3.9, 3.9, 4.0, 4.0, 4.1, 5.0, 6.0, 6.3, 6.6, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0]
 
 {% if use_error_inflation | default(true) %}  # BEGIN use_error_inflation
          # Error inflation (windEastward) based on pressure check (setupw.f90)
@@ -176,21 +172,6 @@
                options:
                  variable: windNorthward
                  inflation factor: 4.0
-
-         # Halve the ob error (based on read_satwnd.f90)
-         - filter: Perform Action
-           udescriptor: "ob_error_inflation"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 57
-           action:
-             name: inflate error
-             inflation factor: 0.5
 {% endif %}  # END use_error_inflation
 
          # Bounds Check (ObsValue)
@@ -209,7 +190,7 @@
            action:
              name: reduce obs space
 
-         # Reject obs with qiWithoutForecast < 90. OR > 100.
+         # Reject obs with qiWithoutForecast < 85. OR > 100.
          - filter: Bounds Check
            udescriptor: "bounds_check_qifn"
            filter variables:
@@ -217,7 +198,7 @@
            - name: windNorthward
            test variables:
            - name: MetaData/qiWithoutForecast
-           minvalue: 90.
+           minvalue: 85.
            maxvalue: 100.
            where:
            - variable: ObsType/windEastward
@@ -244,59 +225,6 @@
            action:
              name: reject
 
-         # Reject obs with pressure < 150 mb
-         - filter: Bounds Check
-           udescriptor: "bounds_check_pressure"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/pressure
-           minvalue: 15000.
-           where:
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 57
-           action:
-             name: reject
-
-         # Reject obs over land (isli=1) where pressure > 850 mb
-         - filter: Perform Action
-           udescriptor: "bounds_check_pressure_over_land"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: MetaData/pressure
-             minvalue: 85000.
-           - variable: GeoVaLs/land_area_fraction
-             minvalue: 0.99
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 57
-           action:
-             name: reject
-
-         # Reject obs with pct1 (Coeff. of Var.) outside of 0.04-0.5
-         - filter: Bounds Check
-           udescriptor: "bounds_check_pct1"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           test variables:
-           - name: MetaData/coefficientOfVariation
-           minvalue: 0.04
-           maxvalue: 0.5
-           where:
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 57
-           action:
-             name: reject
-
          # Reject data over non-water surface type where latitude > 20N
          - filter: Perform Action
            udescriptor: "bounds_check_reject_over_nonwater"
@@ -314,40 +242,6 @@
              is_in: 57
            action:
              name: reject
-
-         # Low wind speed check
-         - filter: Perform Action
-           udescriptor: "reject_low_speed_amv"
-           filter variables:
-           - name: windEastward
-           - name: windNorthward
-           where:
-           - variable: ObsFunction/Velocity
-             maxvalue: 0.1
-           - variable: ObsType/windEastward
-             is_in: 253
-           - variable: MetaData/satelliteIdentifier
-             is_in: 57
-           action:
-             name: reject
-
-         ## AMV expected error norm check
-         #- filter: Perform Action
-         #  udescriptor: "amv_experr_norm_check"
-         #  filter variables:
-         #  - name: windEastward
-         #  - name: windNorthward
-         #  where:
-         #  - variable: ObsFunction/Velocity
-         #    minvalue: 0.1
-         #  - variable: MetaData/exp_err_norm
-         #    minvalue: 0.9
-         #  - variable: ObsType/windEastward
-         #    is_in: 253
-         #  - variable: MetaData/satelliteIdentifier
-         #    is_in: 57
-         #  action:
-         #    name: reject
 
          # Reject when pressure is more than 50 mb above tropopause
          - filter: Difference Check
@@ -383,7 +277,7 @@
            action:
              name: reject
 
-         # Reject when pressure between 399 and 801 mb.
+         # Reject obs with pressure > 401 mb and < 801 mb.
          - filter: Perform Action
            udescriptor: "pressure_range_check"
            filter variables:
@@ -391,7 +285,7 @@
            - name: windNorthward
            where:
            - variable: MetaData/pressure
-             minvalue: 39901.
+             minvalue: 40101.
              maxvalue: 80099.
            - variable: ObsType/windEastward
              is_in: 253


### PR DESCRIPTION
## Description
This PR updates and expands the RDASApp/JCB SATWND wind templates to support additional AMV kx/subtype combinations needed for GOES, Himawari, and Meteosat validation.

These changes broaden SATWND support in RDASApp by adding missing AMV kx/subtype combinations and separating the configuration by satellite wind type and platform. Keeping each kx/subtype pair in its own obs space makes the configuration easier to validate, easier to selectively enable or disable, and less prone to applying platform-specific QC to the wrong observations.

The main updates are:

- Adds new SATWND wind templates for Himawari and Meteosat visible wind types:
  - satwnd_winds_242_174.yaml.j2
  - satwnd_winds_243_56.yaml.j2
  - satwnd_winds_243_57.yaml.j2
- Updates existing GOES SATWND templates for kx 245, 246, and 247 by:
  - adding an explicit subtype filter using MetaData/satelliteIdentifier
  - removing the online domain check from the JEDI YAML templates
  - cleaning up comments and udescriptor names for consistency
- Updates preliminary Himawari and Meteosat templates for:
  - 250_174
  - 252_174
  - 253_56
  - 253_57
- Removes GOES-only QC checks from the preliminary Himawari and Meteosat templates where those checks were not appropriate for those platforms.

## Testing
These changes were tested using the NA3km configuration in order to capture and test non-GOES SATWND observations, including Himawari and Meteosat AMVs.

Testing included generating and running the updated SATWND obs spaces for selected kx/subtype combinations, checking that the corresponding JEDI diagnostic files were produced, and comparing the number of observations against the expected available SATWND counts for each platform/type. The resulting observation counts were generally comparable, supporting that the new templates are reading and filtering the intended observations.

## Note
The non-GOES SATWND observations cannot be added to the ctest since they are all outside of the CONUS domain.

## Issue(s) addressed
https://github.com/NOAA-EMC/RDASApp/issues/266

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have run rrfs tests before creating the PR (if applicable).
- [ ] Unit tests added/updated (if applicable).
