### PR TITLE
Update g16/g18 ABI obsSpace yaml files

### DIFF
--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g16.yaml
@@ -8,7 +8,7 @@
          _anchor_error: &abi_g16_error [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
          _anchor_obserr_bound_max: &abi_g16_obserr_bound_max [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
          distribution:
-           name: "@DISTRIBUTION@"
+           name: "RoundRobin"
            halo size: 500e3
          obsdatain:
            engine:
@@ -19,7 +19,7 @@
            empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
-             obsfile: jdiag_abi_g16.nc4
+             obsfile: jdiag_abi_g16.nc
          io pool:
            max pool size: 1
          simulated variables: [brightnessTemperature]
@@ -82,10 +82,66 @@
                ratio for small dataset: 2.0
            output file: data/satbias_out/abi_g16.satbias_cov.nc
 
-  # Observation Filters (QC)
-  # ------------------------
+       # ----------------------------------------
+       # Observation Filters g16 (QC)
+       # ----------------------------------------
+       # Observation Pre Filters (QC): steps 0-6
+       # -----------------------------------------
        obs pre filters:
-       # Satellite Zenith Angle Check
+       # -----------------------------------------
+       # Step 0: Create Diagnostic Flags
+       # -------------------------------
+       - filter: Create Diagnostic Flags
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         flags:
+         - name: ZenithAngleCheck
+           initial value: false
+           force reinitialization: false
+         - name: Thinning
+           initial value: false
+           force reinitialization: false
+         - name: GeoDomainCheck
+           initial value: false
+           force reinitialization: false
+         - name: CloudFractionCheck
+           initial value: false
+           force reinitialization: false
+         - name: CloudFractionCheck_channel_10
+           initial value: false
+           force reinitialization: false
+         - name: SplitWindowCheck_channel_10
+           initial value: false
+           force reinitialization: false
+         - name: ClearSkyStdCheck
+           initial value: false
+           force reinitialization: false
+         - name: ClearSkyStdCheck_channel_10
+           initial value: false
+           force reinitialization: false
+         - name: BTrangeCheck
+           initial value: false
+           force reinitialization: false
+         - name: CloudDetectMinResidualIR
+           initial value: false
+           force reinitialization: false
+         - name: SurfaceTempJacobianCheck
+           initial value: false
+           force reinitialization: false
+         - name: GrossCheck
+           initial value: false
+           force reinitialization: false
+         - name: NearSSTRetCheckIR
+           initial value: false
+           force reinitialization: false
+         - name: UseflagCheck
+           initial value: false
+           force reinitialization: false
+
+       # ---------------------------------------------------------------------------------------------------
+       # Step 1 : Satellite Zenith Angle check: remove observations with zenith angle larger than 65 degree
+       # ----------------------------------------------------------------------------------------------------
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
@@ -93,26 +149,17 @@
          test variables:
          - name: MetaData/sensorZenithAngle
          maxvalue: 65.
-         action:
-           name: reduce obs space
-       # Data Thinning
-       - filter: Gaussian Thinning
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g16_channels
-         #horizontal_mesh: 145
-         horizontal_mesh: 60
-         use_reduced_horizontal_grid: true
-         distance_norm: maximum
-         time_mesh: 'PT03H'
-         time_min: '2024-05-26T22:30:00Z'
-         time_max: '2024-05-27T01:30:00Z'
-         #  round_horizontal_bin_count_to_nearest: true
-         #  partition_longitude_bins_using_mesh: true
          actions:
-           - name: reduce obs space
+         - name: set
+           flag: ZenithAngleCheck
+         #- name: reject
+         - name: reduce obs space
 
-       # from read_abi: Reject when cloud fraction is more than 30
+
+       # ---------------------------------------------------------------------------------------------------------------------------
+       # Step 2 : Initial cloud fraction check: remove observations when cloud fraction (from channel 8 or others) is more than 30%
+       #          this initial cloud fraction is applied to all 10 channels
+       # ----------------------------------------------------------------------------------------------------------------------------
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
@@ -120,28 +167,106 @@
          where:
          - variable:
              name: MetaData/cloudAmount
-             channels: 8
            maxvalue: 30.
-         action:
-           name: reduce obs space
+         actions:
+         - name: set
+           flag: CloudFractionCheck
+           ignore: rejected observations
+         - name: reduce obs space
+         #- name: reject
 
-       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
-       - filter: Domain Check
+       # --------------------------------------------------------------------------------------------------------------
+       # Step 3 : Initial StdDev check: reject observations for all chennales when SDTB > 1.3 from channels 8/9/10 (or)
+       #          This initial stdDev check is applied to all 10 channels based on SDTB from channel 8 or 9 or 10
+       #          max_exclusive is false (default) sincce STDB=1.3 will not be removed
+       # ---------------------------------------------------------------------------------------------------------------
+       - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
            channels: *abi_g16_channels
-         where:
-         - variable:
-             name: ClearSkyStdDev/brightnessTemperature
-             channels: 8-10
-           maxvalue: 1.3
-           max_exclusive: true
-         action:
-           name: reduce obs space
+         test variables:
+         - name: ClearSkyStdDev/brightnessTemperature
+           channels: 8-10
+         flag all filter variables if any test variable is out of bounds: true
+         maxvalue: 1.3
+         #max_exclusive: true
+         actions:
+           - name: set
+             flag: ClearSkyStdCheck
+             ignore: rejected observations
+           #- name: reject
+           - name: reduce obs space
 
+       # ---------------------------------------------------------------------------------------------------
+       # Step 4 :  BT range check (sanity check)
+       # ----------------------------------------------------------------------------------------------------
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         minvalue: 0.0
+         maxvalue: 1000.0
+         actions:
+         - name: set
+           flag: BTrangeCheck
+           ignore: rejected observations
+         #- name: reject
+         - name: reduce obs space
 
+       # ---------------------------------------------------------------------------------------------------
+       # Step 5 : Create a variable of thinning priority based on cloudFree and StdDev from ABI channel 13
+       # ----------------------------------------------------------------------------------------------------
+       - filter: Variable Assignment
+         assignments:
+         - name: DerivedMetaData/thinning_priority
+           type: float
+           function:
+             name: ObsFunction/LinearCombination
+             options:
+               variables:
+               - name: MetaData/cloudFree
+               - name: ClearSkyStdDev/brightnessTemperature
+                 channels: 13
+               coefficients: [0.1, -10.0]
+               #coefficients: [10, -1.0]
+               constant_term: 100.0
+
+       # ---------------------------------------------------------------------------------------------------
+       # Step 6 : Data Thinning (spatial and temporal thinning)
+       # ----------------------------------------------------------------------------------------------------
+       - filter: Gaussian Thinning
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         #horizontal_mesh: 145
+         horizontal_mesh: 60
+         use_reduced_horizontal_grid: true
+         # Geographic Consistency Parameters
+         round_horizontal_bin_count_to_nearest: true
+         partition_longitude_bins_using_mesh: true
+         # Spatiotemporal Selection
+         distance_norm: maximum
+         #distance_norm: geodesic
+         seed_time: '@analysisDate@'
+         time_mesh: '@THINNING_TIME_MESH@'
+         time_min: '@THINNING_TIME_MIN@'
+         time_max: '@THINNING_TIME_MAX@'
+         priority_variable: DerivedMetaData/thinning_priority
+         #priority_variable: MetaData/cloudFree
+         actions:
+         - name: set
+           flag: Thinning
+           ignore: rejected observations
+         - name: reduce obs space
+         #- name: reject
+
+       # ---------------------------------------
+       # Observation prior Filters (steps 7-9)
+       # ----------------------------------------
        obs prior filters:
-       # Initial obs error assignment
+       # ------------------------------------
+       # Step 7 : Initial obs erro assignment
+       # -----------------------------------
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
@@ -150,7 +275,14 @@
            name: assign error
            error parameter vector: *abi_g16_error
 
-       # Surface flag assignment from geoval
+       # --------------------------------------------------------
+       # Step 8 : Creat surface flag assignment from Geovals
+       # water:0
+       # land: 1
+       # ice:  2
+       # Snow: 3
+       # Mixed/Other: 4.
+       # ----------------------------------------------------------
        - filter: Variable Assignment
          assignments:
          - name: DerivedMetaData/surfaceFlag
@@ -182,7 +314,9 @@
                    minvalue: 0.99
                  value: 3
 
-       # Surface Parameter assignment from geovals
+       # --------------------------------------------------------
+       # Step 9: Surface Parameter assignment from geovals
+       # ----------------------------------------------------------
        - filter: Variable Assignment
          assignments:
          - name: DerivedMetaData/surfaceParam
@@ -214,8 +348,14 @@
                    minvalue: 0.99
                  value: 15
 
+
+       # ----------------------------------------
+       # Observation post Filters (steps 10-20)
+       # ----------------------------------------
        obs post filters:
-       # Regional domain check to remove data outside of model domain
+       # ----------------------------------------------------------------------------------------
+       # Step 10: online geo-domain Check, rejecting observations outside of regional MPAS domain
+       # ----------------------------------------------------------------------------------------
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
@@ -225,8 +365,15 @@
            flag all filter variables if any test variable is out of bounds: true
            minvalue: 0.0
            maxvalue: 0.5
+         actions:
+           - name: set
+             flag: GeoDomainCheck
+           - name: reject
 
-       #Toss data if the hofx is missing or outside of range
+       # ---------------------------------------------------------------------------------------------------
+       # Step 11 :  hofx/BT range check (sanity check)
+       # Toss data if the hofx is missing or outside of range
+       # ----------------------------------------------------------------------------------------------------
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
@@ -241,8 +388,10 @@
          action:
            name: reject
 
-       # Surface type check
-       # Toss channels 7,11-16 over land
+       # -----------------------------------------------------
+       # Step 12 :  Surface type check
+       # Step 12a: Toss all channels 7, 11-16  data over land
+       # ------------------------------------------------------
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -252,7 +401,9 @@
              name: GeoVaLs/land_area_fraction
            minvalue: 0.99
 
-       # Toss all channels data over snow
+       # -------------------------------------------
+       # Setp 12b: Toss all channels data over snow
+       # --------------------------------------------
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -262,7 +413,9 @@
              name: GeoVaLs/surface_snow_area_fraction
            minvalue: 0.99
 
-       # Toss all channels data over ice
+       # ---------------------------------------------------------------------------------
+       # Step 12c: Toss all channels data over ice (reject if ice_area_fraction>=0.99)
+       # ---------------------------------------------------------------------------------
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -272,7 +425,9 @@
              name: GeoVaLs/ice_area_fraction
            minvalue: 0.99
 
-       # Toss all channels data over mixed surface
+       # --------------------------------------------------------
+       # Step 12d:  Toss all channels data over mixed surface
+       # --------------------------------------------------------
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -295,17 +450,11 @@
            maxvalue: 0.99
            max_exclusive: true
 
-       # BT range check
-       - filter: Bounds Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g16_channels
-         minvalue: 0.0
-         maxvalue: 1000.0
-         action:
-           name: reject
 
-       # Model top transmittance check
+       # -----------------------------------------------------------------------------------------------------------------------------------------------
+       # Step 13: Observation Error inflation: Model top Transmittance Check
+       # This obsfunction calculates the observation error inflation factor for satellite radiances as a function of model top-to-space transmittance.
+       # ------------------------------------------------------------------------------------------------------------------------------------------------
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
@@ -318,7 +467,9 @@
              options:
                channels: *abi_g16_channels
 
-       # Cloud detection
+       # --------------------------------------------------
+       # Step 14:  MinResidual Cloud Detection Check
+       # ---------------------------------------------------
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
@@ -333,10 +484,16 @@
              obserr_dtempf: [0.5, 2.0, 4.0, 2.0, 4.0]
              error parameter vector: *abi_g16_error
          maxvalue: 1.0e-12
-         action:
-           name: reject
+         actions:
+           - name: set
+             flag: CloudDetectMinResidualIR
+             ignore: rejected observations
+           - name: reject
 
-       # Scene Consistency Check based on ch13 (10.8 micron)
+       # ---------------------------------------------------------------------------------------------------------------------
+       # Step 15: Second StdDev check: Scene Consistency Check based on StdDev of ch13 (10.8 micron) for chanenel 7, 10-16
+       # This step would remove more data for channel 10
+       # ---------------------------------------------------------------------------------------------------------------------
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
@@ -347,15 +504,23 @@
              channels: 13
            maxvalue: 0.5
            max_exclusive: true
+         actions:
+           - name: set
+             flag: ClearSkyStdCheck_channel_10
+             ignore: rejected observations
+           - name: reject
 
-       # Aadjust Channels 8-10 varinv according to ch8 BT standard deviation
+       # -------------------------------------------------------------------------------------------------------------
+       # Step 16: Observation Error inflation: adjust error for channels 8-10 according to ch8 BT standard deviation
+       # --------------------------------------------------------------------------------------------------------------
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
            channels: 8-10
          where:
          - variable:
-             name: ClearSkyStdDev/brightnessTemperature_8
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8
            maxvalue: 0.5
            minvalue: 0.4
            min_exclusive: true
@@ -369,7 +534,8 @@
            channels: 8-10
          where:
          - variable:
-             name: ClearSkyStdDev/brightnessTemperature_8
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8
            maxvalue: 0.6
            #max_exclusive: true
            minvalue: 0.5
@@ -384,7 +550,8 @@
            channels: 8-10
          where:
          - variable:
-             name: ClearSkyStdDev/brightnessTemperature_8
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8
            maxvalue: 0.7
            #max_exclusive: true
            minvalue: 0.6
@@ -399,14 +566,20 @@
            channels: 8-10
          where:
          - variable:
-             name: ClearSkyStdDev/brightnessTemperature_8
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8
            minvalue: 0.7
            min_exclusive: true
          action:
            name: inflate error
            inflation factor: 1.5199
 
-       # Near SST Check
+       # -------------------------------------------------------------------------------------------------------------------------------------------------------
+       # Step 17: NSST Retrieval Check
+       # This obsFunction is designed to perform QC using retrieved near-sea-surface temperature (NSST) from Infrared radiances.
+       # The output of this obsFunction is the default JEDI QC flags: 0 = channel is retained for assimilation; 1 = channel is not retained for assimilation.
+       # The brightness_temperature is rejected if the QC flags from this ObsFunction output value is bigger than maxvalue=1.0e-12.
+       # ---------------------------------------------------------------------------------------------------------------------------------------------------------
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
@@ -417,11 +590,21 @@
            options:
              channels: *abi_g16_channels
              use_flag: *abi_g16_use_flag
+             sensor: abi_g16
+             obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+             obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
          maxvalue: 1.0e-12
-         action:
-           name: reject
+         actions:
+           - name: set
+             flag: NearSSTRetCheckIR
+             ignore: rejected observations
+           - name: reject
 
-       # Surface Jacobian
+       # ----------------------------------------------------------------------------------------------------------
+       # Step 18: Error inflation: Surface Jacobians Check
+       # This obsFunction is designed to compute observation error inflation factor for brightness temperature as
+       # a function of weighted surface temperature jacobian and surface emissivity jacobian.
+       # -----------------------------------------------------------------------------------------------------------
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
@@ -433,11 +616,15 @@
              channels: *abi_g16_channels
              options:
                channels: *abi_g16_channels
-               sensor: abi_g16
                obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
                obserr_dtempf: [0.5, 2.0, 4.0, 2.0, 4.0]
+               sensor: abi_g16
 
-       # Channels 7, 10-16 Cloud fraction >2
+       # ----------------------------------------------------------------------------------------------------------
+       # Step 19: additional cloud fraction check for channels 7, 10-16
+       # remove when cloud fraction > 2
+       # this step would remove more data from channel 8
+       # -----------------------------------------------------------------------------------------------------------
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
@@ -446,11 +633,19 @@
          - variable:
              name: MetaData/cloudAmount
            maxvalue: 2
+         actions:
+         - name: set
+           flag: CloudFractionCheck_channel_10
+           ignore: rejected observations
+         - name: reject
 
-       # Variable assignment, OmF non bias corrected
+       # ----------------------------------------------------------------------------------------------------------
+       # Step 20: split window check for channels 7, 10-16
+       # Step 20a: Variable assignment, OmF non bias corrected
+       # -----------------------------------------------------------------------------------------------------------
        - filter: Variable Assignment
          assignments:
-         - name: OmFNBC@DerivedMetaData
+         - name: DerivedMetaData/OmFNBC
            type: float
            function:
              name: ObsFunction/Arithmetic
@@ -470,19 +665,28 @@
                  channels: 14
                coefs: [1, -1, 1, -1, 1, -1]
 
-       # Use split window chns to remove opaque clouds
-       # Toss Channels 7, 10-16, when OmFNBC < -0.75
-       - filter: Domain Check
+       # ----------------------------------------------------------------------------------------------------------------
+       # Step 20b: Use split window chns to remove opaque clouds
+       #           reject observatiohs for Channels 7, 10-16, when OmFNBC =< -0.75 min_exclusive:true is uesed to reject
+       #           min_exclusive:true is uesed to reject when omFNBC= -0.75
+       # ------------------------------------------------------------------------------------------------------------------
+       - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
            channels: 7, 10-16
-         where:
-         - variable:
-             name: OmFNBC@DerivedMetaData
-           minvalue: -0.75
-           max_exclusive: true
+         test variables:
+         - name: DerivedMetaData/OmFNBC
+         minvalue: -0.75
+         min_exclusive: true
+         actions:
+           - name: set
+             flag: SplitWindowCheck_channel_10
+             ignore: rejected observations
+           - name: reject
 
-       # Final gross check
+       # ----------------------------------
+       # Step 21: Gross check
+       # ----------------------------------
        - filter: Background Check
          filter variables:
          - name: brightnessTemperature
@@ -496,7 +700,8 @@
              obserr_bound_latitude:
                name: ObsFunction/ObsErrorFactorLatRad
                options:
-                 latitude_parameters: [0.0, 0.0, 0.0, 0.0]
+                 #latitude_parameters: [0.0, 0.0, 0.0, 0.0]
+                 latitude_parameters: [25.0, 0.5, 0.04, 1.0]
              obserr_bound_transmittop:
                name: ObsFunction/ObsErrorFactorTransmitTopRad
                channels: *abi_g16_channels
@@ -504,5 +709,29 @@
                  channels: *abi_g16_channels
              obserr_bound_max: *abi_g16_obserr_bound_max
              error parameter vector: *abi_g16_error
-         action:
-           name: reject
+         actions:
+           - name: set
+             flag: GrossCheck
+             ignore: rejected observations
+           - name: reject
+
+       # -------------------------------
+       # Step 22: Useflag Check
+       # -------------------------------
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g16_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *abi_g16_channels
+           options:
+             channels: *abi_g16_channels
+             use_flag: *abi_g16_use_flag
+         minvalue: 1.0e-12
+         actions:
+           - name: set
+             flag: UseflagCheck
+             ignore: rejected observations
+           - name: reject
+

--- a/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
+++ b/rrfs-test/validated_yamls/templates/obtype_config/abi_g18.yaml
@@ -1,5 +1,3 @@
-  # Observation Space (I/O)
-  # -----------------------
      - obs space:
          name: abi_g18
          _anchor_channels: &abi_g18_channels 7-16
@@ -8,7 +6,7 @@
          _anchor_error: &abi_g18_error [ 2.2, 1.756, 1.587, 1.185, 2.2, 2.2, 2.2, 2.2, 2.2, 2.2 ]
          _anchor_obserr_bound_max: &abi_g18_obserr_bound_max [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
          distribution:
-           name: "@DISTRIBUTION@"
+           name: "RoundRobin"
            halo size: 500e3
          obsdatain:
            engine:
@@ -19,7 +17,7 @@
            empty obs space action: "@emptyObsSpaceAction@"
            engine:
              type: H5File
-             obsfile: jdiag_abi_g18.nc4
+             obsfile: jdiag_abi_g18.nc
          io pool:
            max pool size: 1
          simulated variables: [brightnessTemperature]
@@ -82,10 +80,66 @@
                ratio for small dataset: 2.0
            output file: data/satbias_out/abi_g18.satbias_cov.nc
 
-  # Observation Filters (QC)
-  # ------------------------
+       # ----------------------------------------
+       # Observation Filters g18 (QC)
+       # ----------------------------------------
+       # Observation Pre Filters (QC): steps 0-6
+       # -----------------------------------------
        obs pre filters:
-       # Satellite Zenith Angle Check
+       # -----------------------------------------
+       # Step 0: Create Diagnostic Flags
+       # -------------------------------
+       - filter: Create Diagnostic Flags
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         flags:
+         - name: ZenithAngleCheck
+           initial value: false
+           force reinitialization: false
+         - name: Thinning
+           initial value: false
+           force reinitialization: false
+         - name: GeoDomainCheck
+           initial value: false
+           force reinitialization: false
+         - name: CloudFractionCheck
+           initial value: false
+           force reinitialization: false
+         - name: CloudFractionCheck_channel_10
+           initial value: false
+           force reinitialization: false
+         - name: SplitWindowCheck_channel_10
+           initial value: false
+           force reinitialization: false
+         - name: ClearSkyStdCheck
+           initial value: false
+           force reinitialization: false
+         - name: ClearSkyStdCheck_channel_10
+           initial value: false
+           force reinitialization: false
+         - name: BTrangeCheck
+           initial value: false
+           force reinitialization: false
+         - name: CloudDetectMinResidualIR
+           initial value: false
+           force reinitialization: false
+         - name: SurfaceTempJacobianCheck
+           initial value: false
+           force reinitialization: false
+         - name: GrossCheck
+           initial value: false
+           force reinitialization: false
+         - name: NearSSTRetCheckIR
+           initial value: false
+           force reinitialization: false
+         - name: UseflagCheck
+           initial value: false
+           force reinitialization: false
+
+       # ---------------------------------------------------------------------------------------------------
+       # Step 1 : Satellite Zenith Angle check: remove observations with zenith angle larger than 65 degree
+       # ----------------------------------------------------------------------------------------------------
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
@@ -93,27 +147,17 @@
          test variables:
          - name: MetaData/sensorZenithAngle
          maxvalue: 65.
-         action:
-           name: reduce obs space
-
-       # Data Thinning
-       - filter: Gaussian Thinning
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g18_channels
-         #horizontal_mesh: 145
-         horizontal_mesh: 60
-         use_reduced_horizontal_grid: true
-         distance_norm: maximum
-         time_mesh: 'PT03H'
-         time_min: '2024-05-26T22:30:00Z'
-         time_max: '2024-05-27T01:30:00Z'
-         #  round_horizontal_bin_count_to_nearest: true
-         #  partition_longitude_bins_using_mesh: true
          actions:
-           - name: reduce obs space
+         - name: set
+           flag: ZenithAngleCheck
+         #- name: reject
+         - name: reduce obs space
 
-       # from read_abi: Reject when cloud fraction is more than 30
+
+       # ---------------------------------------------------------------------------------------------------------------------------
+       # Step 2 : Initial cloud fraction check: remove observations when cloud fraction (from channel 8 or others) is more than 30%
+       #          this initial cloud fraction is applied to all 10 channels
+       # ----------------------------------------------------------------------------------------------------------------------------
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
@@ -121,27 +165,106 @@
          where:
          - variable:
              name: MetaData/cloudAmount
-             channels: 8
            maxvalue: 30.
-         action:
-           name: reduce obs space
+         actions:
+         - name: set
+           flag: CloudFractionCheck
+           ignore: rejected observations
+         - name: reduce obs space
+         #- name: reject
 
-       # from read_abi: WV Channels 8-10 scene consistency check SDTB>1.3
-       - filter: Domain Check
+       # --------------------------------------------------------------------------------------------------------------
+       # Step 3 : Initial StdDev check: reject observations for all chennales when SDTB > 1.3 from channels 8/9/10 (or)
+       #          This initial stdDev check is applied to all 10 channels based on SDTB from channel 8 or 9 or 10
+       #          max_exclusive is false (default) sincce STDB=1.3 will not be removed
+       # ---------------------------------------------------------------------------------------------------------------
+       - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
            channels: *abi_g18_channels
-         where:
-         - variable:
-             name: ClearSkyStdDev/brightnessTemperature
-             channels: 8-10
-           maxvalue: 1.3
-           max_exclusive: true
-         action:
-           name: reduce obs space
+         test variables:
+         - name: ClearSkyStdDev/brightnessTemperature
+           channels: 8-10
+         flag all filter variables if any test variable is out of bounds: true
+         maxvalue: 1.3
+         #max_exclusive: true
+         actions:
+           - name: set
+             flag: ClearSkyStdCheck
+             ignore: rejected observations
+           #- name: reject
+           - name: reduce obs space
 
+       # ---------------------------------------------------------------------------------------------------
+       # Step 4 :  BT range check (sanity check)
+       # ----------------------------------------------------------------------------------------------------
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         minvalue: 0.0
+         maxvalue: 1000.0
+         actions:
+         - name: set
+           flag: BTrangeCheck
+           ignore: rejected observations
+         #- name: reject
+         - name: reduce obs space
+
+       # ---------------------------------------------------------------------------------------------------
+       # Step 5 : Create a variable of thinning priority based on cloudFree and StdDev from ABI channel 13
+       # ----------------------------------------------------------------------------------------------------
+       - filter: Variable Assignment
+         assignments:
+         - name: DerivedMetaData/thinning_priority
+           type: float
+           function:
+             name: ObsFunction/LinearCombination
+             options:
+               variables:
+               - name: MetaData/cloudFree
+               - name: ClearSkyStdDev/brightnessTemperature
+                 channels: 13
+               coefficients: [0.1, -10.0]
+               #coefficients: [10, -1.0]
+               constant_term: 100.0
+
+       # ---------------------------------------------------------------------------------------------------
+       # Step 6 : Data Thinning (spatial and temporal thinning)
+       # ----------------------------------------------------------------------------------------------------
+       - filter: Gaussian Thinning
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         #horizontal_mesh: 145
+         horizontal_mesh: 60
+         use_reduced_horizontal_grid: true
+         # Geographic Consistency Parameters
+         round_horizontal_bin_count_to_nearest: true
+         partition_longitude_bins_using_mesh: true
+         # Spatiotemporal Selection
+         distance_norm: maximum
+         #distance_norm: geodesic
+         seed_time: '@analysisDate@'
+         time_mesh: '@THINNING_TIME_MESH@'
+         time_min: '@THINNING_TIME_MIN@'
+         time_max: '@THINNING_TIME_MAX@'
+         priority_variable: DerivedMetaData/thinning_priority
+         #priority_variable: MetaData/cloudFree
+         actions:
+         - name: set
+           flag: Thinning
+           ignore: rejected observations
+         - name: reduce obs space
+         #- name: reject
+
+       # ---------------------------------------
+       # Observation prior Filters (steps 7-9)
+       # ----------------------------------------
        obs prior filters:
-       # Initial obs error assignment
+       # ------------------------------------
+       # Step 7 : Initial obs erro assignment
+       # -----------------------------------
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
@@ -150,7 +273,14 @@
            name: assign error
            error parameter vector: *abi_g18_error
 
-       # Surface flag assignment from geoval
+       # --------------------------------------------------------
+       # Step 8 : Create surface flag assignment from Geovals
+       # water:0
+       # land: 1
+       # ice:  2
+       # Snow: 3
+       # Mixed/Other: 4.
+       # ----------------------------------------------------------
        - filter: Variable Assignment
          assignments:
          - name: DerivedMetaData/surfaceFlag
@@ -182,7 +312,9 @@
                    minvalue: 0.99
                  value: 3
 
-       # Surface Parameter assignment from geovals
+       # --------------------------------------------------------
+       # Step 9: Surface Parameter assignment from geovals
+       # ----------------------------------------------------------
        - filter: Variable Assignment
          assignments:
          - name: DerivedMetaData/surfaceParam
@@ -214,8 +346,14 @@
                    minvalue: 0.99
                  value: 15
 
+
+       # ----------------------------------------
+       # Observation post Filters (steps 10-20)
+       # ----------------------------------------
        obs post filters:
-       # Regional domain check to remove data outside of model domain
+       # ----------------------------------------------------------------------------------------
+       # Step 10: online geo-domain Check, rejecting observations outside of regional MPAS domain
+       # ----------------------------------------------------------------------------------------
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
@@ -225,15 +363,22 @@
            flag all filter variables if any test variable is out of bounds: true
            minvalue: 0.0
            maxvalue: 0.5
+         actions:
+           - name: set
+             flag: GeoDomainCheck
+           - name: reject
 
+       # ---------------------------------------------------------------------------------------------------
+       # Step 11 :  hofx/BT range check (sanity check)
        # Toss data if the hofx is missing or outside of range
+       # ----------------------------------------------------------------------------------------------------
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
            channels: *abi_g18_channels
          where:
          - variable:
-             name: brightnessTemperature@HofX
+             name: HofX/brightnessTemperature
              channels: *abi_g18_channels
            value: is_valid
            minvalue: 50.00001
@@ -241,8 +386,10 @@
          action:
            name: reject
 
-       # Surface type check
-       # Toss channels 7,11-16 over land
+       # -----------------------------------------------------
+       # Step 12 :  Surface type check
+       # Step 12a: Toss all channels 7, 11-16  data over land
+       # ------------------------------------------------------
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -252,7 +399,9 @@
              name: GeoVaLs/land_area_fraction
            minvalue: 0.99
 
-       # Toss all channels data over snow
+       # -------------------------------------------
+       # Setp 12b: Toss all channels data over snow
+       # --------------------------------------------
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -262,7 +411,9 @@
              name: GeoVaLs/surface_snow_area_fraction
            minvalue: 0.99
 
-       # Toss all channels data over ice
+       # ---------------------------------------------------------------------------------
+       # Step 12c: Toss all channels data over ice (reject if ice_area_fraction>=0.99)
+       # ---------------------------------------------------------------------------------
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -272,7 +423,9 @@
              name: GeoVaLs/ice_area_fraction
            minvalue: 0.99
 
-       # Toss all channels data over mixed surface
+       # --------------------------------------------------------
+       # Step 12d:  Toss all channels data over mixed surface
+       # --------------------------------------------------------
        - filter: RejectList
          filter variables:
          - name: brightnessTemperature
@@ -295,17 +448,11 @@
            maxvalue: 0.99
            max_exclusive: true
 
-       # BT range check
-       - filter: Bounds Check
-         filter variables:
-         - name: brightnessTemperature
-           channels: *abi_g18_channels
-         minvalue: 0.0
-         maxvalue: 1000.0
-         action:
-           name: reject
 
-       # Model top transmittance check
+       # -----------------------------------------------------------------------------------------------------------------------------------------------
+       # Step 13: Observation Error inflation: Model top Transmittance Check
+       # This obsfunction calculates the observation error inflation factor for satellite radiances as a function of model top-to-space transmittance.
+       # ------------------------------------------------------------------------------------------------------------------------------------------------
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
@@ -318,7 +465,9 @@
              options:
                channels: *abi_g18_channels
 
-       # Cloud detection
+       # --------------------------------------------------
+       # Step 14:  MinResidual Cloud Detection Check
+       # ---------------------------------------------------
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
@@ -333,10 +482,16 @@
              obserr_dtempf: [0.5, 2.0, 4.0, 2.0, 4.0]
              error parameter vector: *abi_g18_error
          maxvalue: 1.0e-12
-         action:
-           name: reject
+         actions:
+           - name: set
+             flag: CloudDetectMinResidualIR
+             ignore: rejected observations
+           - name: reject
 
-       # Scene Consistency Check based on ch13 (10.8 micron)
+       # ---------------------------------------------------------------------------------------------------------------------
+       # Step 15: Second StdDev check: Scene Consistency Check based on StdDev of ch13 (10.8 micron) for chanenel 7, 10-16
+       # This step would remove more data for channel 10
+       # ---------------------------------------------------------------------------------------------------------------------
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
@@ -347,15 +502,23 @@
              channels: 13
            maxvalue: 0.5
            max_exclusive: true
+         actions:
+           - name: set
+             flag: ClearSkyStdCheck_channel_10
+             ignore: rejected observations
+           - name: reject
 
-       # Aadjust Channels 8-10 varinv according to ch8 BT standard deviation
+       # -------------------------------------------------------------------------------------------------------------
+       # Step 16: Observation Error inflation: adjust error for channels 8-10 according to ch8 BT standard deviation
+       # --------------------------------------------------------------------------------------------------------------
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
            channels: 8-10
          where:
          - variable:
-             name: ClearSkyStdDev/brightnessTemperature_8
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8
            maxvalue: 0.5
            minvalue: 0.4
            min_exclusive: true
@@ -369,7 +532,8 @@
            channels: 8-10
          where:
          - variable:
-             name: ClearSkyStdDev/brightnessTemperature_8
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8
            maxvalue: 0.6
            #max_exclusive: true
            minvalue: 0.5
@@ -384,7 +548,8 @@
            channels: 8-10
          where:
          - variable:
-             name: ClearSkyStdDev/brightnessTemperature_8
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8
            maxvalue: 0.7
            #max_exclusive: true
            minvalue: 0.6
@@ -399,14 +564,20 @@
            channels: 8-10
          where:
          - variable:
-             name: ClearSkyStdDev/brightnessTemperature_8
+             name: ClearSkyStdDev/brightnessTemperature
+             channels: 8
            minvalue: 0.7
            min_exclusive: true
          action:
            name: inflate error
            inflation factor: 1.5199
 
-       # Near SST Check
+       # -------------------------------------------------------------------------------------------------------------------------------------------------------
+       # Step 17: NSST Retrieval Check
+       # This obsFunction is designed to perform QC using retrieved near-sea-surface temperature (NSST) from Infrared radiances.
+       # The output of this obsFunction is the default JEDI QC flags: 0 = channel is retained for assimilation; 1 = channel is not retained for assimilation.
+       # The brightness_temperature is rejected if the QC flags from this ObsFunction output value is bigger than maxvalue=1.0e-12.
+       # ---------------------------------------------------------------------------------------------------------------------------------------------------------
        - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
@@ -417,11 +588,21 @@
            options:
              channels: *abi_g18_channels
              use_flag: *abi_g18_use_flag
+             sensor: abi_g18
+             obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+             obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
          maxvalue: 1.0e-12
-         action:
-           name: reject
+         actions:
+           - name: set
+             flag: NearSSTRetCheckIR
+             ignore: rejected observations
+           - name: reject
 
-       # Surface Jacobian
+       # ----------------------------------------------------------------------------------------------------------
+       # Step 18: Error inflation: Surface Jacobians Check
+       # This obsFunction is designed to compute observation error inflation factor for brightness temperature as
+       # a function of weighted surface temperature jacobian and surface emissivity jacobian.
+       # -----------------------------------------------------------------------------------------------------------
        - filter: Perform Action
          filter variables:
          - name: brightnessTemperature
@@ -433,11 +614,15 @@
              channels: *abi_g18_channels
              options:
                channels: *abi_g18_channels
-               sensor: abi_g18
                obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
                obserr_dtempf: [0.5, 2.0, 4.0, 2.0, 4.0]
+               sensor: abi_g18
 
-       # Channels 7, 10-16 Cloud fraction >2
+       # ----------------------------------------------------------------------------------------------------------
+       # Step 19: additional cloud fraction check for channels 7, 10-16
+       # remove when cloud fraction > 2
+       # this step would remove more data from channel 8
+       # -----------------------------------------------------------------------------------------------------------
        - filter: Domain Check
          filter variables:
          - name: brightnessTemperature
@@ -446,11 +631,19 @@
          - variable:
              name: MetaData/cloudAmount
            maxvalue: 2
+         actions:
+         - name: set
+           flag: CloudFractionCheck_channel_10
+           ignore: rejected observations
+         - name: reject
 
-       # Variable assignment, OmF non bias corrected
+       # ----------------------------------------------------------------------------------------------------------
+       # Step 20: split window check for channels 7, 10-16
+       # Step 20a: Variable assignment, OmF non bias corrected
+       # -----------------------------------------------------------------------------------------------------------
        - filter: Variable Assignment
          assignments:
-         - name: OmFNBC@DerivedMetaData
+         - name: DerivedMetaData/OmFNBC
            type: float
            function:
              name: ObsFunction/Arithmetic
@@ -470,19 +663,28 @@
                  channels: 14
                coefs: [1, -1, 1, -1, 1, -1]
 
-       # Use split window chns to remove opaque clouds
-       # Toss Channels 7, 10-16, when OmFNBC < -0.75
-       - filter: Domain Check
+       # ----------------------------------------------------------------------------------------------------------------
+       # Step 20b: Use split window chns to remove opaque clouds
+       #           reject observatiohs for Channels 7, 10-16, when OmFNBC =< -0.75 min_exclusive:true is uesed to reject
+       #           min_exclusive:true is uesed to reject when omFNBC= -0.75
+       # ------------------------------------------------------------------------------------------------------------------
+       - filter: Bounds Check
          filter variables:
          - name: brightnessTemperature
            channels: 7, 10-16
-         where:
-         - variable:
-             name: OmFNBC@DerivedMetaData
-           minvalue: -0.75
-           max_exclusive: true
+         test variables:
+         - name: DerivedMetaData/OmFNBC
+         minvalue: -0.75
+         min_exclusive: true
+         actions:
+           - name: set
+             flag: SplitWindowCheck_channel_10
+             ignore: rejected observations
+           - name: reject
 
-       # Final gross check
+       # ----------------------------------
+       # Step 21: Gross check
+       # ----------------------------------
        - filter: Background Check
          filter variables:
          - name: brightnessTemperature
@@ -496,7 +698,8 @@
              obserr_bound_latitude:
                name: ObsFunction/ObsErrorFactorLatRad
                options:
-                 latitude_parameters: [0.0, 0.0, 0.0, 0.0]
+                 #latitude_parameters: [0.0, 0.0, 0.0, 0.0]
+                 latitude_parameters: [25.0, 0.5, 0.04, 1.0]
              obserr_bound_transmittop:
                name: ObsFunction/ObsErrorFactorTransmitTopRad
                channels: *abi_g18_channels
@@ -504,5 +707,29 @@
                  channels: *abi_g18_channels
              obserr_bound_max: *abi_g18_obserr_bound_max
              error parameter vector: *abi_g18_error
-         action:
-           name: reject
+         actions:
+           - name: set
+             flag: GrossCheck
+             ignore: rejected observations
+           - name: reject
+
+       # -------------------------------
+       # Step 22: Useflag Check
+       # -------------------------------
+       - filter: Bounds Check
+         filter variables:
+         - name: brightnessTemperature
+           channels: *abi_g18_channels
+         test variables:
+         - name: ObsFunction/ChannelUseflagCheckRad
+           channels: *abi_g18_channels
+           options:
+             channels: *abi_g18_channels
+             use_flag: *abi_g18_use_flag
+         minvalue: 1.0e-12
+         actions:
+           - name: set
+             flag: UseflagCheck
+             ignore: rejected observations
+           - name: reject
+


### PR DESCRIPTION
-Add useflag check to assimilate only 3 water vapor channels instead of all 10 channels and have the flexibility to assimilate more channels if needed
-Remove the channel number for cloudAmout as CloudAmount is not channel dependent in the ioda file. Further update in bufr2netcdf might be needed
-Change max_exclusive: to min_exclusive for split window check
-Remove “max_exclusive: true” for BT StdDev check for channels 8-10
-Move the thinning filter after a few pre filters (e.g., cloud check and BT StdDev check)
-Add QC diagnostic flags
-Create a thinning priority variable based on cloudFree and BT StdDev from channel 13 (similar to GSI) and use this new variable as a priority variable for thinning
-Add “seed time” for temporal thinning
-Other miscellaneous changes (e.g., changed OmFNBC@DerivedMetaData to DerivedMetaData/OmFNBC and similar others; turned on a few parameters for thinning, added some comments etc.)

Related PR: https://github.com/NOAA-EMC/rrfs-workflow/pull/1512